### PR TITLE
Fix Postgres runtime schema DDL

### DIFF
--- a/src/main/java/com/fairing/fairplay/booth/entity/Booth.java
+++ b/src/main/java/com/fairing/fairplay/booth/entity/Booth.java
@@ -51,7 +51,7 @@ public class Booth {
     @Column(length = 100)
     private String location;
 
-    @Column(name = "created_at", updatable = false, columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP")
+    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
     @Column(name="booth_banner_url", length=512)
@@ -65,4 +65,11 @@ public class Booth {
 
     @OneToMany(mappedBy = "booth", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<BoothExternalLink> boothExternalLinks = new HashSet<>();
+
+    @PrePersist
+    public void prePersist() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
 }

--- a/src/main/java/com/fairing/fairplay/booth/entity/BoothApplication.java
+++ b/src/main/java/com/fairing/fairplay/booth/entity/BoothApplication.java
@@ -45,7 +45,7 @@ public class BoothApplication {
     @Column(name = "contact_number", nullable = false, length = 20)
     private String contactNumber;
 
-    @Column(name = "apply_at", columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP")
+    @Column(name = "apply_at")
     private LocalDateTime applyAt;
 
     @Column(name = "admin_comment", columnDefinition = "TEXT")
@@ -81,5 +81,12 @@ public class BoothApplication {
         this.boothApplicationStatusCode = newStatus;
         this.adminComment = adminComment;
         this.statusUpdatedAt = LocalDateTime.now();
+    }
+
+    @PrePersist
+    public void prePersist() {
+        if (applyAt == null) {
+            applyAt = LocalDateTime.now();
+        }
     }
 }

--- a/src/main/java/com/fairing/fairplay/reservation/entity/Reservation.java
+++ b/src/main/java/com/fairing/fairplay/reservation/entity/Reservation.java
@@ -46,12 +46,10 @@ public class Reservation {
     private int quantity;
     private int price;
 
-    @Column(name = "created_at", nullable = false,
-            columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "updated_at",
-            columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
     private boolean canceled;
@@ -65,5 +63,18 @@ public class Reservation {
         this.quantity = quantity;
         this.price = price;
         this.createdAt = LocalDateTime.now();
+    }
+
+    @PrePersist
+    public void prePersist() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+        updatedAt = createdAt;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/fairing/fairplay/ticket/entity/EventSchedule.java
+++ b/src/main/java/com/fairing/fairplay/ticket/entity/EventSchedule.java
@@ -43,7 +43,7 @@ public class EventSchedule {
     @Column(name = "weekday")
     private Integer weekday;
 
-    @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP")
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @QueryTransient
@@ -59,5 +59,12 @@ public class EventSchedule {
         eventSchedule.setWeekday(dto.getDate().getDayOfWeek().getValue() % 7);
         eventSchedule.setCreatedAt(LocalDateTime.now());
         return eventSchedule;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
     }
 }

--- a/src/main/java/com/fairing/fairplay/ticket/entity/Ticket.java
+++ b/src/main/java/com/fairing/fairplay/ticket/entity/Ticket.java
@@ -47,7 +47,7 @@ public class Ticket {
     @Column(name = "max_purchase")
     private Integer maxPurchase;
 
-    @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP")
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @Column(nullable = false, columnDefinition = "BOOLEAN NOT NULL DEFAULT FALSE")
@@ -57,7 +57,7 @@ public class Ticket {
     private Boolean deleted = false;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, columnDefinition = "ENUM('EVENT', 'BOOTH')")
+    @Column(nullable = false, length = 20)
     private TypesEnum types;
 
     @OneToMany(mappedBy = "ticket", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -71,4 +71,11 @@ public class Ticket {
 
     @OneToMany(mappedBy = "ticket", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<ScheduleTicket> scheduleTickets = new HashSet<>();
+
+    @PrePersist
+    public void prePersist() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
 }

--- a/src/main/java/com/fairing/fairplay/user/entity/Users.java
+++ b/src/main/java/com/fairing/fairplay/user/entity/Users.java
@@ -54,10 +54,10 @@ public class Users {
     @JoinColumn(name = "role_code_id")
     private UserRoleCode roleCode;
 
-    @Column(name = "created_at", nullable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "updated_at", columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
     @Column(name = "deleted_at")


### PR DESCRIPTION
## Summary
- Remove remaining MySQL-only JPA column definitions that prevented Postgres ddl-auto schema repair
- Preserve timestamp defaults through JPA lifecycle hooks
- Keep ticket enum storage as string/varchar for Postgres-compatible DDL

## Verification
- git diff --check
- ./gradlew clean test bootJar --no-daemon
- FAIRPLAY_SCHEMA_SMOKE_ENABLED=true ./gradlew test --tests com.fairing.fairplay.PostgresSchemaSmokeTest --no-daemon against mini-server PostgreSQL via SSH tunnel
- xhigh critic APPROVE after blocker fixes

## Notes
- Server env was also repaired so FairPlay uses the actual Redis requirepass; secret values were not committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 타임스탬프 관리 방식을 데이터베이스 기본값에서 애플리케이션 로직으로 변경하여 시스템 전체의 시간 관리 일관성 개선
  * 엔티티 저장 및 수정 시점에 생성 시간과 수정 시간이 자동으로 초기화되도록 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rktclgh/FairPlay_BE/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->