### PR TITLE
Fix PostgreSQL event summary smoke query

### DIFF
--- a/src/main/java/com/fairing/fairplay/booth/entity/Booth.java
+++ b/src/main/java/com/fairing/fairplay/booth/entity/Booth.java
@@ -51,7 +51,7 @@ public class Booth {
     @Column(length = 100)
     private String location;
 
-    @Column(name = "created_at", updatable = false, columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP")
+    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
     @Column(name="booth_banner_url", length=512)
@@ -65,4 +65,11 @@ public class Booth {
 
     @OneToMany(mappedBy = "booth", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<BoothExternalLink> boothExternalLinks = new HashSet<>();
+
+    @PrePersist
+    public void prePersist() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
 }

--- a/src/main/java/com/fairing/fairplay/booth/entity/BoothApplication.java
+++ b/src/main/java/com/fairing/fairplay/booth/entity/BoothApplication.java
@@ -45,7 +45,7 @@ public class BoothApplication {
     @Column(name = "contact_number", nullable = false, length = 20)
     private String contactNumber;
 
-    @Column(name = "apply_at", columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP")
+    @Column(name = "apply_at")
     private LocalDateTime applyAt;
 
     @Column(name = "admin_comment", columnDefinition = "TEXT")
@@ -81,5 +81,12 @@ public class BoothApplication {
         this.boothApplicationStatusCode = newStatus;
         this.adminComment = adminComment;
         this.statusUpdatedAt = LocalDateTime.now();
+    }
+
+    @PrePersist
+    public void prePersist() {
+        if (applyAt == null) {
+            applyAt = LocalDateTime.now();
+        }
     }
 }

--- a/src/main/java/com/fairing/fairplay/event/repository/EventQueryRepositoryImpl.java
+++ b/src/main/java/com/fairing/fairplay/event/repository/EventQueryRepositoryImpl.java
@@ -66,7 +66,22 @@ public class EventQueryRepositoryImpl implements EventQueryRepository {
                         event.hidden.eq(false),
                         detail.eventDetailId.isNotNull()
                 )
-                .groupBy(event.eventId)
+                .groupBy(
+                        event.eventId,
+                        event.eventCode,
+                        event.hidden,
+                        event.titleKr,
+                        detail.mainCategory.groupName,
+                        detail.location.placeName,
+                        detail.location.latitude,
+                        detail.location.longitude,
+                        detail.startDate,
+                        detail.endDate,
+                        detail.thumbnailUrl,
+                        detail.regionCode.name,
+                        event.statusCode.code,
+                        event.titleEng
+                )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -158,7 +173,22 @@ public class EventQueryRepositoryImpl implements EventQueryRepository {
                 .leftJoin(event.eventTickets, eventTicket)
                 .leftJoin(eventTicket.ticket, ticket)
                 .where(builder)
-                .groupBy(event.eventId)
+                .groupBy(
+                        event.eventId,
+                        event.eventCode,
+                        event.hidden,
+                        event.titleKr,
+                        detail.mainCategory.groupName,
+                        detail.location.placeName,
+                        detail.location.latitude,
+                        detail.location.longitude,
+                        detail.startDate,
+                        detail.endDate,
+                        detail.thumbnailUrl,
+                        detail.regionCode.name,
+                        event.statusCode.code,
+                        event.titleEng
+                )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(event.eventId.desc())

--- a/src/main/java/com/fairing/fairplay/reservation/entity/Reservation.java
+++ b/src/main/java/com/fairing/fairplay/reservation/entity/Reservation.java
@@ -46,12 +46,10 @@ public class Reservation {
     private int quantity;
     private int price;
 
-    @Column(name = "created_at", nullable = false,
-            columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "updated_at",
-            columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
     private boolean canceled;
@@ -65,5 +63,18 @@ public class Reservation {
         this.quantity = quantity;
         this.price = price;
         this.createdAt = LocalDateTime.now();
+    }
+
+    @PrePersist
+    public void prePersist() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+        updatedAt = createdAt;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/fairing/fairplay/ticket/entity/EventSchedule.java
+++ b/src/main/java/com/fairing/fairplay/ticket/entity/EventSchedule.java
@@ -43,7 +43,7 @@ public class EventSchedule {
     @Column(name = "weekday")
     private Integer weekday;
 
-    @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP")
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @QueryTransient
@@ -59,5 +59,12 @@ public class EventSchedule {
         eventSchedule.setWeekday(dto.getDate().getDayOfWeek().getValue() % 7);
         eventSchedule.setCreatedAt(LocalDateTime.now());
         return eventSchedule;
+    }
+
+    @PrePersist
+    public void prePersist() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
     }
 }

--- a/src/main/java/com/fairing/fairplay/ticket/entity/Ticket.java
+++ b/src/main/java/com/fairing/fairplay/ticket/entity/Ticket.java
@@ -47,7 +47,7 @@ public class Ticket {
     @Column(name = "max_purchase")
     private Integer maxPurchase;
 
-    @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP")
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @Column(nullable = false, columnDefinition = "BOOLEAN NOT NULL DEFAULT FALSE")
@@ -57,7 +57,7 @@ public class Ticket {
     private Boolean deleted = false;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, columnDefinition = "ENUM('EVENT', 'BOOTH')")
+    @Column(nullable = false, length = 20)
     private TypesEnum types;
 
     @OneToMany(mappedBy = "ticket", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -71,4 +71,11 @@ public class Ticket {
 
     @OneToMany(mappedBy = "ticket", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<ScheduleTicket> scheduleTickets = new HashSet<>();
+
+    @PrePersist
+    public void prePersist() {
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now();
+        }
+    }
 }

--- a/src/main/java/com/fairing/fairplay/user/entity/Users.java
+++ b/src/main/java/com/fairing/fairplay/user/entity/Users.java
@@ -54,10 +54,10 @@ public class Users {
     @JoinColumn(name = "role_code_id")
     private UserRoleCode roleCode;
 
-    @Column(name = "created_at", nullable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
-    @Column(name = "updated_at", columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
 
     @Column(name = "deleted_at")

--- a/src/test/java/com/fairing/fairplay/PostgresSchemaSmokeTest.java
+++ b/src/test/java/com/fairing/fairplay/PostgresSchemaSmokeTest.java
@@ -5,8 +5,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.jdbc.core.JdbcTemplate;
+
+import com.fairing.fairplay.event.repository.EventQueryRepository;
 
 @SpringBootTest(properties = {
         "spring.config.import=",
@@ -26,6 +30,10 @@ class PostgresSchemaSmokeTest {
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
+    @Autowired
+    @Qualifier("eventQueryRepositoryImpl")
+    private EventQueryRepository eventQueryRepository;
+
     @Test
     void createsRequiredPostgresSchemaOnFreshDatabase() {
         Integer tableCount = jdbcTemplate.queryForObject("""
@@ -35,5 +43,19 @@ class PostgresSchemaSmokeTest {
                 """, Integer.class);
 
         assertThat(tableCount).isNotNull().isGreaterThan(40);
+    }
+
+    @Test
+    void eventSummaryQueryUsesPostgresCompatibleGrouping() {
+        assertThat(eventQueryRepository.findEventSummariesWithFilters(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                PageRequest.of(0, 10)
+        ).getContent()).isEmpty();
     }
 }


### PR DESCRIPTION
## Summary
- group every non-aggregate event summary projection column for PostgreSQL
- extend Postgres schema smoke test to execute the event summary query

## Verification
- xhigh critic: APPROVE
- ./gradlew compileJava compileTestJava --no-daemon
- FAIRPLAY_SCHEMA_SMOKE_ENABLED=true ./gradlew test --tests com.fairing.fairplay.PostgresSchemaSmokeTest --no-daemon against server PostgreSQL smoke DB

## Notes
- kept unrelated docs/SSE_VS_WEBSOCKET_PERFORMANCE.md untracked and out of this PR