### PR TITLE
Fix miniserver asset CORS

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -197,7 +197,14 @@ jobs:
           done
 
           curl -fsSI "${BASE_URL}/" | grep -Ei 'HTTP/|content-type'
-          curl -fsS "${BASE_URL}/" | grep -E '<html|<div id="root"' >/dev/null
+          HTML="$(curl -fsS "${BASE_URL}/")"
+          printf '%s' "${HTML}" | grep -E '<html|<div id="root"' >/dev/null
+          ASSET_PATH="$(printf '%s' "${HTML}" | grep -m1 -oE '/assets/[^"]+\.(js|css)')"
+          test -n "${ASSET_PATH}" || { echo "No built frontend asset found in index.html"; exit 1; }
+          curl -fsS \
+            -H "Origin: https://fairplay.rktclgh.site" \
+            -H "Referer: https://fairplay.rktclgh.site/" \
+            "${BASE_URL}${ASSET_PATH}" >/dev/null
           curl -fsS "${BASE_URL}/api/events" >/tmp/fairplay-events.json
 
           SSE_STATUS="$(curl -sS -o /tmp/fairplay-sse.out -w '%{http_code}' --max-time 5 "${BASE_URL}/api/notifications/stream" || true)"

--- a/deploy/miniserver.env.example
+++ b/deploy/miniserver.env.example
@@ -1,6 +1,8 @@
 SPRING_PROFILES_ACTIVE=prod
 APP_ENVIRONMENT=prod
 APP_BASE_URL=https://fairplay.rktclgh.site
+APP_FRONTEND_BASE_URL=https://fairplay.rktclgh.site
+APP_CORS_ALLOWED_ORIGINS=https://fairplay.rktclgh.site
 APP_POSTGRES_AUTO_INIT_CONSTRAINTS=true
 UPLOAD_PATH=/app/uploads
 

--- a/src/main/java/com/fairing/fairplay/chat/websocket/WebSocketConfig.java
+++ b/src/main/java/com/fairing/fairplay/chat/websocket/WebSocketConfig.java
@@ -13,6 +13,12 @@ import org.springframework.web.socket.config.annotation.*;
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    private static final String[] TRUSTED_SOCKJS_ORIGINS = {
+            "http://localhost:5173",
+            "https://fair-play.ink",
+            "https://fairplay.rktclgh.site"
+    };
+
     private final SessionHandshakeInterceptor sessionHandshakeInterceptor;
     private final SessionStompChannelInterceptor sessionStompChannelInterceptor;
 
@@ -25,7 +31,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
         // SockJS fallback 엔드포인트 (JSONP 비활성화)
         registry.addEndpoint("/ws/chat-sockjs")
-                .setAllowedOriginPatterns("http://localhost:5173", "https://fair-play.ink")
+                .setAllowedOriginPatterns(TRUSTED_SOCKJS_ORIGINS)
                 .addInterceptors(sessionHandshakeInterceptor)
                 .withSockJS()
                 .setSessionCookieNeeded(true)
@@ -39,7 +45,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
         // 알림 전용 SockJS fallback 엔드포인트
         registry.addEndpoint("/ws/notifications-sockjs")
-                .setAllowedOriginPatterns("http://localhost:5173", "https://fair-play.ink")
+                .setAllowedOriginPatterns(TRUSTED_SOCKJS_ORIGINS)
                 .addInterceptors(sessionHandshakeInterceptor)
                 .withSockJS()
                 .setSessionCookieNeeded(true)

--- a/src/main/java/com/fairing/fairplay/core/config/WebConfig.java
+++ b/src/main/java/com/fairing/fairplay/core/config/WebConfig.java
@@ -1,5 +1,6 @@
 package com.fairing.fairplay.core.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
@@ -10,30 +11,62 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.servlet.resource.PathResourceResolver;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.stream.Stream;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
+    private static final String[] STATIC_ALLOWED_ORIGINS = {
+        "http://localhost:3000",
+        "http://localhost:5173",
+        "https://fair-play.ink",
+        "https://fairplay.rktclgh.site",
+        "https://service.iamport.kr",
+        "https://pg.uplus.co.kr",
+        "https://mobile.uplus.co.kr",
+        "https://m.uplus.co.kr",
+        "https://payment.uplus.co.kr",
+        "https://webapp.uplus.co.kr",
+        "https://pg.lguplus.co.kr",
+        "https://mobile-pay.uplus.co.kr"
+    };
+
+    private final String frontendBaseUrl;
+    private final String appBaseUrl;
+    private final String extraAllowedOrigins;
+
+    public WebConfig(
+        @Value("${app.frontend.base-url:http://localhost:5173}") String frontendBaseUrl,
+        @Value("${app.base-url:https://fair-play.ink}") String appBaseUrl,
+        @Value("${app.cors.allowed-origins:}") String extraAllowedOrigins
+    ) {
+        this.frontendBaseUrl = frontendBaseUrl;
+        this.appBaseUrl = appBaseUrl;
+        this.extraAllowedOrigins = extraAllowedOrigins;
+    }
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**") // 모든 API
-            .allowedOrigins(
-                "http://localhost:3000", // 프론트 개발 주소
-                "http://localhost:5173", // Vite(React)
-                "https://fair-play.ink", // 배포용 도메인
-                "https://service.iamport.kr", // 아임포트 서비스
-                "https://pg.uplus.co.kr", // LG U+ PG
-                "https://mobile.uplus.co.kr", // LG U+ 모바일
-                "https://m.uplus.co.kr", // LG U+ 모바일 단축
-                "https://payment.uplus.co.kr", // LG U+ 결제
-                "https://webapp.uplus.co.kr", // LG U+ 웹앱
-                "https://pg.lguplus.co.kr", // LG U+ PG 구버전
-                "https://mobile-pay.uplus.co.kr" // LG U+ 모바일 결제
-            )
+            .allowedOrigins(allowedOrigins())
             .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
             .allowedHeaders("*")
             .allowCredentials(true) // 인증(쿠키/헤더) 허용
             .maxAge(3600);
+    }
+
+    String[] allowedOrigins() {
+        return Stream.of(
+                Arrays.stream(STATIC_ALLOWED_ORIGINS),
+                Stream.of(frontendBaseUrl, appBaseUrl),
+                Arrays.stream(extraAllowedOrigins.split(","))
+            )
+            .flatMap(origin -> origin)
+            .map(String::trim)
+            .filter(origin -> !origin.isBlank())
+            .distinct()
+            .toArray(String[]::new);
     }
 
     @Override

--- a/src/test/java/com/fairing/fairplay/core/config/WebConfigTest.java
+++ b/src/test/java/com/fairing/fairplay/core/config/WebConfigTest.java
@@ -1,0 +1,24 @@
+package com.fairing.fairplay.core.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class WebConfigTest {
+
+    @Test
+    void allowedOriginsIncludesMiniserverDomainAndConfiguredUrls() {
+        WebConfig webConfig = new WebConfig(
+                "https://frontend.example.test",
+                "https://api.example.test",
+                "https://extra.example.test, https://fairplay.rktclgh.site");
+
+        assertThat(webConfig.allowedOrigins())
+                .contains(
+                        "https://fairplay.rktclgh.site",
+                        "https://frontend.example.test",
+                        "https://api.example.test",
+                        "https://extra.example.test")
+                .doesNotHaveDuplicates();
+    }
+}


### PR DESCRIPTION
## Summary
- allow the active mini-server origin in Spring MVC CORS so browser JS/CSS asset loads are not rejected
- include the same origin in SockJS fallback allowlists
- add a deploy smoke check that fetches a built frontend asset with the production Origin/Referer headers

## Root cause
Production HTML loaded, but the browser requested /assets/*.js and /assets/*.css with Origin: https://fairplay.rktclgh.site. The backend CORS allowlist only included localhost and the old https://fair-play.ink domain, so Spring returned 403 Invalid CORS request before React could boot.

## Validation
- ./gradlew test --tests com.fairing.fairplay.core.config.WebConfigTest --no-daemon
- xhigh critic: APPROVE

## Known gap
- ./gradlew test currently fails outside this change because existing scheduled tasks run during the Spring context test against empty H2/Redis and emit async failures.