### PR TITLE
Align restored data and miniserver auth settings

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Smoke check deployed service
         run: |
           set -euo pipefail
-          BASE_URL="http://127.0.0.1:18081"
+          BASE_URL="http://127.0.0.1:18083"
           for i in $(seq 1 30); do
             if curl -fsS "${BASE_URL}/actuator/health" >/tmp/fairplay-health.json; then
               cat /tmp/fairplay-health.json

--- a/deploy/host-nginx.fairplay.rktclgh.site.conf
+++ b/deploy/host-nginx.fairplay.rktclgh.site.conf
@@ -59,7 +59,7 @@ server {
     }
 
     location /ws/ {
-        proxy_pass http://127.0.0.1:18081;
+        proxy_pass http://127.0.0.1:18083;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -75,7 +75,7 @@ server {
     }
 
     location /sse/ {
-        proxy_pass http://127.0.0.1:18081;
+        proxy_pass http://127.0.0.1:18083;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Internal-Client-IP $remote_addr;
@@ -91,7 +91,7 @@ server {
     }
 
     location / {
-        proxy_pass http://127.0.0.1:18081;
+        proxy_pass http://127.0.0.1:18083;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Internal-Client-IP $remote_addr;

--- a/deploy/miniserver.env.example
+++ b/deploy/miniserver.env.example
@@ -35,7 +35,7 @@ MAIL_USERNAME=change-me
 MAIL_PASSWORD=change-me
 
 KAKAO_CLIENT_ID=change-me
-KAKAO_REDIRECT_URI=https://fairplay.rktclgh.site/api/oauth/kakao/callback
+KAKAO_REDIRECT_URI=https://fairplay.rktclgh.site/auth/kakao/callback
 KAKAO_CLIENT_SECRET=
 
 AWS_S3_BUCKET_NAME=fairplay

--- a/deploy/nginx.miniserver.conf
+++ b/deploy/nginx.miniserver.conf
@@ -1,5 +1,5 @@
 server {
-    listen 127.0.0.1:18081;
+    listen 127.0.0.1:18083;
     server_name fairplay.rktclgh.site localhost 127.0.0.1;
 
     client_max_body_size 100M;

--- a/src/main/java/com/fairing/fairplay/ai/controller/AiChatWebSocketController.java
+++ b/src/main/java/com/fairing/fairplay/ai/controller/AiChatWebSocketController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
@@ -28,14 +29,18 @@ public class AiChatWebSocketController {
     private final ChatMessageService chatMessageService;
 
     @MessageMapping("/ai-chat.sendMessage")
-    public void sendAiMessage(@Payload AiChatMessageDto message, Principal principal) {
+    public void sendAiMessage(
+            @Payload AiChatMessageDto message,
+            Principal principal,
+            SimpMessageHeaderAccessor accessor
+    ) {
         log.info("=== AI WebSocket 메시지 수신 ===");
         log.info("Principal: {}", principal);
         log.info("Message: {}", message);
         
         try {
             // 사용자 ID 추출
-            Long senderId = authenticatedSenderId(principal);
+            Long senderId = authenticatedSenderId(principal, accessor);
             if (senderId == null) {
                 sendErrorMessage(message.getChatRoomId(), "인증이 필요합니다.");
                 return;
@@ -109,15 +114,18 @@ public class AiChatWebSocketController {
         messagingTemplate.convertAndSend(topic, errorResponse);
     }
 
-    private Long authenticatedSenderId(Principal principal) {
-        if (principal == null || principal.getName() == null) {
+    private Long authenticatedSenderId(Principal principal, SimpMessageHeaderAccessor accessor) {
+        if (principal != null && principal.getName() != null) {
+            try {
+                return Long.parseLong(principal.getName());
+            } catch (NumberFormatException e) {
+                log.warn("AI WebSocket principal user id parsing failed: {}", principal.getName());
+            }
+        }
+        if (accessor == null || accessor.getSessionAttributes() == null) {
             return null;
         }
-        try {
-            return Long.parseLong(principal.getName());
-        } catch (NumberFormatException e) {
-            log.warn("AI WebSocket principal user id parsing failed: {}", principal.getName());
-            return null;
-        }
+        Object userId = accessor.getSessionAttributes().get("userId");
+        return userId instanceof Long ? (Long) userId : null;
     }
 }

--- a/src/main/java/com/fairing/fairplay/ai/controller/AiChatWebSocketController.java
+++ b/src/main/java/com/fairing/fairplay/ai/controller/AiChatWebSocketController.java
@@ -49,16 +49,8 @@ public class AiChatWebSocketController {
             );
             
             // 사용자 메시지 브로드캐스트
-            AiChatMessageDto userResponse = AiChatMessageDto.builder()
-                .type("user_message")
-                .content(message.getContent())
-                .chatRoomId(message.getChatRoomId())
-                .senderId(senderId)
-                .timestamp(LocalDateTime.now().toString())
-                .build();
-            
             String topic = "/topic/ai-chat." + message.getChatRoomId();
-            messagingTemplate.convertAndSend(topic, userResponse);
+            messagingTemplate.convertAndSend(topic, userMessage);
 
             // 2. AI 응답 생성을 위한 메시지 구성
             List<ChatMessageDto> chatMessages = new ArrayList<>();
@@ -92,16 +84,7 @@ public class AiChatWebSocketController {
             );
 
             // 5. AI 응답 브로드캐스트
-            AiChatMessageDto aiResponseDto = AiChatMessageDto.builder()
-                .type("ai_response")
-                .content(aiResponse)
-                .chatRoomId(message.getChatRoomId())
-                .senderId(botUserId)
-                .timestamp(LocalDateTime.now().toString())
-                .provider(message.getProvider() != null ? message.getProvider() : "gemini")
-                .build();
-
-            messagingTemplate.convertAndSend(topic, aiResponseDto);
+            messagingTemplate.convertAndSend(topic, aiMessage);
 
             // 6. 채팅방 목록 업데이트 알림
             messagingTemplate.convertAndSend("/topic/chat-room-list", "UPDATE");

--- a/src/main/java/com/fairing/fairplay/banner/entity/BannerApplication.java
+++ b/src/main/java/com/fairing/fairplay/banner/entity/BannerApplication.java
@@ -58,7 +58,7 @@ public class BannerApplication {
     private ApplyStatusCode statusCode;     // PENDING/APPROVED/REJECTED
 
     @Lob
-    @Column(name = "admin_comment")
+    @Column(name = "admin_comment", columnDefinition = "TEXT")
     private String adminComment;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/fairing/fairplay/chat/service/ChatMessageService.java
+++ b/src/main/java/com/fairing/fairplay/chat/service/ChatMessageService.java
@@ -28,6 +28,7 @@ public class ChatMessageService {
     private final ChatRoomRepository chatRoomRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final ChatCacheService chatCacheService;
+    private final ChatRoomAccessService chatRoomAccessService;
 
     @Transactional
     public ChatMessageResponseDto sendMessage(Long chatRoomId, Long senderId, String content) {
@@ -71,7 +72,7 @@ public class ChatMessageService {
         if (userId == null) {
             throw new AccessDeniedException("인증된 사용자만 채팅방에 접근할 수 있습니다.");
         }
-        if (userId.equals(chatRoom.getUserId()) || userId.equals(chatRoom.getTargetId())) {
+        if (chatRoomAccessService.canAccess(chatRoom, userId)) {
             return;
         }
         throw new AccessDeniedException(message);

--- a/src/main/java/com/fairing/fairplay/chat/service/ChatRoomAccessService.java
+++ b/src/main/java/com/fairing/fairplay/chat/service/ChatRoomAccessService.java
@@ -1,0 +1,32 @@
+package com.fairing.fairplay.chat.service;
+
+import com.fairing.fairplay.chat.entity.ChatRoom;
+import com.fairing.fairplay.chat.entity.TargetType;
+import com.fairing.fairplay.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomAccessService {
+
+    private static final String ROLE_ADMIN = "ADMIN";
+
+    private final UserRepository userRepository;
+
+    public boolean canAccess(ChatRoom chatRoom, Long userId) {
+        if (chatRoom == null || userId == null) {
+            return false;
+        }
+        if (userId.equals(chatRoom.getUserId()) || userId.equals(chatRoom.getTargetId())) {
+            return true;
+        }
+        if (TargetType.ADMIN.equals(chatRoom.getTargetType())) {
+            return userRepository.findById(userId)
+                    .map(user -> user.getRoleCode())
+                    .map(role -> ROLE_ADMIN.equals(role.getCode()))
+                    .orElse(false);
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/fairing/fairplay/chat/websocket/SessionStompChannelInterceptor.java
+++ b/src/main/java/com/fairing/fairplay/chat/websocket/SessionStompChannelInterceptor.java
@@ -2,6 +2,7 @@ package com.fairing.fairplay.chat.websocket;
 
 import com.fairing.fairplay.chat.entity.ChatRoom;
 import com.fairing.fairplay.chat.repository.ChatRoomRepository;
+import com.fairing.fairplay.chat.service.ChatRoomAccessService;
 import com.fairing.fairplay.core.service.SessionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +31,7 @@ public class SessionStompChannelInterceptor implements ChannelInterceptor {
 
     private final SessionService sessionService;
     private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomAccessService chatRoomAccessService;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -123,7 +125,7 @@ public class SessionStompChannelInterceptor implements ChannelInterceptor {
 
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new AccessDeniedException("Chat room not found."));
-        if (userId.equals(chatRoom.getUserId()) || userId.equals(chatRoom.getTargetId())) {
+        if (chatRoomAccessService.canAccess(chatRoom, userId)) {
             return;
         }
         log.warn("STOMP SUBSCRIBE denied. userId={}, destination={}", userId, destination);

--- a/src/main/java/com/fairing/fairplay/core/config/PostgresRuntimeSchemaInitializer.java
+++ b/src/main/java/com/fairing/fairplay/core/config/PostgresRuntimeSchemaInitializer.java
@@ -25,6 +25,10 @@ public class PostgresRuntimeSchemaInitializer implements ApplicationRunner {
             return;
         }
 
+        dropEventManagerUniqueConstraintIfExists();
+        relaxLegacyPaymentTargetConstraintIfExists();
+        normalizeBannerApplicationCommentTypeIfExists();
+
         createUniqueIndexIfTableExists(
                 "admin_kpi_statistics",
                 "uk_admin_kpi_statistics_stat_date",
@@ -51,5 +55,75 @@ public class PostgresRuntimeSchemaInitializer implements ApplicationRunner {
         }
 
         jdbcTemplate.execute("CREATE UNIQUE INDEX IF NOT EXISTS " + indexName + " ON " + indexTarget);
+    }
+
+    private void dropEventManagerUniqueConstraintIfExists() {
+        Boolean tableExists = jdbcTemplate.queryForObject(
+                "SELECT to_regclass(?) IS NOT NULL",
+                Boolean.class,
+                "event");
+
+        if (!Boolean.TRUE.equals(tableExists)) {
+            log.debug("Skipping event.manager_id uniqueness cleanup because event table does not exist.");
+            return;
+        }
+
+        jdbcTemplate.execute("""
+                DO $$
+                DECLARE
+                    constraint_name text;
+                BEGIN
+                    SELECT tc.constraint_name
+                    INTO constraint_name
+                    FROM information_schema.table_constraints tc
+                    JOIN information_schema.key_column_usage kcu
+                      ON tc.constraint_name = kcu.constraint_name
+                     AND tc.table_schema = kcu.table_schema
+                    WHERE tc.table_schema = 'public'
+                      AND tc.table_name = 'event'
+                      AND tc.constraint_type = 'UNIQUE'
+                    GROUP BY tc.constraint_name
+                    HAVING array_agg(kcu.column_name::text ORDER BY kcu.ordinal_position) = ARRAY['manager_id']::text[];
+
+                    IF constraint_name IS NOT NULL THEN
+                        EXECUTE format('ALTER TABLE "event" DROP CONSTRAINT %I', constraint_name);
+                    END IF;
+                END $$;
+                """);
+    }
+
+    private void relaxLegacyPaymentTargetConstraintIfExists() {
+        Boolean tableExists = jdbcTemplate.queryForObject(
+                "SELECT to_regclass(?) IS NOT NULL",
+                Boolean.class,
+                "payment");
+
+        if (!Boolean.TRUE.equals(tableExists)) {
+            log.debug("Skipping payment.target_id nullability cleanup because payment table does not exist.");
+            return;
+        }
+
+        jdbcTemplate.execute("ALTER TABLE payment ALTER COLUMN target_id DROP NOT NULL");
+    }
+
+    private void normalizeBannerApplicationCommentTypeIfExists() {
+        Boolean columnExists = jdbcTemplate.queryForObject(
+                """
+                        SELECT EXISTS (
+                            SELECT 1
+                            FROM information_schema.columns
+                            WHERE table_schema = 'public'
+                              AND table_name = 'banner_application'
+                              AND column_name = 'admin_comment'
+                        )
+                        """,
+                Boolean.class);
+
+        if (!Boolean.TRUE.equals(columnExists)) {
+            log.debug("Skipping banner_application.admin_comment type cleanup because column does not exist.");
+            return;
+        }
+
+        jdbcTemplate.execute("ALTER TABLE banner_application ALTER COLUMN admin_comment TYPE text USING admin_comment::text");
     }
 }

--- a/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
+++ b/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
@@ -108,8 +108,6 @@ public class SecurityConfig {
                                 "/api/qr-tickets/reissue",
                                 "/ws/**", // ★ 반드시 필요
                                 "/ws/*/info", // SockJS info 엔드포인트
-                                "/api/chat/rooms", // 채팅방 목록 조회
-                                "/api/chat/rooms/**", // 채팅방 목록 조회만 허용
                                 "/api/chat/presence/status/**", // 사용자 온라인 상태 조회 허용
                                 "/api/uploads/**",
                                 "/uploads/**", // 로컬 파일 시스템의 정적 파일 서빙

--- a/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
+++ b/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
@@ -108,6 +108,7 @@ public class SecurityConfig {
                                 "/api/qr-tickets/reissue",
                                 "/ws/**", // ★ 반드시 필요
                                 "/ws/*/info", // SockJS info 엔드포인트
+                                "/api/chat/rooms", // 채팅방 목록 조회
                                 "/api/chat/rooms/**", // 채팅방 목록 조회만 허용
                                 "/api/chat/presence/status/**", // 사용자 온라인 상태 조회 허용
                                 "/api/uploads/**",

--- a/src/main/java/com/fairing/fairplay/event/entity/Event.java
+++ b/src/main/java/com/fairing/fairplay/event/entity/Event.java
@@ -25,7 +25,7 @@ public class Event {
     @Column(name = "event_id")
     private Long eventId;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "manager_id")
     private EventAdmin manager;
 

--- a/src/main/java/com/fairing/fairplay/payment/entity/Payment.java
+++ b/src/main/java/com/fairing/fairplay/payment/entity/Payment.java
@@ -35,7 +35,7 @@ public class Payment {
     @JoinColumn(name = "payment_target_type_id", nullable = false)
     private PaymentTargetType paymentTargetType; // 결제 대상 타입 (예약/부스/광고)
 
-    @Column(name = "target_id", nullable = false)
+    @Column(name = "target_id")
     private Long targetId; // 실제 결제 대상의 ID (reservation_id, booth_id, advertisement_id)
 
     @Column(name = "merchant_uid", nullable = false, unique = true, length = 100)

--- a/src/test/java/com/fairing/fairplay/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/fairing/fairplay/chat/service/ChatMessageServiceTest.java
@@ -1,6 +1,8 @@
 package com.fairing.fairplay.chat.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -19,16 +21,19 @@ class ChatMessageServiceTest {
     private final ChatRoomRepository chatRoomRepository = mock(ChatRoomRepository.class);
     private final ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
     private final ChatCacheService chatCacheService = mock(ChatCacheService.class);
+    private final ChatRoomAccessService chatRoomAccessService = mock(ChatRoomAccessService.class);
     private final ChatMessageService chatMessageService = new ChatMessageService(
             chatMessageRepository,
             chatRoomRepository,
             eventPublisher,
-            chatCacheService);
+            chatCacheService,
+            chatRoomAccessService);
 
     @Test
     void rejectsMessageReadForNonParticipant() {
         when(chatRoomRepository.findById(123L)).thenReturn(Optional.of(chatRoom(10L, 20L)));
         when(chatCacheService.getCachedMessages(123L)).thenReturn(Collections.emptyList());
+        when(chatRoomAccessService.canAccess(any(ChatRoom.class), eq(30L))).thenReturn(false);
 
         assertThatThrownBy(() -> chatMessageService.getMessages(123L, 30L))
                 .isInstanceOf(AccessDeniedException.class);
@@ -37,6 +42,7 @@ class ChatMessageServiceTest {
     @Test
     void rejectsMessageWriteForNonParticipant() {
         when(chatRoomRepository.findById(123L)).thenReturn(Optional.of(chatRoom(10L, 20L)));
+        when(chatRoomAccessService.canAccess(any(ChatRoom.class), eq(30L))).thenReturn(false);
 
         assertThatThrownBy(() -> chatMessageService.sendMessage(123L, 30L, "hello"))
                 .isInstanceOf(AccessDeniedException.class);

--- a/src/test/java/com/fairing/fairplay/chat/websocket/SessionStompChannelInterceptorTest.java
+++ b/src/test/java/com/fairing/fairplay/chat/websocket/SessionStompChannelInterceptorTest.java
@@ -2,11 +2,14 @@ package com.fairing.fairplay.chat.websocket;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.fairing.fairplay.chat.entity.ChatRoom;
 import com.fairing.fairplay.chat.repository.ChatRoomRepository;
+import com.fairing.fairplay.chat.service.ChatRoomAccessService;
 import com.fairing.fairplay.core.service.SessionService;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -19,8 +22,9 @@ import org.springframework.security.access.AccessDeniedException;
 class SessionStompChannelInterceptorTest {
 
     private final ChatRoomRepository chatRoomRepository = mock(ChatRoomRepository.class);
+    private final ChatRoomAccessService chatRoomAccessService = mock(ChatRoomAccessService.class);
     private final SessionStompChannelInterceptor interceptor =
-            new SessionStompChannelInterceptor(mock(SessionService.class), chatRoomRepository);
+            new SessionStompChannelInterceptor(mock(SessionService.class), chatRoomRepository, chatRoomAccessService);
 
     @Test
     void rejectsUnauthenticatedAppSend() {
@@ -57,6 +61,7 @@ class SessionStompChannelInterceptorTest {
     @Test
     void rejectsAuthenticatedChatSubscribeForNonParticipant() {
         when(chatRoomRepository.findById(123L)).thenReturn(Optional.of(chatRoom(10L, 20L)));
+        when(chatRoomAccessService.canAccess(any(ChatRoom.class), eq(30L))).thenReturn(false);
         Message<byte[]> message = stompMessage(StompCommand.SUBSCRIBE, "/topic/chat.123", new StompPrincipal("30"));
 
         assertThatThrownBy(() -> interceptor.preSend(message, null))
@@ -66,6 +71,7 @@ class SessionStompChannelInterceptorTest {
     @Test
     void allowsAuthenticatedChatSubscribeForParticipant() {
         when(chatRoomRepository.findById(123L)).thenReturn(Optional.of(chatRoom(10L, 20L)));
+        when(chatRoomAccessService.canAccess(any(ChatRoom.class), eq(10L))).thenReturn(true);
         Message<byte[]> message = stompMessage(StompCommand.SUBSCRIBE, "/topic/chat.123", new StompPrincipal("10"));
 
         assertThatCode(() -> interceptor.preSend(message, null))


### PR DESCRIPTION
## Summary
- align JPA mappings with the restored legacy RDS data shape
- remove the generated uniqueness assumption for event.manager_id at runtime
- relax payment.target_id and normalize banner_application.admin_comment for PostgreSQL restores

## Verification
- ./gradlew compileJava --no-daemon
- rollback restore dry-run against production PostgreSQL before committing the actual restored data

## Notes
- The production PostgreSQL restore has already committed restored content from the recovered RDS dump.
- This PR keeps future deployments from reintroducing the schema constraints that blocked the restore.
