### PR TITLE
Separate AI chat response work from request transaction

### DIFF
--- a/src/main/java/com/fairing/fairplay/ai/controller/AiChatWebSocketController.java
+++ b/src/main/java/com/fairing/fairplay/ai/controller/AiChatWebSocketController.java
@@ -1,9 +1,6 @@
 package com.fairing.fairplay.ai.controller;
 
 import com.fairing.fairplay.ai.dto.AiChatMessageDto;
-import com.fairing.fairplay.ai.dto.ChatMessageDto;
-import com.fairing.fairplay.ai.dto.ChatRequestDto;
-import com.fairing.fairplay.ai.service.ChatAiService;
 import com.fairing.fairplay.chat.dto.ChatMessageResponseDto;
 import com.fairing.fairplay.chat.service.ChatMessageService;
 import lombok.RequiredArgsConstructor;
@@ -14,9 +11,6 @@ import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
 
 import java.security.Principal;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Controller
 @RequiredArgsConstructor
@@ -24,7 +18,6 @@ import java.util.List;
 public class AiChatWebSocketController {
 
     private final SimpMessagingTemplate messagingTemplate;
-    private final ChatAiService chatAiService;
     private final ChatMessageService chatMessageService;
 
     @MessageMapping("/ai-chat.sendMessage")
@@ -41,72 +34,20 @@ public class AiChatWebSocketController {
                 return;
             }
 
-            // 1. 사용자 메시지를 DB에 저장하고 브로드캐스트
+            // 사용자 메시지 저장 이벤트가 커밋된 뒤 AiChatOrchestrator가 AI 응답을 생성한다.
             ChatMessageResponseDto userMessage = chatMessageService.sendMessage(
                 message.getChatRoomId(), 
                 senderId, 
                 message.getContent()
             );
             
-            // 사용자 메시지 브로드캐스트
-            AiChatMessageDto userResponse = AiChatMessageDto.builder()
-                .type("user_message")
-                .content(message.getContent())
-                .chatRoomId(message.getChatRoomId())
-                .senderId(senderId)
-                .timestamp(LocalDateTime.now().toString())
-                .build();
-            
             String topic = "/topic/ai-chat." + message.getChatRoomId();
-            messagingTemplate.convertAndSend(topic, userResponse);
+            messagingTemplate.convertAndSend(topic, userMessage);
 
-            // 2. AI 응답 생성을 위한 메시지 구성
-            List<ChatMessageDto> chatMessages = new ArrayList<>();
-            chatMessages.add(ChatMessageDto.builder()
-                .role(ChatMessageDto.Role.SYSTEM)
-                .content("당신은 FairPlay 이벤트 플랫폼의 도움이 되는 AI 어시스턴트입니다. 한국어로 친근하고 도움이 되는 답변을 해주세요.")
-                .build());
-            
-            chatMessages.add(ChatMessageDto.builder()
-                .role(ChatMessageDto.Role.USER)
-                .content(message.getContent())
-                .build());
-
-            // 3. AI 서비스 호출
-            ChatRequestDto aiRequest = ChatRequestDto.builder()
-                .messages(chatMessages)
-                .temperature(message.getTemperature() != null ? message.getTemperature() : 0.7)
-                .maxOutputTokens(message.getMaxOutputTokens() != null ? message.getMaxOutputTokens() : 2048)
-                .providerOverride(message.getProvider())
-                .build();
-
-            String aiResponse = chatAiService.chat(aiRequest);
-
-            // 4. AI 응답을 DB에 저장 (봇 계정으로)
-            Long botUserId = 999L; // application.properties의 llm.bot-user-id 값
-            
-            ChatMessageResponseDto aiMessage = chatMessageService.sendMessage(
-                message.getChatRoomId(),
-                botUserId,
-                aiResponse
-            );
-
-            // 5. AI 응답 브로드캐스트
-            AiChatMessageDto aiResponseDto = AiChatMessageDto.builder()
-                .type("ai_response")
-                .content(aiResponse)
-                .chatRoomId(message.getChatRoomId())
-                .senderId(botUserId)
-                .timestamp(LocalDateTime.now().toString())
-                .provider(message.getProvider() != null ? message.getProvider() : "gemini")
-                .build();
-
-            messagingTemplate.convertAndSend(topic, aiResponseDto);
-
-            // 6. 채팅방 목록 업데이트 알림
+            // 채팅방 목록 업데이트 알림
             messagingTemplate.convertAndSend("/topic/chat-room-list", "UPDATE");
             
-            log.info("AI 채팅 처리 완료");
+            log.info("AI 채팅 사용자 메시지 처리 완료");
 
         } catch (Exception e) {
             log.error("AI 채팅 처리 중 오류 발생", e);
@@ -119,7 +60,6 @@ public class AiChatWebSocketController {
             .type("system_error")
             .content(errorMessage)
             .chatRoomId(chatRoomId)
-            .timestamp(LocalDateTime.now().toString())
             .build();
         
         String topic = "/topic/ai-chat." + chatRoomId;

--- a/src/main/java/com/fairing/fairplay/ai/orchestrator/AiChatOrchestrator.java
+++ b/src/main/java/com/fairing/fairplay/ai/orchestrator/AiChatOrchestrator.java
@@ -1,9 +1,10 @@
 // src/main/java/com/fairing/fairplay/ai/orchestrator/AiChatOrchestrator.java
 package com.fairing.fairplay.ai.orchestrator;
 
-import com.fairing.fairplay.ai.service.LlmRouter;
+import com.fairing.fairplay.ai.dto.AiChatMessageDto;
 import com.fairing.fairplay.ai.dto.ChatMessageDto;
 import com.fairing.fairplay.ai.rag.service.RagChatService;
+import com.fairing.fairplay.ai.service.LlmRouter;
 import com.fairing.fairplay.chat.dto.ChatMessageResponseDto;
 import com.fairing.fairplay.chat.entity.ChatMessage;
 import com.fairing.fairplay.chat.entity.ChatRoom;
@@ -12,19 +13,30 @@ import com.fairing.fairplay.chat.event.ChatMessageCreatedEvent;
 import com.fairing.fairplay.chat.repository.ChatMessageRepository;
 import com.fairing.fairplay.chat.repository.ChatRoomRepository;
 import com.fairing.fairplay.chat.service.ChatMessageService;
-import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 @Component
-@RequiredArgsConstructor
+@Slf4j
 public class AiChatOrchestrator {
 
     private final ChatRoomRepository chatRoomRepository;
@@ -33,90 +45,189 @@ public class AiChatOrchestrator {
     private final LlmRouter llmRouter;
     private final RagChatService ragChatService;
     private final SimpMessagingTemplate messagingTemplate;
+    private final Executor aiResponseExecutor;
 
     // ✅ 봇 계정은 “로그인” 필요 없음. 서버가 DB에 저장할 때 senderId=botUserId로 넣어줌
     @Value("${llm.bot-user-id}")
     private Long botUserId;
 
+    @Autowired
+    public AiChatOrchestrator(
+            ChatRoomRepository chatRoomRepository,
+            ChatMessageRepository chatMessageRepository,
+            ChatMessageService chatMessageService,
+            LlmRouter llmRouter,
+            RagChatService ragChatService,
+            SimpMessagingTemplate messagingTemplate,
+            @Qualifier("aiChatTaskExecutor") Executor aiResponseExecutor
+    ) {
+        this.chatRoomRepository = chatRoomRepository;
+        this.chatMessageRepository = chatMessageRepository;
+        this.chatMessageService = chatMessageService;
+        this.llmRouter = llmRouter;
+        this.ragChatService = ragChatService;
+        this.messagingTemplate = messagingTemplate;
+        this.aiResponseExecutor = aiResponseExecutor;
+    }
+
+    public AiChatOrchestrator(
+            ChatRoomRepository chatRoomRepository,
+            ChatMessageRepository chatMessageRepository,
+            ChatMessageService chatMessageService,
+            LlmRouter llmRouter,
+            RagChatService ragChatService,
+            SimpMessagingTemplate messagingTemplate
+    ) {
+        this(
+                chatRoomRepository,
+                chatMessageRepository,
+                chatMessageService,
+                llmRouter,
+                ragChatService,
+                messagingTemplate,
+                createFallbackExecutor()
+        );
+    }
+
+    private static Executor createFallbackExecutor() {
+        ThreadFactory threadFactory = new ThreadFactory() {
+            private int threadNumber = 1;
+
+            @Override
+            public synchronized Thread newThread(Runnable runnable) {
+                Thread thread = new Thread(runnable, "ai-chat-response-test-" + threadNumber++);
+                thread.setDaemon(true);
+                return thread;
+            }
+        };
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(
+                2,
+                2,
+                0L,
+                TimeUnit.MILLISECONDS,
+                new ArrayBlockingQueue<>(100),
+                threadFactory,
+                new ThreadPoolExecutor.AbortPolicy()
+        );
+        executor.prestartAllCoreThreads();
+        return executor;
+    }
+
     // 간단 루프 방지(봇이 쓴 메시지에 또 반응하지 않기)
     private boolean shouldRespond(Long senderId) {
-        return !senderId.equals(botUserId);
+        return !botUserId.equals(senderId);
     }
 
     @EventListener
-    @Transactional(readOnly = true)
     public void onUserMessage(ChatMessageCreatedEvent event) {
+        if (!hasSavedMessagePayload(event)) {
+            log.info("AI 응답 스킵: 저장된 사용자 메시지 payload가 없음. roomId={}, chatMessageId={}",
+                    event.getChatRoomId(), event.getChatMessageId());
+            return;
+        }
+
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    runAfterTransaction(event);
+                }
+            });
+            return;
+        }
+
+        handleUserMessage(event);
+    }
+
+    private void runAfterTransaction(ChatMessageCreatedEvent event) {
+        try {
+            if (aiResponseExecutor instanceof ThreadPoolExecutor fallbackExecutor) {
+                Future<?> future = fallbackExecutor.submit(() -> handleUserMessageSafely(event));
+                try {
+                    future.get(20, TimeUnit.MILLISECONDS);
+                } catch (TimeoutException ignored) {
+                    // 테스트 호환용 fallback 경로에서는 긴 AI 작업을 기다리지 않는다.
+                }
+                return;
+            }
+            aiResponseExecutor.execute(() -> handleUserMessageSafely(event));
+        } catch (RuntimeException e) {
+            log.error("AI 응답 작업 제출 실패. roomId={}", event.getChatRoomId(), e);
+            sendErrorMessage(event.getChatRoomId(), "AI 응답 작업을 시작하지 못했습니다. 잠시 후 다시 시도해주세요.");
+        } catch (Exception e) {
+            log.error("AI 응답 작업 확인 중 오류 발생. roomId={}", event.getChatRoomId(), e);
+            sendErrorMessage(event.getChatRoomId(), "AI 응답 작업을 시작하지 못했습니다. 잠시 후 다시 시도해주세요.");
+        }
+    }
+
+    private void handleUserMessageSafely(ChatMessageCreatedEvent event) {
+        try {
+            handleUserMessage(event);
+        } catch (Exception e) {
+            log.error("AI 응답 처리 중 오류 발생. roomId={}", event.getChatRoomId(), e);
+            sendErrorMessage(event.getChatRoomId(), "AI 응답 생성 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.");
+        }
+    }
+
+    private void handleUserMessage(ChatMessageCreatedEvent event) {
         Long roomId = event.getChatRoomId();
         Long senderId = event.getSenderId();
-        
-        System.out.println("=== AI 오케스트레이터 이벤트 수신 ===");
-        System.out.println("Room ID: " + roomId);
-        System.out.println("Sender ID: " + senderId);
-        System.out.println("Bot User ID: " + botUserId);
+
+        log.info("AI 오케스트레이터 이벤트 수신. roomId={}, senderId={}, chatMessageId={}",
+                roomId, senderId, event.getChatMessageId());
 
         if (!shouldRespond(senderId)) {
-            System.out.println("AI 응답 스킵: 봇이 보낸 메시지");
+            log.info("AI 응답 스킵: 봇이 보낸 메시지. roomId={}", roomId);
             return;
         }
 
         ChatRoom room = chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new IllegalArgumentException("채팅방 없음: " + roomId));
 
-        System.out.println("채팅방 타입: " + room.getTargetType());
-        System.out.println("타겟 ID: " + room.getTargetId());
+        log.info("AI 채팅방 확인. roomId={}, targetType={}, targetId={}",
+                roomId, room.getTargetType(), room.getTargetId());
 
         // AI 어시스던트 방만 처리
         if (room.getTargetType() != TargetType.AI) {
-            System.out.println("AI 응답 스킵: AI 채팅방이 아님");
+            log.info("AI 응답 스킵: AI 채팅방이 아님. roomId={}", roomId);
             return;
         }
-        
-        System.out.println("AI 응답 처리 시작...");
 
         // 최근 대화 기록 구성
         List<ChatMessage> history = chatMessageRepository.findByChatRoomOrderBySentAtAsc(room);
-        if (history.isEmpty()) return;
         history.sort(Comparator.comparing(ChatMessage::getSentAt));
+
+        ResolvedUserMessage userMessage = new ResolvedUserMessage(event.getChatMessageId(), event.getContent());
 
         // 대화 기록을 ChatMessageDto로 변환
         List<ChatMessageDto> conversationHistory = new ArrayList<>();
-        for (ChatMessage m : history.subList(Math.max(0, history.size() - 10), history.size())) {
+        List<ChatMessage> scopedHistory = historyUpToEventMessage(history, userMessage.chatMessageId());
+        for (ChatMessage m : scopedHistory.subList(Math.max(0, scopedHistory.size() - 10), scopedHistory.size())) {
             if (m.getSenderId().equals(botUserId)) {
                 conversationHistory.add(ChatMessageDto.assistant(m.getContent()));
             } else {
                 conversationHistory.add(ChatMessageDto.user(m.getContent()));
             }
         }
-
-        // 마지막 사용자 메시지 추출
-        String userQuestion = null;
-        for (int i = history.size() - 1; i >= 0; i--) {
-            ChatMessage m = history.get(i);
-            if (!m.getSenderId().equals(botUserId)) {
-                userQuestion = m.getContent();
-                break;
-            }
-        }
-        if (userQuestion == null || userQuestion.isBlank()) {
-            System.out.println("AI 응답 스킵: 사용자 발화를 찾지 못함");
-            return;
+        if (conversationHistory.isEmpty()
+                || !userMessage.content().equals(conversationHistory.get(conversationHistory.size() - 1).getContent())) {
+            conversationHistory.add(ChatMessageDto.user(userMessage.content()));
         }
 
         // RAG 기반 응답 생성 (사용자 ID 포함)
         String reply;
         try {
-            System.out.println("RAG 채팅 호출 시작... (사용자 ID: " + room.getUserId() + ")");
-            RagChatService.RagResponse ragResponse = ragChatService.chat(userQuestion, conversationHistory, room.getUserId());
+            log.info("RAG 채팅 호출 시작. roomId={}, userId={}, chatMessageId={}",
+                    roomId, room.getUserId(), userMessage.chatMessageId());
+            RagChatService.RagResponse ragResponse = ragChatService.chat(userMessage.content(), conversationHistory, room.getUserId());
             
             reply = ragResponse.getAnswer();
             
-            System.out.println("RAG 응답: " + reply);
-            System.out.println("컨텍스트 사용: " + ragResponse.isHasContext());
-            System.out.println("인용 청크: " + ragResponse.getCitedChunks().size());
+            log.info("RAG 응답 생성 완료. roomId={}, hasContext={}, citedChunks={}",
+                    roomId, ragResponse.isHasContext(), ragResponse.getCitedChunks().size());
             
         } catch (Exception e) {
-            System.out.println("RAG 채팅 실패, 기본 LLM으로 fallback: " + e.getMessage());
-            e.printStackTrace();
+            log.warn("RAG 채팅 실패, 기본 LLM으로 fallback. roomId={}", roomId, e);
             
             // Fallback to original 0-shot approach
             List<ChatMessageDto> prompt = new ArrayList<>();
@@ -138,25 +249,54 @@ public class AiChatOrchestrator {
                     reply = "죄송해요, 방금은 답변을 생성하지 못했어요. 한 번만 더 질문해줄래요?";
                 }
             } catch (Exception e2) {
+                log.error("기본 LLM fallback 실패. roomId={}", roomId, e2);
                 reply = "지금은 답변 생성에 문제가 있어요. 잠시 후 다시 시도해주세요.";
             }
         }
 
-        System.out.println("최종 AI 응답: " + reply);
         // ✅ 트랜잭션 분리해서 저장 및 방송
         saveAndBroadcast(roomId, reply);
     }
 
+    private boolean hasSavedMessagePayload(ChatMessageCreatedEvent event) {
+        return event.getChatMessageId() != null
+                && event.getContent() != null
+                && !event.getContent().isBlank();
+    }
+
+    private List<ChatMessage> historyUpToEventMessage(List<ChatMessage> history, Long chatMessageId) {
+        if (chatMessageId == null) {
+            return history;
+        }
+
+        for (int i = 0; i < history.size(); i++) {
+            if (chatMessageId.equals(history.get(i).getChatMessageId())) {
+                return history.subList(0, i + 1);
+            }
+        }
+        return history;
+    }
+
     @Transactional
     protected void saveAndBroadcast(Long roomId, String reply) {
-        System.out.println("AI 메시지 저장 및 브로드캐스트...");
-        System.out.println("Room ID: " + roomId + ", Bot User ID: " + botUserId);
+        log.info("AI 메시지 저장 및 브로드캐스트. roomId={}, botUserId={}", roomId, botUserId);
         ChatMessageResponseDto saved = chatMessageService.sendMessage(roomId, botUserId, reply);
-        System.out.println("저장된 메시지 ID: " + saved.getChatMessageId());
-        messagingTemplate.convertAndSend("/topic/chat." + roomId, saved);
-        System.out.println("WebSocket 브로드캐스트 완료");
+        messagingTemplate.convertAndSend("/topic/ai-chat." + roomId, saved);
         // 방 목록 업데이트 브로드캐스트(기존 패턴 맞춤)
         messagingTemplate.convertAndSend("/topic/chat-room-list", "UPDATE");
-        System.out.println("=== AI 응답 처리 완료 ===");
+        log.info("AI 응답 처리 완료. roomId={}, chatMessageId={}", roomId, saved.getChatMessageId());
+    }
+
+    private void sendErrorMessage(Long roomId, String errorMessage) {
+        AiChatMessageDto errorResponse = AiChatMessageDto.builder()
+                .type("system_error")
+                .content(errorMessage)
+                .chatRoomId(roomId)
+                .build();
+
+        messagingTemplate.convertAndSend("/topic/ai-chat." + roomId, errorResponse);
+    }
+
+    private record ResolvedUserMessage(Long chatMessageId, String content) {
     }
 }

--- a/src/main/java/com/fairing/fairplay/ai/orchestrator/AiChatOrchestrator.java
+++ b/src/main/java/com/fairing/fairplay/ai/orchestrator/AiChatOrchestrator.java
@@ -20,20 +20,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 @Component
 @Slf4j
@@ -47,7 +40,7 @@ public class AiChatOrchestrator {
     private final SimpMessagingTemplate messagingTemplate;
     private final Executor aiResponseExecutor;
 
-    // ✅ 봇 계정은 “로그인” 필요 없음. 서버가 DB에 저장할 때 senderId=botUserId로 넣어줌
+    // 봇 계정은 로그인 없이 서버가 DB에 저장할 때 senderId=botUserId로 사용한다.
     @Value("${llm.bot-user-id}")
     private Long botUserId;
 
@@ -68,49 +61,6 @@ public class AiChatOrchestrator {
         this.ragChatService = ragChatService;
         this.messagingTemplate = messagingTemplate;
         this.aiResponseExecutor = aiResponseExecutor;
-    }
-
-    public AiChatOrchestrator(
-            ChatRoomRepository chatRoomRepository,
-            ChatMessageRepository chatMessageRepository,
-            ChatMessageService chatMessageService,
-            LlmRouter llmRouter,
-            RagChatService ragChatService,
-            SimpMessagingTemplate messagingTemplate
-    ) {
-        this(
-                chatRoomRepository,
-                chatMessageRepository,
-                chatMessageService,
-                llmRouter,
-                ragChatService,
-                messagingTemplate,
-                createFallbackExecutor()
-        );
-    }
-
-    private static Executor createFallbackExecutor() {
-        ThreadFactory threadFactory = new ThreadFactory() {
-            private int threadNumber = 1;
-
-            @Override
-            public synchronized Thread newThread(Runnable runnable) {
-                Thread thread = new Thread(runnable, "ai-chat-response-test-" + threadNumber++);
-                thread.setDaemon(true);
-                return thread;
-            }
-        };
-        ThreadPoolExecutor executor = new ThreadPoolExecutor(
-                2,
-                2,
-                0L,
-                TimeUnit.MILLISECONDS,
-                new ArrayBlockingQueue<>(100),
-                threadFactory,
-                new ThreadPoolExecutor.AbortPolicy()
-        );
-        executor.prestartAllCoreThreads();
-        return executor;
     }
 
     // 간단 루프 방지(봇이 쓴 메시지에 또 반응하지 않기)
@@ -141,15 +91,6 @@ public class AiChatOrchestrator {
 
     private void runAfterTransaction(ChatMessageCreatedEvent event) {
         try {
-            if (aiResponseExecutor instanceof ThreadPoolExecutor fallbackExecutor) {
-                Future<?> future = fallbackExecutor.submit(() -> handleUserMessageSafely(event));
-                try {
-                    future.get(20, TimeUnit.MILLISECONDS);
-                } catch (TimeoutException ignored) {
-                    // 테스트 호환용 fallback 경로에서는 긴 AI 작업을 기다리지 않는다.
-                }
-                return;
-            }
             aiResponseExecutor.execute(() -> handleUserMessageSafely(event));
         } catch (RuntimeException e) {
             log.error("AI 응답 작업 제출 실패. roomId={}", event.getChatRoomId(), e);
@@ -254,7 +195,7 @@ public class AiChatOrchestrator {
             }
         }
 
-        // ✅ 트랜잭션 분리해서 저장 및 방송
+        // chatMessageService.sendMessage가 자체 트랜잭션에서 저장과 이벤트 발행을 담당한다.
         saveAndBroadcast(roomId, reply);
     }
 
@@ -277,7 +218,6 @@ public class AiChatOrchestrator {
         return history;
     }
 
-    @Transactional
     protected void saveAndBroadcast(Long roomId, String reply) {
         log.info("AI 메시지 저장 및 브로드캐스트. roomId={}, botUserId={}", roomId, botUserId);
         ChatMessageResponseDto saved = chatMessageService.sendMessage(roomId, botUserId, reply);

--- a/src/main/java/com/fairing/fairplay/chat/event/ChatMessageCreatedEvent.java
+++ b/src/main/java/com/fairing/fairplay/chat/event/ChatMessageCreatedEvent.java
@@ -7,9 +7,17 @@ import lombok.Getter;
 public class ChatMessageCreatedEvent {
     private final Long chatRoomId;
     private final Long senderId;
+    private final Long chatMessageId;
+    private final String content;
 
     public ChatMessageCreatedEvent(Long chatRoomId, Long senderId) {
+        this(chatRoomId, senderId, null, null);
+    }
+
+    public ChatMessageCreatedEvent(Long chatRoomId, Long senderId, Long chatMessageId, String content) {
         this.chatRoomId = chatRoomId;
         this.senderId = senderId;
+        this.chatMessageId = chatMessageId;
+        this.content = content;
     }
 }

--- a/src/main/java/com/fairing/fairplay/chat/service/ChatMessageService.java
+++ b/src/main/java/com/fairing/fairplay/chat/service/ChatMessageService.java
@@ -62,7 +62,12 @@ public class ChatMessageService {
         invalidateUnreadCaches(chatRoomId);
 
         // 이벤트 발행
-        eventPublisher.publishEvent(new ChatMessageCreatedEvent(chatRoomId, senderId));
+        eventPublisher.publishEvent(new ChatMessageCreatedEvent(
+                chatRoomId,
+                senderId,
+                saved.getChatMessageId(),
+                saved.getContent()
+        ));
 
         return responseDto;
     }

--- a/src/main/java/com/fairing/fairplay/config/AsyncConfig.java
+++ b/src/main/java/com/fairing/fairplay/config/AsyncConfig.java
@@ -4,6 +4,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+import java.util.concurrent.ThreadPoolExecutor;
+
 /**
  * 비동기 처리를 위한 ThreadPool 설정
  * RAG 임베딩 병렬 처리에 사용
@@ -43,6 +45,21 @@ public class AsyncConfig {
         // 초기화
         executor.initialize();
         
+        return executor;
+    }
+
+    @Bean(name = "aiChatTaskExecutor")
+    public ThreadPoolTaskExecutor aiChatTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("ai-chat-response-");
+        executor.setBeanName("aiChatTaskExecutor");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(20);
+        executor.initialize();
         return executor;
     }
 }

--- a/src/test/java/com/fairing/fairplay/ai/controller/AiChatWebSocketControllerContractTest.java
+++ b/src/test/java/com/fairing/fairplay/ai/controller/AiChatWebSocketControllerContractTest.java
@@ -1,0 +1,126 @@
+package com.fairing.fairplay.ai.controller;
+
+import com.fairing.fairplay.ai.dto.AiChatMessageDto;
+import com.fairing.fairplay.ai.service.ChatAiService;
+import com.fairing.fairplay.chat.dto.ChatMessageResponseDto;
+import com.fairing.fairplay.chat.service.ChatMessageService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.security.Principal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AiChatWebSocketControllerContractTest {
+
+    @Mock
+    SimpMessagingTemplate messagingTemplate;
+
+    @Mock
+    ChatAiService chatAiService;
+
+    @Mock
+    ChatMessageService chatMessageService;
+
+    @InjectMocks
+    AiChatWebSocketController controller;
+
+    @Test
+    void sendAiMessagePersistsExactlyOneMessageForOneUserMessage() {
+        Long roomId = 101L;
+        Long senderId = 42L;
+        when(chatMessageService.sendMessage(roomId, senderId, "예매 방법 알려줘"))
+                .thenReturn(savedUserMessage(roomId, senderId, "예매 방법 알려줘"));
+
+        controller.sendAiMessage(aiChatMessage(roomId, senderId), principal(senderId));
+
+        verify(chatMessageService).sendMessage(roomId, senderId, "예매 방법 알려줘");
+    }
+
+    @Test
+    void sendAiMessageDoesNotCallChatAiServiceDirectly() {
+        Long roomId = 101L;
+        Long senderId = 42L;
+        when(chatMessageService.sendMessage(roomId, senderId, "예매 방법 알려줘"))
+                .thenReturn(savedUserMessage(roomId, senderId, "예매 방법 알려줘"));
+
+        controller.sendAiMessage(aiChatMessage(roomId, senderId), principal(senderId));
+
+        verifyNoInteractions(chatAiService);
+    }
+
+    @Test
+    void sendAiMessageBroadcastsSavedUserMessageDtoWithChatMessageIdAndSentAt() {
+        Long roomId = 101L;
+        Long senderId = 42L;
+        ChatMessageResponseDto savedUserMessage = savedUserMessage(roomId, senderId, "저장된 사용자 질문");
+        when(chatMessageService.sendMessage(roomId, senderId, "예매 방법 알려줘"))
+                .thenReturn(savedUserMessage);
+
+        controller.sendAiMessage(aiChatMessage(roomId, senderId), principal(senderId));
+
+        ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(messagingTemplate).convertAndSend(
+                eq("/topic/ai-chat." + roomId),
+                payloadCaptor.capture()
+        );
+        assertThat(payloadCaptor.getValue())
+                .isInstanceOf(ChatMessageResponseDto.class)
+                .isSameAs(savedUserMessage)
+                .extracting("chatMessageId", "sentAt")
+                .containsExactly(501L, LocalDateTime.of(2026, 5, 18, 10, 0));
+    }
+
+    @Test
+    void sendAiMessageBroadcastsSavedUserMessageWithoutSystemError() {
+        Long roomId = 101L;
+        Long senderId = 42L;
+        when(chatMessageService.sendMessage(roomId, senderId, "예매 방법 알려줘"))
+                .thenReturn(savedUserMessage(roomId, senderId, "저장된 사용자 질문"));
+
+        controller.sendAiMessage(aiChatMessage(roomId, senderId), principal(senderId));
+
+        verify(messagingTemplate, never()).convertAndSend(
+                eq("/topic/ai-chat." + roomId),
+                (Object) argThat(payload -> payload instanceof AiChatMessageDto dto
+                        && "system_error".equals(dto.getType()))
+        );
+        verifyNoInteractions(chatAiService);
+    }
+
+    private AiChatMessageDto aiChatMessage(Long roomId, Long senderId) {
+        return AiChatMessageDto.builder()
+                .chatRoomId(roomId)
+                .senderId(senderId)
+                .content("예매 방법 알려줘")
+                .build();
+    }
+
+    private Principal principal(Long senderId) {
+        return () -> senderId.toString();
+    }
+
+    private ChatMessageResponseDto savedUserMessage(Long roomId, Long senderId, String content) {
+        return ChatMessageResponseDto.builder()
+                .chatMessageId(501L)
+                .chatRoomId(roomId)
+                .senderId(senderId)
+                .content(content)
+                .sentAt(LocalDateTime.of(2026, 5, 18, 10, 0))
+                .isRead(false)
+                .build();
+    }
+}

--- a/src/test/java/com/fairing/fairplay/ai/orchestrator/AiChatOrchestratorTransactionContractTest.java
+++ b/src/test/java/com/fairing/fairplay/ai/orchestrator/AiChatOrchestratorTransactionContractTest.java
@@ -14,6 +14,7 @@ import com.fairing.fairplay.chat.service.ChatMessageService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -35,6 +36,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -84,7 +86,7 @@ class AiChatOrchestratorTransactionContractTest {
     }
 
     @Test
-    void invokesRagChatAfterCommitWithoutAnActiveTransaction() {
+    void invokesRagChatAfterCommitWithoutAnActiveTransaction() throws Exception {
         Long roomId = 101L;
         Long senderId = 42L;
         ChatRoom aiRoom = ChatRoom.builder()
@@ -102,6 +104,7 @@ class AiChatOrchestratorTransactionContractTest {
                 .sentAt(LocalDateTime.now())
                 .isRead(false)
                 .build();
+        CountDownLatch ragCalled = new CountDownLatch(1);
 
         when(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(aiRoom));
         when(chatMessageRepository.findByChatRoomOrderBySentAtAsc(aiRoom)).thenReturn(new ArrayList<>(List.of(userMessage)));
@@ -111,6 +114,7 @@ class AiChatOrchestratorTransactionContractTest {
                             TransactionSynchronizationManager.isActualTransactionActive(),
                             "RAG/LLM 호출은 사용자 메시지 저장 트랜잭션 커밋 이후, 트랜잭션 밖에서 실행되어야 한다."
                     );
+                    ragCalled.countDown();
                     return RagChatService.RagResponse.builder()
                             .answer("예매는 행사 상세 페이지에서 할 수 있어요.")
                             .hasContext(false)
@@ -132,6 +136,7 @@ class AiChatOrchestratorTransactionContractTest {
                 eventPublisher.publishEvent(new ChatMessageCreatedEvent(roomId, senderId, 1L, "예매 방법 알려줘"))
         );
 
+        assertTrue(ragCalled.await(1, TimeUnit.SECONDS));
         verify(ragChatService).chat(eq("예매 방법 알려줘"), any(List.class), eq(senderId));
         verify(chatMessageService).sendMessage(roomId, 999L, "예매는 행사 상세 페이지에서 할 수 있어요.");
     }
@@ -315,7 +320,8 @@ class AiChatOrchestratorTransactionContractTest {
                 ChatMessageService chatMessageService,
                 LlmRouter llmRouter,
                 RagChatService ragChatService,
-                SimpMessagingTemplate messagingTemplate
+                SimpMessagingTemplate messagingTemplate,
+                @Qualifier("aiChatTaskExecutor") Executor aiResponseExecutor
         ) {
             return new AiChatOrchestrator(
                     chatRoomRepository,
@@ -323,8 +329,14 @@ class AiChatOrchestratorTransactionContractTest {
                     chatMessageService,
                     llmRouter,
                     ragChatService,
-                    messagingTemplate
+                    messagingTemplate,
+                    aiResponseExecutor
             );
+        }
+
+        @Bean(destroyMethod = "shutdownNow")
+        ExecutorService aiChatTaskExecutor() {
+            return Executors.newCachedThreadPool();
         }
 
         @Bean

--- a/src/test/java/com/fairing/fairplay/ai/orchestrator/AiChatOrchestratorTransactionContractTest.java
+++ b/src/test/java/com/fairing/fairplay/ai/orchestrator/AiChatOrchestratorTransactionContractTest.java
@@ -1,0 +1,382 @@
+package com.fairing.fairplay.ai.orchestrator;
+
+import com.fairing.fairplay.ai.dto.ChatMessageDto;
+import com.fairing.fairplay.ai.rag.service.RagChatService;
+import com.fairing.fairplay.ai.service.LlmRouter;
+import com.fairing.fairplay.chat.dto.ChatMessageResponseDto;
+import com.fairing.fairplay.chat.entity.ChatMessage;
+import com.fairing.fairplay.chat.entity.ChatRoom;
+import com.fairing.fairplay.chat.entity.TargetType;
+import com.fairing.fairplay.chat.event.ChatMessageCreatedEvent;
+import com.fairing.fairplay.chat.repository.ChatMessageRepository;
+import com.fairing.fairplay.chat.repository.ChatRoomRepository;
+import com.fairing.fairplay.chat.service.ChatMessageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.support.AbstractPlatformTransactionManager;
+import org.springframework.transaction.support.DefaultTransactionStatus;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SpringJUnitConfig(AiChatOrchestratorTransactionContractTest.TestConfig.class)
+@TestPropertySource(properties = "llm.bot-user-id=999")
+class AiChatOrchestratorTransactionContractTest {
+
+    @Autowired
+    ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    PlatformTransactionManager transactionManager;
+
+    @Autowired
+    ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    ChatMessageRepository chatMessageRepository;
+
+    @Autowired
+    ChatMessageService chatMessageService;
+
+    @Autowired
+    RagChatService ragChatService;
+
+    @Autowired
+    LlmRouter llmRouter;
+
+    @Autowired
+    SimpMessagingTemplate messagingTemplate;
+
+    @BeforeEach
+    void resetMocks() {
+        reset(chatRoomRepository, chatMessageRepository, chatMessageService, ragChatService, messagingTemplate);
+    }
+
+    @Test
+    void invokesRagChatAfterCommitWithoutAnActiveTransaction() {
+        Long roomId = 101L;
+        Long senderId = 42L;
+        ChatRoom aiRoom = ChatRoom.builder()
+                .chatRoomId(roomId)
+                .userId(senderId)
+                .targetType(TargetType.AI)
+                .targetId(1L)
+                .createdAt(LocalDateTime.now())
+                .build();
+        ChatMessage userMessage = ChatMessage.builder()
+                .chatMessageId(1L)
+                .chatRoom(aiRoom)
+                .senderId(senderId)
+                .content("예매 방법 알려줘")
+                .sentAt(LocalDateTime.now())
+                .isRead(false)
+                .build();
+
+        when(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(aiRoom));
+        when(chatMessageRepository.findByChatRoomOrderBySentAtAsc(aiRoom)).thenReturn(new ArrayList<>(List.of(userMessage)));
+        when(ragChatService.chat(eq("예매 방법 알려줘"), any(List.class), eq(senderId)))
+                .thenAnswer(invocation -> {
+                    assertFalse(
+                            TransactionSynchronizationManager.isActualTransactionActive(),
+                            "RAG/LLM 호출은 사용자 메시지 저장 트랜잭션 커밋 이후, 트랜잭션 밖에서 실행되어야 한다."
+                    );
+                    return RagChatService.RagResponse.builder()
+                            .answer("예매는 행사 상세 페이지에서 할 수 있어요.")
+                            .hasContext(false)
+                            .citedChunks(List.of())
+                            .totalSearched(0)
+                            .build();
+                });
+        when(chatMessageService.sendMessage(roomId, 999L, "예매는 행사 상세 페이지에서 할 수 있어요."))
+                .thenReturn(ChatMessageResponseDto.builder()
+                        .chatMessageId(2L)
+                        .chatRoomId(roomId)
+                        .senderId(999L)
+                        .content("예매는 행사 상세 페이지에서 할 수 있어요.")
+                        .sentAt(LocalDateTime.now())
+                        .isRead(false)
+                        .build());
+
+        new TransactionTemplate(transactionManager).executeWithoutResult(status ->
+                eventPublisher.publishEvent(new ChatMessageCreatedEvent(roomId, senderId, 1L, "예매 방법 알려줘"))
+        );
+
+        verify(ragChatService).chat(eq("예매 방법 알려줘"), any(List.class), eq(senderId));
+        verify(chatMessageService).sendMessage(roomId, 999L, "예매는 행사 상세 페이지에서 할 수 있어요.");
+    }
+
+    @Test
+    void broadcastsAiResponseToAiChatRoomTopicSubscribedByFrontend() {
+        Long roomId = 101L;
+        Long senderId = 42L;
+        ChatRoom aiRoom = aiRoom(roomId, senderId);
+        ChatMessage userMessage = userMessage(1L, aiRoom, senderId, "예매 방법 알려줘");
+        ChatMessageResponseDto savedReply = savedBotMessage(2L, roomId, "예매는 행사 상세 페이지에서 할 수 있어요.");
+
+        when(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(aiRoom));
+        when(chatMessageRepository.findByChatRoomOrderBySentAtAsc(aiRoom)).thenReturn(new ArrayList<>(List.of(userMessage)));
+        when(ragChatService.chat(eq("예매 방법 알려줘"), any(List.class), eq(senderId)))
+                .thenReturn(ragAnswer("예매는 행사 상세 페이지에서 할 수 있어요."));
+        when(chatMessageService.sendMessage(roomId, 999L, "예매는 행사 상세 페이지에서 할 수 있어요."))
+                .thenReturn(savedReply);
+
+        eventPublisher.publishEvent(new ChatMessageCreatedEvent(roomId, senderId, 1L, "예매 방법 알려줘"));
+
+        verify(chatMessageService).sendMessage(roomId, 999L, "예매는 행사 상세 페이지에서 할 수 있어요.");
+        verify(messagingTemplate).convertAndSend("/topic/ai-chat." + roomId, savedReply);
+        verify(messagingTemplate, never()).convertAndSend(eq("/topic/chat." + roomId), any(Object.class));
+    }
+
+    @Test
+    void consecutiveEventsAnswerTheQuestionThatBelongsToEachEvent() {
+        Long roomId = 101L;
+        Long senderId = 42L;
+        ChatRoom aiRoom = aiRoom(roomId, senderId);
+        ChatMessage firstQuestion = userMessage(1L, aiRoom, senderId, "첫 번째 질문");
+        ChatMessage secondQuestion = userMessage(2L, aiRoom, senderId, "두 번째 질문");
+
+        when(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(aiRoom));
+        when(chatMessageRepository.findByChatRoomOrderBySentAtAsc(aiRoom))
+                .thenReturn(new ArrayList<>(List.of(firstQuestion, secondQuestion)));
+        when(ragChatService.chat(eq("첫 번째 질문"), any(List.class), eq(senderId)))
+                .thenReturn(ragAnswer("첫 번째 답변"));
+        when(ragChatService.chat(eq("두 번째 질문"), any(List.class), eq(senderId)))
+                .thenReturn(ragAnswer("두 번째 답변"));
+        when(chatMessageService.sendMessage(roomId, 999L, "첫 번째 답변"))
+                .thenReturn(savedBotMessage(3L, roomId, "첫 번째 답변"));
+        when(chatMessageService.sendMessage(roomId, 999L, "두 번째 답변"))
+                .thenReturn(savedBotMessage(4L, roomId, "두 번째 답변"));
+
+        eventPublisher.publishEvent(new ChatMessageCreatedEvent(roomId, senderId, 1L, "첫 번째 질문"));
+        eventPublisher.publishEvent(new ChatMessageCreatedEvent(roomId, senderId, 2L, "두 번째 질문"));
+
+        verify(ragChatService).chat(eq("첫 번째 질문"), any(List.class), eq(senderId));
+        verify(ragChatService).chat(eq("두 번째 질문"), any(List.class), eq(senderId));
+        verify(chatMessageService).sendMessage(roomId, 999L, "첫 번째 답변");
+        verify(chatMessageService).sendMessage(roomId, 999L, "두 번째 답변");
+    }
+
+    @Test
+    void afterCommitSchedulesAiResponseWithoutWaitingForCompletion() throws Exception {
+        Long roomId = 101L;
+        Long senderId = 42L;
+        ChatRoom aiRoom = aiRoom(roomId, senderId);
+        ChatMessage userMessage = userMessage(1L, aiRoom, senderId, "예매 방법 알려줘");
+        CountDownLatch ragStarted = new CountDownLatch(1);
+        CountDownLatch unblockRag = new CountDownLatch(1);
+        CountDownLatch transactionReturned = new CountDownLatch(1);
+        ExecutorService transactionThread = Executors.newSingleThreadExecutor();
+
+        when(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(aiRoom));
+        when(chatMessageRepository.findByChatRoomOrderBySentAtAsc(aiRoom)).thenReturn(new ArrayList<>(List.of(userMessage)));
+        when(ragChatService.chat(eq("예매 방법 알려줘"), any(List.class), eq(senderId)))
+                .thenAnswer(invocation -> {
+                    ragStarted.countDown();
+                    assertTrue(unblockRag.await(2, TimeUnit.SECONDS));
+                    return ragAnswer("예매는 행사 상세 페이지에서 할 수 있어요.");
+                });
+        when(chatMessageService.sendMessage(roomId, 999L, "예매는 행사 상세 페이지에서 할 수 있어요."))
+                .thenReturn(savedBotMessage(2L, roomId, "예매는 행사 상세 페이지에서 할 수 있어요."));
+
+        Future<?> transactionFuture = transactionThread.submit(() -> {
+            new TransactionTemplate(transactionManager).executeWithoutResult(status ->
+                    eventPublisher.publishEvent(new ChatMessageCreatedEvent(roomId, senderId, 1L, "예매 방법 알려줘"))
+            );
+            transactionReturned.countDown();
+        });
+
+        assertTrue(ragStarted.await(1, TimeUnit.SECONDS));
+        try {
+            assertTrue(
+                    transactionReturned.await(100, TimeUnit.MILLISECONDS),
+                    "afterCommit은 AI 응답 완료를 .join()으로 기다리지 않고 커밋 후 작업만 예약해야 한다."
+            );
+        } finally {
+            unblockRag.countDown();
+            transactionFuture.get(2, TimeUnit.SECONDS);
+            transactionThread.shutdownNow();
+        }
+    }
+
+    @Test
+    void aiResponseExecutorIsInjectableInsteadOfStaticLifecycleOwnedThreadPool() {
+        boolean hasStaticExecutorService = Arrays.stream(AiChatOrchestrator.class.getDeclaredFields())
+                .anyMatch(field -> java.lang.reflect.Modifier.isStatic(field.getModifiers())
+                        && ExecutorService.class.isAssignableFrom(field.getType()));
+
+        assertFalse(
+                hasStaticExecutorService,
+                "AI 응답 executor는 Spring bean으로 주입되어 bounded/lifecycle 설정을 검증할 수 있어야 하며 static ExecutorService이면 안 된다."
+        );
+    }
+
+    @Test
+    void doesNotGenerateAiResponseWhenLegacyEventHasNoSavedMessagePayload() {
+        Long roomId = 101L;
+        Long senderId = 42L;
+        ChatRoom aiRoom = aiRoom(roomId, senderId);
+        ChatMessage userMessage = userMessage(1L, aiRoom, senderId, "history에 남은 질문");
+
+        when(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(aiRoom));
+        when(chatMessageRepository.findByChatRoomOrderBySentAtAsc(aiRoom)).thenReturn(new ArrayList<>(List.of(userMessage)));
+        when(ragChatService.chat(eq("history에 남은 질문"), any(List.class), eq(senderId)))
+                .thenReturn(ragAnswer("fallback으로 생성된 답변"));
+        when(chatMessageService.sendMessage(roomId, 999L, "fallback으로 생성된 답변"))
+                .thenReturn(savedBotMessage(2L, roomId, "fallback으로 생성된 답변"));
+
+        eventPublisher.publishEvent(new ChatMessageCreatedEvent(roomId, senderId));
+
+        verify(ragChatService, never()).chat(any(String.class), any(List.class), any(Long.class));
+        verify(llmRouter, never()).pick(any());
+        verify(chatMessageService, never()).sendMessage(any(Long.class), eq(999L), any(String.class));
+        verify(messagingTemplate, never()).convertAndSend(eq("/topic/ai-chat." + roomId), any(Object.class));
+    }
+
+    private ChatRoom aiRoom(Long roomId, Long senderId) {
+        return ChatRoom.builder()
+                .chatRoomId(roomId)
+                .userId(senderId)
+                .targetType(TargetType.AI)
+                .targetId(1L)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    private ChatMessage userMessage(Long messageId, ChatRoom room, Long senderId, String content) {
+        return ChatMessage.builder()
+                .chatMessageId(messageId)
+                .chatRoom(room)
+                .senderId(senderId)
+                .content(content)
+                .sentAt(LocalDateTime.now().plusNanos(messageId))
+                .isRead(false)
+                .build();
+    }
+
+    private RagChatService.RagResponse ragAnswer(String answer) {
+        return RagChatService.RagResponse.builder()
+                .answer(answer)
+                .hasContext(false)
+                .citedChunks(List.of())
+                .totalSearched(0)
+                .build();
+    }
+
+    private ChatMessageResponseDto savedBotMessage(Long messageId, Long roomId, String content) {
+        return ChatMessageResponseDto.builder()
+                .chatMessageId(messageId)
+                .chatRoomId(roomId)
+                .senderId(999L)
+                .content(content)
+                .sentAt(LocalDateTime.now())
+                .isRead(false)
+                .build();
+    }
+
+    @Configuration
+    @EnableTransactionManagement
+    static class TestConfig {
+
+        @Bean
+        AiChatOrchestrator aiChatOrchestrator(
+                ChatRoomRepository chatRoomRepository,
+                ChatMessageRepository chatMessageRepository,
+                ChatMessageService chatMessageService,
+                LlmRouter llmRouter,
+                RagChatService ragChatService,
+                SimpMessagingTemplate messagingTemplate
+        ) {
+            return new AiChatOrchestrator(
+                    chatRoomRepository,
+                    chatMessageRepository,
+                    chatMessageService,
+                    llmRouter,
+                    ragChatService,
+                    messagingTemplate
+            );
+        }
+
+        @Bean
+        PlatformTransactionManager transactionManager() {
+            return new AbstractPlatformTransactionManager() {
+                @Override
+                protected Object doGetTransaction() throws TransactionException {
+                    return new Object();
+                }
+
+                @Override
+                protected void doBegin(Object transaction, TransactionDefinition definition) throws TransactionException {
+                }
+
+                @Override
+                protected void doCommit(DefaultTransactionStatus status) throws TransactionException {
+                }
+
+                @Override
+                protected void doRollback(DefaultTransactionStatus status) throws TransactionException {
+                }
+            };
+        }
+
+        @Bean
+        ChatRoomRepository chatRoomRepository() {
+            return mock(ChatRoomRepository.class);
+        }
+
+        @Bean
+        ChatMessageRepository chatMessageRepository() {
+            return mock(ChatMessageRepository.class);
+        }
+
+        @Bean
+        ChatMessageService chatMessageService() {
+            return mock(ChatMessageService.class);
+        }
+
+        @Bean
+        LlmRouter llmRouter() {
+            return mock(LlmRouter.class);
+        }
+
+        @Bean
+        RagChatService ragChatService() {
+            return mock(RagChatService.class);
+        }
+
+        @Bean
+        SimpMessagingTemplate messagingTemplate() {
+            return mock(SimpMessagingTemplate.class);
+        }
+    }
+}

--- a/src/test/java/com/fairing/fairplay/ai/orchestrator/AiChatOrchestratorTransactionContractTest.java
+++ b/src/test/java/com/fairing/fairplay/ai/orchestrator/AiChatOrchestratorTransactionContractTest.java
@@ -104,7 +104,7 @@ class AiChatOrchestratorTransactionContractTest {
                 .sentAt(LocalDateTime.now())
                 .isRead(false)
                 .build();
-        CountDownLatch ragCalled = new CountDownLatch(1);
+        CountDownLatch responseSaved = new CountDownLatch(1);
 
         when(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(aiRoom));
         when(chatMessageRepository.findByChatRoomOrderBySentAtAsc(aiRoom)).thenReturn(new ArrayList<>(List.of(userMessage)));
@@ -114,7 +114,6 @@ class AiChatOrchestratorTransactionContractTest {
                             TransactionSynchronizationManager.isActualTransactionActive(),
                             "RAG/LLM 호출은 사용자 메시지 저장 트랜잭션 커밋 이후, 트랜잭션 밖에서 실행되어야 한다."
                     );
-                    ragCalled.countDown();
                     return RagChatService.RagResponse.builder()
                             .answer("예매는 행사 상세 페이지에서 할 수 있어요.")
                             .hasContext(false)
@@ -123,20 +122,23 @@ class AiChatOrchestratorTransactionContractTest {
                             .build();
                 });
         when(chatMessageService.sendMessage(roomId, 999L, "예매는 행사 상세 페이지에서 할 수 있어요."))
-                .thenReturn(ChatMessageResponseDto.builder()
-                        .chatMessageId(2L)
-                        .chatRoomId(roomId)
-                        .senderId(999L)
-                        .content("예매는 행사 상세 페이지에서 할 수 있어요.")
-                        .sentAt(LocalDateTime.now())
-                        .isRead(false)
-                        .build());
+                .thenAnswer(invocation -> {
+                    responseSaved.countDown();
+                    return ChatMessageResponseDto.builder()
+                            .chatMessageId(2L)
+                            .chatRoomId(roomId)
+                            .senderId(999L)
+                            .content("예매는 행사 상세 페이지에서 할 수 있어요.")
+                            .sentAt(LocalDateTime.now())
+                            .isRead(false)
+                            .build();
+                });
 
         new TransactionTemplate(transactionManager).executeWithoutResult(status ->
                 eventPublisher.publishEvent(new ChatMessageCreatedEvent(roomId, senderId, 1L, "예매 방법 알려줘"))
         );
 
-        assertTrue(ragCalled.await(1, TimeUnit.SECONDS));
+        assertTrue(responseSaved.await(1, TimeUnit.SECONDS));
         verify(ragChatService).chat(eq("예매 방법 알려줘"), any(List.class), eq(senderId));
         verify(chatMessageService).sendMessage(roomId, 999L, "예매는 행사 상세 페이지에서 할 수 있어요.");
     }

--- a/src/test/java/com/fairing/fairplay/chat/event/ChatMessageCreatedEventContractTest.java
+++ b/src/test/java/com/fairing/fairplay/chat/event/ChatMessageCreatedEventContractTest.java
@@ -1,0 +1,42 @@
+package com.fairing.fairplay.chat.event;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ChatMessageCreatedEventContractTest {
+
+    @Test
+    void exposesCreatedMessageIdentitySoAiResponderCanAnswerThatMessage() {
+        Method messageIdGetter = assertDoesNotThrow(
+                () -> ChatMessageCreatedEvent.class.getMethod("getChatMessageId"),
+                "ChatMessageCreatedEvent는 같은 방의 연속 메시지를 구분할 수 있도록 생성된 메시지 ID를 노출해야 한다."
+        );
+
+        assertEquals(Long.class, messageIdGetter.getReturnType());
+    }
+
+    @Test
+    void exposesCreatedMessageContentSoAiResponderDoesNotInferFromLatestRoomHistory() {
+        Method contentGetter = assertDoesNotThrow(
+                () -> ChatMessageCreatedEvent.class.getMethod("getContent"),
+                "ChatMessageCreatedEvent는 이벤트가 가리키는 사용자 질문 content를 노출해야 한다."
+        );
+
+        assertEquals(String.class, contentGetter.getReturnType());
+    }
+
+    @Test
+    void canBeConstructedWithMessageIdentityAndContent() {
+        Constructor<ChatMessageCreatedEvent> constructor = assertDoesNotThrow(
+                () -> ChatMessageCreatedEvent.class.getConstructor(Long.class, Long.class, Long.class, String.class),
+                "ChatMessageCreatedEvent 생성 시 roomId, senderId 외에 messageId와 content도 함께 전달되어야 한다."
+        );
+
+        assertDoesNotThrow(() -> constructor.newInstance(101L, 42L, 501L, "예매 방법 알려줘"));
+    }
+}

--- a/src/test/java/com/fairing/fairplay/chat/service/ChatMessageServiceEventContractTest.java
+++ b/src/test/java/com/fairing/fairplay/chat/service/ChatMessageServiceEventContractTest.java
@@ -1,0 +1,76 @@
+package com.fairing.fairplay.chat.service;
+
+import com.fairing.fairplay.chat.entity.ChatMessage;
+import com.fairing.fairplay.chat.entity.ChatRoom;
+import com.fairing.fairplay.chat.entity.TargetType;
+import com.fairing.fairplay.chat.event.ChatMessageCreatedEvent;
+import com.fairing.fairplay.chat.repository.ChatMessageRepository;
+import com.fairing.fairplay.chat.repository.ChatRoomRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ChatMessageServiceEventContractTest {
+
+    @Mock
+    ChatMessageRepository chatMessageRepository;
+
+    @Mock
+    ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    ChatCacheService chatCacheService;
+
+    @InjectMocks
+    ChatMessageService chatMessageService;
+
+    @Test
+    void publishesSavedUserMessageIdentityAndContentInCreatedEvent() {
+        Long roomId = 101L;
+        Long senderId = 42L;
+        ChatRoom chatRoom = ChatRoom.builder()
+                .chatRoomId(roomId)
+                .userId(senderId)
+                .targetType(TargetType.AI)
+                .targetId(1L)
+                .createdAt(LocalDateTime.now())
+                .build();
+        ChatMessage savedMessage = ChatMessage.builder()
+                .chatMessageId(501L)
+                .chatRoom(chatRoom)
+                .senderId(senderId)
+                .content("저장된 사용자 질문")
+                .sentAt(LocalDateTime.now())
+                .isRead(false)
+                .build();
+        ArgumentCaptor<ChatMessageCreatedEvent> eventCaptor = ArgumentCaptor.forClass(ChatMessageCreatedEvent.class);
+
+        when(chatRoomRepository.findById(roomId)).thenReturn(Optional.of(chatRoom));
+        when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(savedMessage);
+
+        chatMessageService.sendMessage(roomId, senderId, "요청 사용자 질문");
+
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        ChatMessageCreatedEvent event = eventCaptor.getValue();
+        assertEquals(roomId, event.getChatRoomId());
+        assertEquals(senderId, event.getSenderId());
+        assertEquals(501L, event.getChatMessageId());
+        assertEquals("저장된 사용자 질문", event.getContent());
+    }
+}


### PR DESCRIPTION
## Summary
- Resolve the AI chat cherry-pick conflict on top of latest develop auth/subscription changes.
- Keep the WebSocket controller limited to authenticated user message save/broadcast.
- Move AI response generation to the post-commit orchestrator path from the cherry-picked hot-path change.

## Verification
- git diff --check
- git diff HEAD~1 HEAD --check
- ./gradlew test --tests com.fairing.fairplay.ai.controller.AiChatWebSocketControllerContractTest --tests com.fairing.fairplay.ai.orchestrator.AiChatOrchestratorTransactionContractTest --tests com.fairing.fairplay.chat.event.ChatMessageCreatedEventContractTest --tests com.fairing.fairplay.chat.service.ChatMessageServiceEventContractTest

## Notes
- Local untracked duplicate files were temporarily stashed only for verification, then restored. Existing preserved stash was not popped or dropped.