### PR TITLE
Prevent temp uploads from leaking through public static surfaces

### DIFF
--- a/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
+++ b/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
@@ -110,7 +110,6 @@ public class SecurityConfig {
                                 "/ws/*/info", // SockJS info 엔드포인트
                                 "/api/chat/rooms/**", // 채팅방 목록 조회만 허용
                                 "/api/chat/presence/status/**", // 사용자 온라인 상태 조회 허용
-                                "/api/uploads/**",
                                 "/uploads/**", // 로컬 파일 시스템의 정적 파일 서빙
                                 "/api/payments/complete", // PG사에서 호출하는 결제 완료 웹훅
                                 "/api/events/apply", // 행사 등록 신청

--- a/src/main/java/com/fairing/fairplay/core/config/WebConfig.java
+++ b/src/main/java/com/fairing/fairplay/core/config/WebConfig.java
@@ -1,10 +1,16 @@
 package com.fairing.fairplay.core.config;
 
+import com.fairing.fairplay.core.util.TempUploadKeyPolicy;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -76,7 +82,17 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addResourceHandler("/uploads/**")
             .addResourceLocations("file:" + uploadPath + "/")
             .setCachePeriod(3600) // 1시간 캐시
-            .resourceChain(false); // 캐시 체인 비활성화로 실시간 파일 변경 반영
+            .resourceChain(true)
+            .addResolver(new PathResourceResolver() {
+                @Override
+                protected Resource getResource(String resourcePath, Resource location) throws IOException {
+                    if (isBlockedUploadResourcePath(resourcePath)) {
+                        return null;
+                    }
+
+                    return super.getResource(resourcePath, location);
+                }
+            });
         
         // SPA를 위한 정적 리소스 핸들링
         registry.addResourceHandler("/**")
@@ -104,8 +120,32 @@ public class WebConfig implements WebMvcConfigurer {
     }
 
     @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new HandlerInterceptor() {
+            @Override
+            public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+                String path = request.getRequestURI();
+                String uploadResourcePath = path.startsWith("/uploads/")
+                        ? path.substring("/uploads/".length())
+                        : path;
+
+                if (isBlockedUploadResourcePath(uploadResourcePath)) {
+                    response.sendError(HttpStatus.NOT_FOUND.value());
+                    return false;
+                }
+
+                return true;
+            }
+        }).addPathPatterns("/uploads/**");
+    }
+
+    @Override
     public void addViewControllers(ViewControllerRegistry registry) {
         // 루트 경로를 index.html로 포워딩
         registry.addViewController("/").setViewName("forward:/index.html");
+    }
+
+    private boolean isBlockedUploadResourcePath(String resourcePath) {
+        return TempUploadKeyPolicy.isBlockedPublicUploadKey(resourcePath);
     }
 }

--- a/src/main/java/com/fairing/fairplay/core/security/SessionAuthenticationFilter.java
+++ b/src/main/java/com/fairing/fairplay/core/security/SessionAuthenticationFilter.java
@@ -51,7 +51,6 @@ public class SessionAuthenticationFilter extends OncePerRequestFilter {
         "/api/email/",
         "/ws/",
         "/api/qr-tickets/",
-        "/api/uploads/",
         "/uploads/"
     );
 

--- a/src/main/java/com/fairing/fairplay/core/service/AwsS3Service.java
+++ b/src/main/java/com/fairing/fairplay/core/service/AwsS3Service.java
@@ -2,6 +2,7 @@ package com.fairing.fairplay.core.service;
 
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.core.dto.FileUploadResponseDto;
+import com.fairing.fairplay.core.util.TempUploadKeyPolicy;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,7 +20,6 @@ import software.amazon.awssdk.services.s3.model.*;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -47,7 +47,7 @@ public class AwsS3Service {
                 .map(f -> f.substring(f.lastIndexOf('.')))
                 .orElse("");
         String uuid = UUID.randomUUID().toString();
-        String key = "uploads/tmp" + LocalDate.now() + "/" + uuid + ext;
+        String key = TempUploadKeyPolicy.newPrivateTempPrefix() + uuid + ext;
 
         try {
             s3Client.putObject(
@@ -82,7 +82,7 @@ public class AwsS3Service {
         
         String ext = key.contains(".") ? key.substring(key.lastIndexOf('.')) : "";
         String uuid = UUID.randomUUID().toString();
-        String destKey = "uploads/" + destPrefix + "/" + uuid + ext;
+        String destKey = TempUploadKeyPolicy.PUBLIC_UPLOAD_PREFIX + destPrefix + "/" + uuid + ext;
 
         try {
             // 먼저 원본 파일이 존재하는지 확인
@@ -146,6 +146,15 @@ public class AwsS3Service {
      * CloudFront 도메인이 설정되어 있으면 CloudFront URL, 없으면 직접 S3 URL 반환
      */
     public String getCdnUrl(String key) {
+        if (key == null || key.isEmpty()) {
+            return null;
+        }
+
+        String cleanKey = TempUploadKeyPolicy.normalizeKey(key);
+        if (TempUploadKeyPolicy.isBlockedPublicUploadKey(cleanKey)) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "비공개 파일 키는 공개 URL로 변환할 수 없습니다.");
+        }
+
         if (cloudfrontDomain != null && !cloudfrontDomain.trim().isEmpty()) {
             // CloudFront 도메인이 설정된 경우
             String cleanDomain = cloudfrontDomain.trim();
@@ -155,11 +164,10 @@ public class AwsS3Service {
             if (cleanDomain.endsWith("/")) {
                 cleanDomain = cleanDomain.substring(0, cleanDomain.length() - 1);
             }
-            String cleanKey = key.startsWith("/") ? key : "/" + key;
-            return cleanDomain + cleanKey;
+            return cleanDomain + "/" + cleanKey;
         } else {
             // CloudFront가 설정되지 않은 경우 직접 S3 URL 사용
-            return getPublicUrl(key);
+            return getPublicUrl(cleanKey);
         }
     }
 

--- a/src/main/java/com/fairing/fairplay/core/service/LocalFileService.java
+++ b/src/main/java/com/fairing/fairplay/core/service/LocalFileService.java
@@ -2,6 +2,7 @@ package com.fairing.fairplay.core.service;
 
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.core.dto.FileUploadResponseDto;
+import com.fairing.fairplay.core.util.TempUploadKeyPolicy;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
@@ -25,7 +26,6 @@ import java.nio.file.SecureDirectoryStream;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -49,7 +49,7 @@ public class LocalFileService {
                 .map(f -> f.substring(f.lastIndexOf('.')))
                 .orElse("");
         String uuid = UUID.randomUUID().toString();
-        String key = "uploads/tmp" + LocalDate.now() + "/" + uuid + ext;
+        String key = TempUploadKeyPolicy.newPrivateTempPrefix() + uuid + ext;
         
         try {
             try (InputStream inputStream = file.getInputStream()) {
@@ -80,7 +80,7 @@ public class LocalFileService {
         
         String ext = key.contains(".") ? key.substring(key.lastIndexOf('.')) : "";
         String uuid = UUID.randomUUID().toString();
-        String destKey = "uploads/" + normalizeRelativeKey(destPrefix) + "/" + uuid + ext;
+        String destKey = TempUploadKeyPolicy.PUBLIC_UPLOAD_PREFIX + normalizeRelativeKey(destPrefix) + "/" + uuid + ext;
 
         try {
             moveFile(key, destKey);
@@ -133,7 +133,11 @@ public class LocalFileService {
             return null;
         }
         
-        String cleanKey = key.startsWith("/") ? key.substring(1) : key;
+        String cleanKey = TempUploadKeyPolicy.normalizeKey(key);
+        if (TempUploadKeyPolicy.isBlockedPublicUploadKey(cleanKey)) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "비공개 파일 키는 공개 URL로 변환할 수 없습니다.");
+        }
+
         // baseUrl이 이미 /uploads로 끝나는 경우 중복 방지
         String normalizedBaseUrl = baseUrl.endsWith("/uploads") ? baseUrl : baseUrl + "/uploads";
         return normalizedBaseUrl + "/" + cleanKey;

--- a/src/main/java/com/fairing/fairplay/core/service/LocalFileService.java
+++ b/src/main/java/com/fairing/fairplay/core/service/LocalFileService.java
@@ -11,14 +11,25 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.*;
+import java.nio.channels.Channels;
+import java.nio.channels.SeekableByteChannel;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
+import java.nio.file.SecureDirectoryStream;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 @Service
@@ -40,15 +51,9 @@ public class LocalFileService {
         String uuid = UUID.randomUUID().toString();
         String key = "uploads/tmp" + LocalDate.now() + "/" + uuid + ext;
         
-        Path filePath = Paths.get(uploadBasePath, key);
-        
         try {
-            // 디렉토리 생성
-            Files.createDirectories(filePath.getParent());
-            
-            // 파일 저장
             try (InputStream inputStream = file.getInputStream()) {
-                Files.copy(inputStream, filePath, StandardCopyOption.REPLACE_EXISTING);
+                writeNewFile(key, inputStream);
             }
         } catch (IOException e) {
             log.error("로컬 파일 업로드 실패. Key: {}", key, e);
@@ -75,26 +80,15 @@ public class LocalFileService {
         
         String ext = key.contains(".") ? key.substring(key.lastIndexOf('.')) : "";
         String uuid = UUID.randomUUID().toString();
-        String destKey = "uploads/" + destPrefix + "/" + uuid + ext;
-
-        Path sourcePath = Paths.get(uploadBasePath, key);
-        Path destPath = Paths.get(uploadBasePath, destKey);
+        String destKey = "uploads/" + normalizeRelativeKey(destPrefix) + "/" + uuid + ext;
 
         try {
-            // 원본 파일 존재 확인
-            if (!Files.exists(sourcePath)) {
-                throw new CustomException(HttpStatus.NOT_FOUND, "영구 저장으로 이동할 임시 파일을 찾을 수 없습니다: " + key);
-            }
-
-            // 대상 디렉토리 생성
-            Files.createDirectories(destPath.getParent());
-            
-            // 파일 이동
-            Files.move(sourcePath, destPath, StandardCopyOption.REPLACE_EXISTING);
-
+            moveFile(key, destKey);
             log.info("Successfully moved file from {} to {}", key, destKey);
             return destKey;
 
+        } catch (NoSuchFileException e) {
+            throw new CustomException(HttpStatus.NOT_FOUND, "영구 저장으로 이동할 임시 파일을 찾을 수 없습니다: " + key);
         } catch (IOException e) {
             log.error("Error moving file from {} to {}: {}", key, destKey, e.getMessage(), e);
             throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 이동 중 오류가 발생했습니다.");
@@ -103,15 +97,8 @@ public class LocalFileService {
 
     // 파일 다운로드
     public void downloadFile(String key, HttpServletResponse response) throws IOException {
-        Path filePath = Paths.get(uploadBasePath, key);
-        
-        if (!Files.exists(filePath)) {
-            log.error("로컬 파일 다운로드 실패. 파일을 찾을 수 없음. Key: {}", key);
-            throw new CustomException(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다.");
-        }
-
         try {
-            String contentType = Files.probeContentType(filePath);
+            String contentType = java.net.URLConnection.guessContentTypeFromName(key);
             response.setContentType(contentType != null ? contentType : "application/octet-stream");
             
             String fileName = key != null && key.contains("/") ? 
@@ -119,10 +106,13 @@ public class LocalFileService {
                 (key != null ? key : "download");
             response.setHeader("Content-Disposition", "attachment; filename=\"" + URLEncoder.encode(fileName, "UTF-8") + "\"");
 
-            try (InputStream inputStream = Files.newInputStream(filePath)) {
+            try (InputStream inputStream = openFileForRead(key)) {
                 IOUtils.copy(inputStream, response.getOutputStream());
             }
             response.flushBuffer();
+        } catch (NoSuchFileException e) {
+            log.error("로컬 파일 다운로드 실패. 파일을 찾을 수 없음. Key: {}", key);
+            throw new CustomException(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다.");
         } catch (IOException e) {
             log.error("로컬 파일 다운로드 실패. Key: {}", key, e);
             throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 다운로드 중 오류가 발생했습니다.");
@@ -171,11 +161,8 @@ public class LocalFileService {
 
     // 파일 삭제
     public void deleteFile(String key) {
-        Path filePath = Paths.get(uploadBasePath, key);
-        
         try {
-            if (Files.exists(filePath)) {
-                Files.delete(filePath);
+            if (deleteFileIfExists(key)) {
                 log.info("로컬 파일 삭제 성공. Key: {}", key);
             } else {
                 log.warn("삭제하려는 파일이 존재하지 않음. Key: {}", key);
@@ -190,7 +177,228 @@ public class LocalFileService {
      * 로컬 파일 시스템에서 파일 존재 여부 확인
      */
     public boolean fileExists(String key) {
-        Path filePath = Paths.get(uploadBasePath, key);
-        return Files.exists(filePath);
+        try {
+            return fileExistsSecurely(key);
+        } catch (NoSuchFileException e) {
+            return false;
+        } catch (IOException e) {
+            log.error("로컬 파일 존재 확인 실패. Key: {}", key, e);
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 존재 확인 중 오류가 발생했습니다.");
+        }
+    }
+
+    private InputStream openFileForRead(String key) throws IOException {
+        List<Path> segments = keySegments(key);
+        try (SecureDirectoryStream<Path> secureRoot = openSecureUploadRoot()) {
+            SecurePath securePath = openSecureParent(secureRoot, segments, false);
+            try (securePath) {
+                BasicFileAttributes attrs = readAttributes(securePath.parent(), securePath.fileName());
+                if (attrs == null) {
+                    throw new NoSuchFileException(key);
+                }
+                rejectUnsafeFinalFile(attrs);
+                SeekableByteChannel channel = securePath.parent().newByteChannel(
+                        securePath.fileName(),
+                        Set.of(StandardOpenOption.READ, LinkOption.NOFOLLOW_LINKS));
+                return Channels.newInputStream(channel);
+            }
+        }
+    }
+
+    private void writeNewFile(String key, InputStream inputStream) throws IOException {
+        List<Path> segments = keySegments(key);
+        try (SecureDirectoryStream<Path> secureRoot = openSecureUploadRoot()) {
+            SecurePath securePath = openSecureParent(secureRoot, segments, true);
+            try (securePath;
+                 SeekableByteChannel outputChannel = securePath.parent().newByteChannel(
+                         securePath.fileName(),
+                         Set.of(StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE, LinkOption.NOFOLLOW_LINKS));
+                 OutputStream outputStream = Channels.newOutputStream(outputChannel)) {
+                IOUtils.copy(inputStream, outputStream);
+            }
+        }
+    }
+
+    private void moveFile(String sourceKey, String destKey) throws IOException {
+        List<Path> sourceSegments = keySegments(sourceKey);
+        List<Path> destSegments = keySegments(destKey);
+
+        try (SecureDirectoryStream<Path> secureRoot = openSecureUploadRoot()) {
+            SecurePath source = openSecureParent(secureRoot, sourceSegments, false);
+            try (source; SecureDirectoryStream<Path> secureSecondRoot = openSecureUploadRoot()) {
+                SecurePath dest = openSecureParent(secureSecondRoot, destSegments, true);
+                try (dest) {
+                    BasicFileAttributes sourceAttrs = readAttributes(source.parent(), source.fileName());
+                    if (sourceAttrs == null) {
+                        throw new NoSuchFileException(sourceKey);
+                    }
+                    rejectUnsafeFinalFile(sourceAttrs);
+                    BasicFileAttributes destAttrs = readAttributes(dest.parent(), dest.fileName());
+                    if (destAttrs != null) {
+                        if (destAttrs.isDirectory()) {
+                            throw new IOException("대상 경로가 디렉터리입니다: " + destKey);
+                        }
+                        dest.parent().deleteFile(dest.fileName());
+                    }
+                    source.parent().move(source.fileName(), dest.parent(), dest.fileName());
+                }
+            }
+        }
+    }
+
+    private boolean deleteFileIfExists(String key) throws IOException {
+        List<Path> segments = keySegments(key);
+        try (SecureDirectoryStream<Path> secureRoot = openSecureUploadRoot()) {
+            SecurePath securePath = openSecureParent(secureRoot, segments, false);
+            try (securePath) {
+                BasicFileAttributes attrs = readAttributes(securePath.parent(), securePath.fileName());
+                if (attrs == null) {
+                    return false;
+                }
+                rejectUnsafeFinalFile(attrs);
+                securePath.parent().deleteFile(securePath.fileName());
+                return true;
+            }
+        }
+    }
+
+    private boolean fileExistsSecurely(String key) throws IOException {
+        List<Path> segments = keySegments(key);
+        try (SecureDirectoryStream<Path> secureRoot = openSecureUploadRoot()) {
+            SecurePath securePath = openSecureParent(secureRoot, segments, false);
+            try (securePath) {
+                BasicFileAttributes attrs = readAttributes(securePath.parent(), securePath.fileName());
+                if (attrs == null) {
+                    return false;
+                }
+                rejectUnsafeFinalFile(attrs);
+                return true;
+            }
+        }
+    }
+
+    private DirectoryStream<Path> openUploadRoot() throws IOException {
+        Path basePath = uploadRootPath();
+        Files.createDirectories(basePath);
+        return Files.newDirectoryStream(basePath);
+    }
+
+    private SecureDirectoryStream<Path> openSecureUploadRoot() throws IOException {
+        DirectoryStream<Path> root = openUploadRoot();
+        if (root instanceof SecureDirectoryStream<Path> secureRoot) {
+            return secureRoot;
+        }
+
+        root.close();
+        throw new IOException("SecureDirectoryStream is required for local file I/O");
+    }
+
+    private SecurePath openSecureParent(
+            SecureDirectoryStream<Path> root,
+            List<Path> segments,
+            boolean createDirectories
+    ) throws IOException {
+        SecureDirectoryStream<Path> current = root;
+        Path currentPath = uploadRootPath();
+        boolean closeCurrent = false;
+
+        for (int i = 0; i < segments.size() - 1; i++) {
+            Path segment = segments.get(i);
+            BasicFileAttributes attrs = readAttributes(current, segment);
+            if (attrs == null) {
+                if (!createDirectories) {
+                    throw new NoSuchFileException(segment.toString());
+                }
+                try {
+                    Files.createDirectory(currentPath.resolve(segment));
+                } catch (java.nio.file.FileAlreadyExistsException ignored) {
+                    // Created concurrently; validate and open it below through the secure stream.
+                }
+                attrs = readAttributes(current, segment);
+            }
+            rejectUnsafeDirectory(attrs);
+
+            SecureDirectoryStream<Path> next = current.newDirectoryStream(segment, LinkOption.NOFOLLOW_LINKS);
+            if (closeCurrent) {
+                current.close();
+            }
+            current = next;
+            closeCurrent = true;
+            currentPath = currentPath.resolve(segment);
+        }
+
+        return new SecurePath(current, segments.get(segments.size() - 1), closeCurrent);
+    }
+
+    private BasicFileAttributes readAttributes(SecureDirectoryStream<Path> directory, Path name) throws IOException {
+        try {
+            BasicFileAttributeView view = directory.getFileAttributeView(
+                    name,
+                    BasicFileAttributeView.class,
+                    LinkOption.NOFOLLOW_LINKS);
+            return view.readAttributes();
+        } catch (NoSuchFileException e) {
+            return null;
+        }
+    }
+
+    private void rejectUnsafeDirectory(BasicFileAttributes attrs) {
+        if (attrs.isSymbolicLink() || !attrs.isDirectory()) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "파일 키가 허용된 저장소 범위를 벗어났습니다.");
+        }
+    }
+
+    private void rejectUnsafeFinalFile(BasicFileAttributes attrs) {
+        if (attrs.isSymbolicLink() || !attrs.isRegularFile()) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "파일 키가 허용된 저장소 범위를 벗어났습니다.");
+        }
+    }
+
+    private String normalizeRelativeKey(String key) {
+        if (key == null || key.isBlank()) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "파일 키가 유효하지 않습니다.");
+        }
+
+        String normalizedSeparators = key.replace('\\', '/');
+        Path relativePath = Paths.get(normalizedSeparators).normalize();
+
+        if (relativePath.isAbsolute() || relativePath.startsWith("..") || relativePath.toString().equals("..")) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "파일 키가 허용된 저장소 범위를 벗어났습니다.");
+        }
+
+        return relativePath.toString().replace(File.separatorChar, '/');
+    }
+
+    private List<Path> keySegments(String key) {
+        Path relativePath = Paths.get(normalizeRelativeKey(key));
+        List<Path> segments = new ArrayList<>();
+        for (Path segment : relativePath) {
+            segments.add(segment);
+        }
+        if (segments.isEmpty()) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, "파일 키가 유효하지 않습니다.");
+        }
+        return segments;
+    }
+
+    private Path uploadRootPath() {
+        return Paths.get(uploadBasePath).toAbsolutePath().normalize();
+    }
+
+    boolean isSecureDirectoryStreamSupported() {
+        try (DirectoryStream<Path> root = openUploadRoot()) {
+            return root instanceof SecureDirectoryStream<Path>;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private record SecurePath(SecureDirectoryStream<Path> parent, Path fileName, boolean closeParent) implements AutoCloseable {
+        @Override
+        public void close() throws IOException {
+            if (closeParent) {
+                parent.close();
+            }
+        }
     }
 }

--- a/src/main/java/com/fairing/fairplay/core/service/LocalFileService.java
+++ b/src/main/java/com/fairing/fairplay/core/service/LocalFileService.java
@@ -104,7 +104,7 @@ public class LocalFileService {
             String fileName = key != null && key.contains("/") ? 
                 key.substring(key.lastIndexOf('/') + 1) : 
                 (key != null ? key : "download");
-            response.setHeader("Content-Disposition", "attachment; filename=\"" + URLEncoder.encode(fileName, "UTF-8") + "\"");
+            response.setHeader("Content-Disposition", "attachment; filename=\"" + URLEncoder.encode(fileName, StandardCharsets.UTF_8) + "\"");
 
             try (InputStream inputStream = openFileForRead(key)) {
                 IOUtils.copy(inputStream, response.getOutputStream());
@@ -306,32 +306,52 @@ public class LocalFileService {
         Path currentPath = uploadRootPath();
         boolean closeCurrent = false;
 
-        for (int i = 0; i < segments.size() - 1; i++) {
-            Path segment = segments.get(i);
-            BasicFileAttributes attrs = readAttributes(current, segment);
-            if (attrs == null) {
-                if (!createDirectories) {
-                    throw new NoSuchFileException(segment.toString());
+        try {
+            for (int i = 0; i < segments.size() - 1; i++) {
+                Path segment = segments.get(i);
+                BasicFileAttributes attrs = readAttributes(current, segment);
+                if (attrs == null) {
+                    if (!createDirectories) {
+                        throw new NoSuchFileException(segment.toString());
+                    }
+                    try {
+                        Files.createDirectory(currentPath.resolve(segment));
+                    } catch (java.nio.file.FileAlreadyExistsException ignored) {
+                        // Created concurrently; validate and open it below through the secure stream.
+                    }
+                    attrs = readAttributes(current, segment);
                 }
-                try {
-                    Files.createDirectory(currentPath.resolve(segment));
-                } catch (java.nio.file.FileAlreadyExistsException ignored) {
-                    // Created concurrently; validate and open it below through the secure stream.
-                }
-                attrs = readAttributes(current, segment);
-            }
-            rejectUnsafeDirectory(attrs);
+                rejectUnsafeDirectory(attrs);
 
-            SecureDirectoryStream<Path> next = current.newDirectoryStream(segment, LinkOption.NOFOLLOW_LINKS);
+                SecureDirectoryStream<Path> next = current.newDirectoryStream(segment, LinkOption.NOFOLLOW_LINKS);
+                if (closeCurrent) {
+                    try {
+                        current.close();
+                    } catch (IOException e) {
+                        try {
+                            next.close();
+                        } catch (IOException suppressed) {
+                            e.addSuppressed(suppressed);
+                        }
+                        throw e;
+                    }
+                }
+                current = next;
+                closeCurrent = true;
+                currentPath = currentPath.resolve(segment);
+            }
+
+            return new SecurePath(current, segments.get(segments.size() - 1), closeCurrent);
+        } catch (IOException | RuntimeException e) {
             if (closeCurrent) {
-                current.close();
+                try {
+                    current.close();
+                } catch (IOException suppressed) {
+                    e.addSuppressed(suppressed);
+                }
             }
-            current = next;
-            closeCurrent = true;
-            currentPath = currentPath.resolve(segment);
+            throw e;
         }
-
-        return new SecurePath(current, segments.get(segments.size() - 1), closeCurrent);
     }
 
     private BasicFileAttributes readAttributes(SecureDirectoryStream<Path> directory, Path name) throws IOException {

--- a/src/main/java/com/fairing/fairplay/core/util/TempUploadKeyPolicy.java
+++ b/src/main/java/com/fairing/fairplay/core/util/TempUploadKeyPolicy.java
@@ -1,0 +1,43 @@
+package com.fairing.fairplay.core.util;
+
+import java.time.LocalDate;
+import java.util.regex.Pattern;
+
+public final class TempUploadKeyPolicy {
+
+    public static final String PRIVATE_TEMP_PREFIX = "private/tmp/";
+    public static final String PUBLIC_UPLOAD_PREFIX = "uploads/";
+
+    private static final String LEGACY_TEMP_DIRECTORY_PREFIX = "uploads/temp/";
+    private static final Pattern LEGACY_TMP_DATE_PATTERN = Pattern.compile("^uploads/tmp\\d{4}-\\d{2}-\\d{2}/.+");
+
+    private TempUploadKeyPolicy() {
+    }
+
+    public static String newPrivateTempPrefix() {
+        return PRIVATE_TEMP_PREFIX + LocalDate.now() + "/";
+    }
+
+    public static boolean isTemporaryUploadKey(String key) {
+        String normalizedKey = normalizeKey(key);
+        return normalizedKey.startsWith(PRIVATE_TEMP_PREFIX)
+                || normalizedKey.startsWith(LEGACY_TEMP_DIRECTORY_PREFIX)
+                || LEGACY_TMP_DATE_PATTERN.matcher(normalizedKey).matches();
+    }
+
+    public static boolean isBlockedPublicUploadKey(String key) {
+        return isTemporaryUploadKey(key);
+    }
+
+    public static String normalizeKey(String key) {
+        if (key == null) {
+            return "";
+        }
+
+        String normalizedKey = key.replace('\\', '/');
+        while (normalizedKey.startsWith("/")) {
+            normalizedKey = normalizedKey.substring(1);
+        }
+        return normalizedKey;
+    }
+}

--- a/src/main/java/com/fairing/fairplay/event/service/EventDetailModificationRequestService.java
+++ b/src/main/java/com/fairing/fairplay/event/service/EventDetailModificationRequestService.java
@@ -2,6 +2,7 @@ package com.fairing.fairplay.event.service;
 
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.core.service.LocalFileService;
+import com.fairing.fairplay.core.util.TempUploadKeyPolicy;
 // import com.fairing.fairplay.core.service.AwsS3Service;
 import com.fairing.fairplay.core.util.JsonUtil;
 import com.fairing.fairplay.event.dto.EventDetailModificationDto;
@@ -23,6 +24,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.*;
 
@@ -76,9 +79,7 @@ public class EventDetailModificationRequestService {
                     String cdnUrl = localFileService.getCdnUrl(newKey);
                     newFileKeys.add(newKey);
 
-                    // 임시 URL과 영구 URL 매핑 저장
-                    String tempCdnUrl = localFileService.getCdnUrl(fileDto.getS3Key());
-                    urlMappings.put(tempCdnUrl, cdnUrl);
+                    addTempDownloadUrlMappings(urlMappings, fileDto.getS3Key(), cdnUrl);
                     
                     /* S3 버전 (롤백용 주석처리)
                     String newKey = awsS3Service.moveToPermanent(fileDto.getS3Key(), directory);
@@ -159,6 +160,16 @@ public class EventDetailModificationRequestService {
         }
 
         return modificationRequestRepository.save(request);
+    }
+
+    private void addTempDownloadUrlMappings(Map<String, String> urlMappings, String tempKey, String permanentUrl) {
+        String normalizedKey = TempUploadKeyPolicy.normalizeKey(tempKey);
+        if (normalizedKey.isBlank()) {
+            return;
+        }
+
+        urlMappings.put("/api/uploads/download?key=" + normalizedKey, permanentUrl);
+        urlMappings.put("/api/uploads/download?key=" + URLEncoder.encode(normalizedKey, StandardCharsets.UTF_8), permanentUrl);
     }
 
     @Transactional

--- a/src/main/java/com/fairing/fairplay/settlement/service/SettlementDisputeService.java
+++ b/src/main/java/com/fairing/fairplay/settlement/service/SettlementDisputeService.java
@@ -2,6 +2,7 @@ package com.fairing.fairplay.settlement.service;
 
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.core.service.LocalFileService;
+import com.fairing.fairplay.core.util.TempUploadKeyPolicy;
 import com.fairing.fairplay.settlement.controller.SettlementDisputeController;
 import com.fairing.fairplay.settlement.dto.SettlementDisputeDto;
 import com.fairing.fairplay.settlement.entity.DisputeStatus;
@@ -20,8 +21,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -32,7 +31,6 @@ import java.util.stream.IntStream;
 @Slf4j
 public class SettlementDisputeService {
 
-    private static final String TEMP_PREFIX = "uploads/temp/";
     private final SettlementDisputeRepository disputeRepository;
     private final SettlementDisputeFileRepository disputeFileRepository;
     private final SettlementRepository settlementRepository;
@@ -90,7 +88,7 @@ public class SettlementDisputeService {
         // 임시 파일들이 실제로 존재하는지 확인
         if (request.getTempFileKeys() != null) {
             for (String key : request.getTempFileKeys()) {
-                if (!key.startsWith(TEMP_PREFIX) || !localFileService.fileExists(key)) {
+                if (!TempUploadKeyPolicy.isTemporaryUploadKey(key) || !localFileService.fileExists(key)) {
                     throw new CustomException(HttpStatus.NOT_FOUND, "임시 업로드된 파일을 찾을 수 없습니다: " + key);
                 }
             }

--- a/src/test/java/com/fairing/fairplay/core/config/SecurityConfigPublicSurfaceTest.java
+++ b/src/test/java/com/fairing/fairplay/core/config/SecurityConfigPublicSurfaceTest.java
@@ -1,0 +1,76 @@
+package com.fairing.fairplay.core.config;
+
+import com.fairing.fairplay.core.controller.FileUploadController;
+import com.fairing.fairplay.core.security.SessionAuthenticationFilter;
+import com.fairing.fairplay.core.service.LocalFileService;
+import com.fairing.fairplay.core.service.SessionService;
+import com.fairing.fairplay.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = FileUploadController.class)
+@Import(SecurityConfig.class)
+class SecurityConfigPublicSurfaceTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private LocalFileService localFileService;
+
+    @MockBean
+    private SessionService sessionService;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @Test
+    void uploadDownloadRequiresAuthenticationWithoutSession() throws Exception {
+        mockMvc.perform(get("/api/uploads/download").param("key", "uploads/events/banner.txt"))
+                .andExpect(status().isUnauthorized());
+
+        verifyNoInteractions(localFileService);
+    }
+
+    @Test
+    void tempUploadRequiresAuthenticationWithoutSession() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "banner.txt",
+                "text/plain",
+                "banner".getBytes());
+
+        mockMvc.perform(multipart("/api/uploads/temp").file(file))
+                .andExpect(status().isUnauthorized());
+
+        verifyNoInteractions(localFileService);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void sessionFilterDoesNotClassifyUploadApiAsPublicPath() {
+        List<String> publicPaths = (List<String>) ReflectionTestUtils.getField(
+                SessionAuthenticationFilter.class,
+                "PUBLIC_PATHS");
+
+        assertThat(publicPaths).doesNotContain("/api/uploads/");
+    }
+}

--- a/src/test/java/com/fairing/fairplay/core/config/UploadStaticResourceSecurityTest.java
+++ b/src/test/java/com/fairing/fairplay/core/config/UploadStaticResourceSecurityTest.java
@@ -1,0 +1,111 @@
+package com.fairing.fairplay.core.config;
+
+import com.fairing.fairplay.core.service.SessionService;
+import com.fairing.fairplay.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = UploadStaticResourceSecurityTest.NoopController.class)
+@Import({WebConfig.class, SecurityConfig.class})
+class UploadStaticResourceSecurityTest {
+
+    private static final Path UPLOAD_ROOT = createUploadRoot();
+
+    static {
+        System.setProperty("app.upload.path", UPLOAD_ROOT.toString());
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SessionService sessionService;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        writeFile("uploads/events/sample.txt", "public");
+        writeFile("private/tmp/2026-05-18/source.txt", "private");
+        writeFile("uploads/tmp2026-05-18/source.txt", "legacy tmp");
+        writeFile("uploads/temp/2026-05-18/source.txt", "legacy temp");
+        writeFile("uploads/tmp-assets/sample.txt", "tmp assets");
+        writeFile("uploads/temporary/sample.txt", "temporary assets");
+    }
+
+    @Test
+    void permanentUploadResourceIsPubliclyServed() throws Exception {
+        mockMvc.perform(get("/uploads/uploads/events/sample.txt"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("public"));
+    }
+
+    @Test
+    void privateTempResourceIsNotPubliclyServed() throws Exception {
+        mockMvc.perform(get("/uploads/private/tmp/2026-05-18/source.txt"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void legacyTmpResourceIsNotPubliclyServed() throws Exception {
+        mockMvc.perform(get("/uploads/uploads/tmp2026-05-18/source.txt"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void legacyTempResourceIsNotPubliclyServed() throws Exception {
+        mockMvc.perform(get("/uploads/uploads/temp/2026-05-18/source.txt"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void permanentTmpAssetsResourceIsPubliclyServed() throws Exception {
+        mockMvc.perform(get("/uploads/uploads/tmp-assets/sample.txt"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("tmp assets"));
+    }
+
+    @Test
+    void permanentTemporaryResourceIsPubliclyServed() throws Exception {
+        mockMvc.perform(get("/uploads/uploads/temporary/sample.txt"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("temporary assets"));
+    }
+
+    private static Path createUploadRoot() {
+        try {
+            return Files.createTempDirectory("fairplay-upload-static-test");
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private void writeFile(String key, String content) throws IOException {
+        Path file = UPLOAD_ROOT.resolve(key);
+        Files.createDirectories(file.getParent());
+        Files.writeString(file, content);
+    }
+
+    @RestController
+    static class NoopController {
+    }
+}

--- a/src/test/java/com/fairing/fairplay/core/service/LocalFileServiceTest.java
+++ b/src/test/java/com/fairing/fairplay/core/service/LocalFileServiceTest.java
@@ -187,7 +187,7 @@ class LocalFileServiceTest {
     void uploadTempRejectsIntermediateSymlinkEscapeOutsideUploadRoot() throws Exception {
         Path outsideDir = tempDir.resolve("outside-upload");
         Files.createDirectories(outsideDir);
-        Path symlinkDir = uploadRoot.resolve("uploads");
+        Path symlinkDir = uploadRoot.resolve("private");
         createSymlinkOrSkip(symlinkDir, outsideDir);
         MockMultipartFile file = new MockMultipartFile("file", "banner.txt", "text/plain", "banner".getBytes());
 

--- a/src/test/java/com/fairing/fairplay/core/service/LocalFileServiceTest.java
+++ b/src/test/java/com/fairing/fairplay/core/service/LocalFileServiceTest.java
@@ -1,0 +1,275 @@
+package com.fairing.fairplay.core.service;
+
+import com.fairing.fairplay.common.exception.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SecureDirectoryStream;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LocalFileServiceTest {
+
+    @TempDir
+    Path tempDir;
+
+    private LocalFileService localFileService;
+    private Path uploadRoot;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        uploadRoot = tempDir.resolve("uploads");
+        Files.createDirectories(uploadRoot);
+
+        localFileService = new LocalFileService();
+        ReflectionTestUtils.setField(localFileService, "uploadBasePath", uploadRoot.toString());
+        ReflectionTestUtils.setField(localFileService, "baseUrl", "https://fair-play.test");
+    }
+
+    @Test
+    void downloadFileServesFileInsideUploadRoot() throws Exception {
+        Path storedFile = uploadRoot.resolve("uploads/events/banner.txt");
+        Files.createDirectories(storedFile.getParent());
+        Files.writeString(storedFile, "banner");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        if (!secureDirectoryStreamSupported()) {
+            assertFailClosed(() -> localFileService.downloadFile("uploads/events/banner.txt", response));
+            assertThat(response.getContentAsString()).isEmpty();
+            return;
+        }
+
+        localFileService.downloadFile("uploads/events/banner.txt", response);
+        assertThat(response.getContentAsString()).isEqualTo("banner");
+        assertThat(response.getHeader("Content-Disposition")).contains("banner.txt");
+    }
+
+    @Test
+    void uploadTempStoresFileOnlyWhenSecureDirectoryStreamIsAvailable() throws Exception {
+        MockMultipartFile file = new MockMultipartFile("file", "banner.txt", "text/plain", "banner".getBytes());
+
+        if (!secureDirectoryStreamSupported()) {
+            assertFailClosed(() -> localFileService.uploadTemp(file));
+            try (Stream<Path> files = Files.walk(uploadRoot)) {
+                assertThat(files.filter(Files::isRegularFile)).isEmpty();
+            }
+            return;
+        }
+
+        var response = localFileService.uploadTemp(file);
+
+        assertThat(response.getKey()).startsWith("uploads/tmp");
+        assertThat(uploadRoot.resolve(response.getKey())).hasContent("banner");
+    }
+
+    @Test
+    void downloadFileRejectsPathTraversalOutsideUploadRoot() throws Exception {
+        Files.writeString(tempDir.resolve("secret.txt"), "outside");
+
+        assertThatThrownBy(() -> localFileService.downloadFile("../secret.txt", new MockHttpServletResponse()))
+                .isInstanceOf(CustomException.class)
+                .satisfies(error -> assertThat(((CustomException) error).getStatus()).isEqualTo(HttpStatus.BAD_REQUEST));
+    }
+
+    @Test
+    void downloadFileRejectsFinalSymlinkEscapeOutsideUploadRoot() throws Exception {
+        Path outsideFile = tempDir.resolve("secret.txt");
+        Files.writeString(outsideFile, "outside");
+        Path symlink = uploadRoot.resolve("uploads/secret-link.txt");
+        Files.createDirectories(symlink.getParent());
+        createSymlinkOrSkip(symlink, outsideFile);
+
+        assertSecurityRejected(() -> localFileService.downloadFile("uploads/secret-link.txt", new MockHttpServletResponse()));
+    }
+
+    @Test
+    void downloadFileRejectsIntermediateSymlinkEscapeOutsideUploadRoot() throws Exception {
+        Path outsideDir = tempDir.resolve("outside");
+        Files.createDirectories(outsideDir);
+        Files.writeString(outsideDir.resolve("secret.txt"), "outside");
+        Path symlinkDir = uploadRoot.resolve("uploads/link-dir");
+        Files.createDirectories(symlinkDir.getParent());
+        createSymlinkOrSkip(symlinkDir, outsideDir);
+
+        assertSecurityRejected(() -> localFileService.downloadFile("uploads/link-dir/secret.txt", new MockHttpServletResponse()));
+    }
+
+    @Test
+    void moveToPermanentMovesFileWithinUploadRoot() throws Exception {
+        Path sourceFile = uploadRoot.resolve("uploads/tmp2026-05-18/source.txt");
+        Files.createDirectories(sourceFile.getParent());
+        Files.writeString(sourceFile, "staged");
+
+        if (!secureDirectoryStreamSupported()) {
+            assertFailClosed(() -> localFileService.moveToPermanent("uploads/tmp2026-05-18/source.txt", "events/banners"));
+            assertThat(sourceFile).exists();
+            return;
+        }
+
+        String destKey = localFileService.moveToPermanent("uploads/tmp2026-05-18/source.txt", "events/banners");
+        assertThat(destKey).startsWith("uploads/events/banners/");
+        assertThat(destKey).endsWith(".txt");
+        assertThat(sourceFile).doesNotExist();
+        assertThat(uploadRoot.resolve(destKey)).hasContent("staged");
+    }
+
+    @Test
+    void moveToPermanentRejectsSourceOutsideUploadRoot() throws Exception {
+        Files.writeString(tempDir.resolve("staged.txt"), "outside");
+
+        assertThatThrownBy(() -> localFileService.moveToPermanent("../staged.txt", "events"))
+                .isInstanceOf(CustomException.class)
+                .satisfies(error -> assertThat(((CustomException) error).getStatus()).isEqualTo(HttpStatus.BAD_REQUEST));
+    }
+
+    @Test
+    void moveToPermanentRejectsDestinationIntermediateSymlinkEscapeOutsideUploadRoot() throws Exception {
+        Path sourceFile = uploadRoot.resolve("uploads/tmp2026-05-18/source.txt");
+        Files.createDirectories(sourceFile.getParent());
+        Files.writeString(sourceFile, "staged");
+        Path outsideDir = tempDir.resolve("outside-dest");
+        Files.createDirectories(outsideDir);
+        Path symlinkDir = uploadRoot.resolve("uploads/events");
+        Files.createDirectories(symlinkDir.getParent());
+        createSymlinkOrSkip(symlinkDir, outsideDir);
+
+        assertSecurityRejected(() -> localFileService.moveToPermanent("uploads/tmp2026-05-18/source.txt", "events/banners"));
+
+        assertThat(sourceFile).exists();
+        try (Stream<Path> outsideFiles = Files.list(outsideDir)) {
+            assertThat(outsideFiles).isEmpty();
+        }
+    }
+
+    @Test
+    void uploadTempRejectsIntermediateSymlinkEscapeOutsideUploadRoot() throws Exception {
+        Path outsideDir = tempDir.resolve("outside-upload");
+        Files.createDirectories(outsideDir);
+        Path symlinkDir = uploadRoot.resolve("uploads");
+        createSymlinkOrSkip(symlinkDir, outsideDir);
+        MockMultipartFile file = new MockMultipartFile("file", "banner.txt", "text/plain", "banner".getBytes());
+
+        assertSecurityRejected(() -> localFileService.uploadTemp(file));
+
+        try (Stream<Path> outsideFiles = Files.list(outsideDir)) {
+            assertThat(outsideFiles).isEmpty();
+        }
+    }
+
+    @Test
+    void deleteFileDeletesOnlyWhenSecureDirectoryStreamIsAvailable() throws Exception {
+        Path storedFile = uploadRoot.resolve("uploads/events/delete-me.txt");
+        Files.createDirectories(storedFile.getParent());
+        Files.writeString(storedFile, "delete");
+
+        if (!secureDirectoryStreamSupported()) {
+            assertFailClosed(() -> localFileService.deleteFile("uploads/events/delete-me.txt"));
+            assertThat(storedFile).exists();
+            return;
+        }
+
+        localFileService.deleteFile("uploads/events/delete-me.txt");
+
+        assertThat(storedFile).doesNotExist();
+    }
+
+    @Test
+    void deleteFileRejectsPathTraversalOutsideUploadRoot() throws Exception {
+        Files.writeString(tempDir.resolve("delete-me.txt"), "outside");
+
+        assertThatThrownBy(() -> localFileService.deleteFile("../delete-me.txt"))
+                .isInstanceOf(CustomException.class)
+                .satisfies(error -> assertThat(((CustomException) error).getStatus()).isEqualTo(HttpStatus.BAD_REQUEST));
+
+        assertThat(tempDir.resolve("delete-me.txt")).exists();
+    }
+
+    @Test
+    void deleteFileRejectsIntermediateSymlinkEscapeOutsideUploadRoot() throws Exception {
+        Path outsideDir = tempDir.resolve("outside-delete");
+        Files.createDirectories(outsideDir);
+        Path outsideFile = outsideDir.resolve("delete-me.txt");
+        Files.writeString(outsideFile, "outside");
+        Path symlinkDir = uploadRoot.resolve("uploads/link-delete");
+        Files.createDirectories(symlinkDir.getParent());
+        createSymlinkOrSkip(symlinkDir, outsideDir);
+
+        assertSecurityRejected(() -> localFileService.deleteFile("uploads/link-delete/delete-me.txt"));
+
+        assertThat(outsideFile).exists();
+    }
+
+    @Test
+    void fileExistsReturnsFalseOnlyForMissingFile() {
+        if (!secureDirectoryStreamSupported()) {
+            assertFailClosed(() -> localFileService.fileExists("uploads/events/missing.txt"));
+            return;
+        }
+
+        assertThat(localFileService.fileExists("uploads/events/missing.txt")).isFalse();
+    }
+
+    @Test
+    void fileExistsRejectsFinalSymlinkInsteadOfMaskingAsMissing() throws Exception {
+        Path outsideFile = tempDir.resolve("secret-exists.txt");
+        Files.writeString(outsideFile, "outside");
+        Path symlink = uploadRoot.resolve("uploads/secret-exists-link.txt");
+        Files.createDirectories(symlink.getParent());
+        createSymlinkOrSkip(symlink, outsideFile);
+
+        assertSecurityRejected(() -> localFileService.fileExists("uploads/secret-exists-link.txt"));
+    }
+
+    @Test
+    void secureDirectoryStreamSupportMatchesRuntimeFileSystemProvider() throws Exception {
+        try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(uploadRoot)) {
+            assertThat(localFileService.isSecureDirectoryStreamSupported())
+                    .isEqualTo(directoryStream instanceof SecureDirectoryStream<Path>);
+        }
+    }
+
+    private void createSymlinkOrSkip(Path link, Path target) {
+        try {
+            Files.createSymbolicLink(link, target);
+        } catch (UnsupportedOperationException | java.io.IOException | SecurityException e) {
+            assumeTrue(false, "symbolic links are not available in this test environment: " + e.getMessage());
+        }
+    }
+
+    private boolean secureDirectoryStreamSupported() {
+        return localFileService.isSecureDirectoryStreamSupported();
+    }
+
+    private void assertSecurityRejected(ThrowingOperation operation) {
+        HttpStatus expectedStatus = secureDirectoryStreamSupported()
+                ? HttpStatus.BAD_REQUEST
+                : HttpStatus.INTERNAL_SERVER_ERROR;
+
+        assertThatThrownBy(operation::run)
+                .isInstanceOf(CustomException.class)
+                .satisfies(error -> assertThat(((CustomException) error).getStatus()).isEqualTo(expectedStatus));
+    }
+
+    private void assertFailClosed(ThrowingOperation operation) {
+        assertThatThrownBy(operation::run)
+                .isInstanceOf(CustomException.class)
+                .satisfies(error -> assertThat(((CustomException) error).getStatus()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR));
+    }
+
+    @FunctionalInterface
+    private interface ThrowingOperation {
+        void run() throws Exception;
+    }
+}

--- a/src/test/java/com/fairing/fairplay/core/service/LocalFileServiceTest.java
+++ b/src/test/java/com/fairing/fairplay/core/service/LocalFileServiceTest.java
@@ -70,7 +70,8 @@ class LocalFileServiceTest {
 
         var response = localFileService.uploadTemp(file);
 
-        assertThat(response.getKey()).startsWith("uploads/tmp");
+        assertThat(response.getKey()).startsWith("private/tmp/");
+        assertThat(response.getKey()).doesNotStartWith("uploads/");
         assertThat(uploadRoot.resolve(response.getKey())).hasContent("banner");
     }
 
@@ -108,21 +109,50 @@ class LocalFileServiceTest {
 
     @Test
     void moveToPermanentMovesFileWithinUploadRoot() throws Exception {
-        Path sourceFile = uploadRoot.resolve("uploads/tmp2026-05-18/source.txt");
+        Path sourceFile = uploadRoot.resolve("private/tmp/2026-05-18/source.txt");
         Files.createDirectories(sourceFile.getParent());
         Files.writeString(sourceFile, "staged");
 
         if (!secureDirectoryStreamSupported()) {
-            assertFailClosed(() -> localFileService.moveToPermanent("uploads/tmp2026-05-18/source.txt", "events/banners"));
+            assertFailClosed(() -> localFileService.moveToPermanent("private/tmp/2026-05-18/source.txt", "events/banners"));
             assertThat(sourceFile).exists();
             return;
         }
 
-        String destKey = localFileService.moveToPermanent("uploads/tmp2026-05-18/source.txt", "events/banners");
+        String destKey = localFileService.moveToPermanent("private/tmp/2026-05-18/source.txt", "events/banners");
         assertThat(destKey).startsWith("uploads/events/banners/");
         assertThat(destKey).endsWith(".txt");
         assertThat(sourceFile).doesNotExist();
         assertThat(uploadRoot.resolve(destKey)).hasContent("staged");
+    }
+
+    @Test
+    void getCdnUrlRejectsPrivateAndLegacyTempKeys() {
+        assertThatThrownBy(() -> localFileService.getCdnUrl("private/tmp/2026-05-18/source.txt"))
+                .isInstanceOf(CustomException.class)
+                .satisfies(error -> assertThat(((CustomException) error).getStatus()).isEqualTo(HttpStatus.BAD_REQUEST));
+
+        assertThatThrownBy(() -> localFileService.getCdnUrl("uploads/tmp2026-05-18/source.txt"))
+                .isInstanceOf(CustomException.class)
+                .satisfies(error -> assertThat(((CustomException) error).getStatus()).isEqualTo(HttpStatus.BAD_REQUEST));
+
+        assertThatThrownBy(() -> localFileService.getCdnUrl("uploads/temp/2026-05-18/source.txt"))
+                .isInstanceOf(CustomException.class)
+                .satisfies(error -> assertThat(((CustomException) error).getStatus()).isEqualTo(HttpStatus.BAD_REQUEST));
+    }
+
+    @Test
+    void getCdnUrlAllowsPermanentUploadKey() {
+        assertThat(localFileService.getCdnUrl("uploads/events/banner.txt"))
+                .isEqualTo("https://fair-play.test/uploads/uploads/events/banner.txt");
+    }
+
+    @Test
+    void getCdnUrlAllowsPermanentKeysWhoseNamesOnlyStartWithTempWords() {
+        assertThat(localFileService.getCdnUrl("uploads/tmp-assets/banner.txt"))
+                .isEqualTo("https://fair-play.test/uploads/uploads/tmp-assets/banner.txt");
+        assertThat(localFileService.getCdnUrl("uploads/temporary/banner.txt"))
+                .isEqualTo("https://fair-play.test/uploads/uploads/temporary/banner.txt");
     }
 
     @Test
@@ -136,7 +166,7 @@ class LocalFileServiceTest {
 
     @Test
     void moveToPermanentRejectsDestinationIntermediateSymlinkEscapeOutsideUploadRoot() throws Exception {
-        Path sourceFile = uploadRoot.resolve("uploads/tmp2026-05-18/source.txt");
+        Path sourceFile = uploadRoot.resolve("private/tmp/2026-05-18/source.txt");
         Files.createDirectories(sourceFile.getParent());
         Files.writeString(sourceFile, "staged");
         Path outsideDir = tempDir.resolve("outside-dest");
@@ -145,7 +175,7 @@ class LocalFileServiceTest {
         Files.createDirectories(symlinkDir.getParent());
         createSymlinkOrSkip(symlinkDir, outsideDir);
 
-        assertSecurityRejected(() -> localFileService.moveToPermanent("uploads/tmp2026-05-18/source.txt", "events/banners"));
+        assertSecurityRejected(() -> localFileService.moveToPermanent("private/tmp/2026-05-18/source.txt", "events/banners"));
 
         assertThat(sourceFile).exists();
         try (Stream<Path> outsideFiles = Files.list(outsideDir)) {

--- a/src/test/java/com/fairing/fairplay/event/service/EventDetailModificationRequestServiceTest.java
+++ b/src/test/java/com/fairing/fairplay/event/service/EventDetailModificationRequestServiceTest.java
@@ -1,0 +1,179 @@
+package com.fairing.fairplay.event.service;
+
+import com.fairing.fairplay.core.service.LocalFileService;
+import com.fairing.fairplay.event.dto.EventDetailModificationDto;
+import com.fairing.fairplay.event.dto.EventDetailRequestDto;
+import com.fairing.fairplay.event.entity.Event;
+import com.fairing.fairplay.event.entity.EventDetail;
+import com.fairing.fairplay.event.entity.EventDetailModificationRequest;
+import com.fairing.fairplay.event.entity.UpdateStatusCode;
+import com.fairing.fairplay.event.repository.EventDetailModificationRequestRepository;
+import com.fairing.fairplay.event.repository.EventDetailRepository;
+import com.fairing.fairplay.event.repository.EventRepository;
+import com.fairing.fairplay.event.repository.EventStatusCodeRepository;
+import com.fairing.fairplay.event.repository.ExternalLinkRepository;
+import com.fairing.fairplay.event.repository.LocationRepository;
+import com.fairing.fairplay.event.repository.MainCategoryRepository;
+import com.fairing.fairplay.event.repository.RegionCodeRepository;
+import com.fairing.fairplay.event.repository.SubCategoryRepository;
+import com.fairing.fairplay.event.repository.UpdateStatusCodeRepository;
+import com.fairing.fairplay.file.service.FileService;
+import com.fairing.fairplay.user.repository.EventAdminRepository;
+import com.fairing.fairplay.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EventDetailModificationRequestServiceTest {
+
+    @Mock
+    private EventDetailModificationRequestRepository modificationRequestRepository;
+
+    @Mock
+    private UpdateStatusCodeRepository updateStatusCodeRepository;
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @Mock
+    private EventDetailRepository eventDetailRepository;
+
+    @Mock
+    private LocationRepository locationRepository;
+
+    @Mock
+    private MainCategoryRepository mainCategoryRepository;
+
+    @Mock
+    private SubCategoryRepository subCategoryRepository;
+
+    @Mock
+    private RegionCodeRepository regionCodeRepository;
+
+    @Mock
+    private EventAdminRepository eventAdminRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ExternalLinkRepository externalLinkRepository;
+
+    @Mock
+    private EventStatusCodeRepository statusCodeRepository;
+
+    @Mock
+    private EventVersionService eventVersionService;
+
+    @Mock
+    private LocalFileService localFileService;
+
+    @Mock
+    private FileService fileService;
+
+    private EventDetailModificationRequestService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new EventDetailModificationRequestService(
+                modificationRequestRepository,
+                updateStatusCodeRepository,
+                eventRepository,
+                eventDetailRepository,
+                locationRepository,
+                mainCategoryRepository,
+                subCategoryRepository,
+                regionCodeRepository,
+                eventAdminRepository,
+                userRepository,
+                externalLinkRepository,
+                statusCodeRepository,
+                eventVersionService,
+                localFileService,
+                fileService
+        );
+    }
+
+    @Test
+    void createModificationRequestReplacesPreviewDownloadUrlAfterMovingPrivateTempFile() {
+        String tempKey = "private/tmp/2026-05-18/banner.png";
+        String previewUrl = "/api/uploads/download?key=private%2Ftmp%2F2026-05-18%2Fbanner.png";
+        String permanentKey = "uploads/events/42/content_image/banner.png";
+        String permanentUrl = "https://fair-play.test/uploads/" + permanentKey;
+
+        Event event = eventWithDetail(42L);
+        EventDetailModificationDto dto = new EventDetailModificationDto();
+        dto.setContent("<img src=\"" + previewUrl + "\">");
+        dto.setTempFiles(List.of(fileUpload(tempKey, "content_image")));
+
+        when(eventRepository.findById(42L)).thenReturn(Optional.of(event));
+        when(modificationRequestRepository.existsPendingRequestByEventId(42L)).thenReturn(false);
+        when(localFileService.moveToPermanent(tempKey, "events/42/content_image")).thenReturn(permanentKey);
+        when(localFileService.getCdnUrl(permanentKey)).thenReturn(permanentUrl);
+        lenient().when(updateStatusCodeRepository.findByCode("PENDING")).thenReturn(Optional.of(pendingStatus()));
+        lenient().when(externalLinkRepository.findByEvent(event)).thenReturn(List.of());
+        lenient().when(modificationRequestRepository.save(any(EventDetailModificationRequest.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertThatCode(() -> service.createModificationRequest(42L, dto, 100L))
+                .doesNotThrowAnyException();
+
+        ArgumentCaptor<EventDetailModificationRequest> requestCaptor =
+                ArgumentCaptor.forClass(EventDetailModificationRequest.class);
+        verify(modificationRequestRepository).save(requestCaptor.capture());
+        EventDetailModificationDto savedDto = requestCaptor.getValue().getModifiedDataAsDto();
+        assertThat(savedDto.getContent()).contains(permanentUrl);
+        assertThat(savedDto.getContent()).doesNotContain(previewUrl);
+        verify(localFileService, never()).getCdnUrl(tempKey);
+    }
+
+    private Event eventWithDetail(Long eventId) {
+        Event event = new Event();
+        event.setEventId(eventId);
+        event.setTitleKr("행사");
+        event.setTitleEng("Event");
+
+        EventDetail detail = new EventDetail();
+        detail.setContent("current content");
+        detail.setPolicy("current policy");
+        detail.setStartDate(LocalDate.of(2026, 5, 18));
+        detail.setEndDate(LocalDate.of(2026, 5, 19));
+        detail.setReentryAllowed(true);
+        detail.setCheckInAllowed(false);
+        detail.setCheckOutAllowed(false);
+        detail.setAge(false);
+        event.setEventDetail(detail);
+        return event;
+    }
+
+    private EventDetailRequestDto.FileUploadDto fileUpload(String key, String usage) {
+        EventDetailRequestDto.FileUploadDto fileUpload = new EventDetailRequestDto.FileUploadDto();
+        fileUpload.setS3Key(key);
+        fileUpload.setOriginalFileName("banner.png");
+        fileUpload.setUsage(usage);
+        return fileUpload;
+    }
+
+    private UpdateStatusCode pendingStatus() {
+        UpdateStatusCode status = new UpdateStatusCode();
+        status.setCode("PENDING");
+        status.setName("대기");
+        return status;
+    }
+}

--- a/src/test/java/com/fairing/fairplay/settlement/service/SettlementDisputeServiceTest.java
+++ b/src/test/java/com/fairing/fairplay/settlement/service/SettlementDisputeServiceTest.java
@@ -1,0 +1,100 @@
+package com.fairing.fairplay.settlement.service;
+
+import com.fairing.fairplay.core.service.LocalFileService;
+import com.fairing.fairplay.settlement.dto.SettlementDisputeDto;
+import com.fairing.fairplay.settlement.entity.Settlement;
+import com.fairing.fairplay.settlement.entity.SettlementDispute;
+import com.fairing.fairplay.settlement.entity.SettlementDisputeFile;
+import com.fairing.fairplay.settlement.repository.SettlementDisputeFileRepository;
+import com.fairing.fairplay.settlement.repository.SettlementDisputeRepository;
+import com.fairing.fairplay.settlement.repository.SettlementRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SettlementDisputeServiceTest {
+
+    @Mock
+    private SettlementDisputeRepository disputeRepository;
+
+    @Mock
+    private SettlementDisputeFileRepository disputeFileRepository;
+
+    @Mock
+    private SettlementRepository settlementRepository;
+
+    @Mock
+    private LocalFileService localFileService;
+
+    private SettlementDisputeService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SettlementDisputeService(
+                disputeRepository,
+                disputeFileRepository,
+                settlementRepository,
+                localFileService
+        );
+    }
+
+    @Test
+    void submitDisputeAcceptsPrivateTempUploadKeyAndMovesFileToPermanentStorage() {
+        String tempKey = "private/tmp/2026-05-18/evidence.pdf";
+        String permanentKey = "uploads/disputes/900/evidence.pdf";
+        Settlement settlement = settlement();
+        SettlementDisputeDto.CreateRequest request = SettlementDisputeDto.CreateRequest.builder()
+                .settlementId(7L)
+                .disputeReason("정산 금액 증빙이 필요합니다.")
+                .tempFileKeys(List.of(tempKey))
+                .build();
+
+        when(settlementRepository.findById(7L)).thenReturn(Optional.of(settlement));
+        when(disputeRepository.existsBySettlement_SettlementId(7L)).thenReturn(false);
+        when(localFileService.fileExists(tempKey)).thenReturn(true);
+        lenient().when(disputeRepository.save(any(SettlementDispute.class))).thenAnswer(invocation -> {
+            SettlementDispute dispute = invocation.getArgument(0);
+            dispute.setDisputeId(900L);
+            return dispute;
+        });
+        lenient().when(localFileService.moveToPermanent(tempKey, "disputes/900")).thenReturn(permanentKey);
+        lenient().when(disputeFileRepository.save(any(SettlementDisputeFile.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        lenient().when(settlementRepository.save(settlement)).thenReturn(settlement);
+
+        assertThatCode(() -> service.submitDispute(request, 55L))
+                .doesNotThrowAnyException();
+
+        verify(localFileService).moveToPermanent(tempKey, "disputes/900");
+        ArgumentCaptor<SettlementDisputeFile> fileCaptor = ArgumentCaptor.forClass(SettlementDisputeFile.class);
+        verify(disputeFileRepository).save(fileCaptor.capture());
+        assertThat(fileCaptor.getValue().getS3Key()).isEqualTo(permanentKey);
+        assertThat(fileCaptor.getValue().getOriginalFilename()).isEqualTo("evidence.pdf");
+        assertThat(fileCaptor.getValue().getUploadOrder()).isEqualTo(1);
+    }
+
+    private Settlement settlement() {
+        return Settlement.builder()
+                .settlementId(7L)
+                .eventTitle("정산 행사")
+                .totalAmount(BigDecimal.valueOf(10000))
+                .feeAmount(BigDecimal.valueOf(1000))
+                .finalAmount(BigDecimal.valueOf(9000))
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- Rebased `epic/security-public-write-surface` onto latest `origin/develop` (`7e97640`).
- Preserved develop-side dynamic CORS/miniserver changes while keeping upload static-resource blocking for private and legacy temp keys.
- Preserved develop-side `LocalFileService` settlement dispute flow while accepting private temp upload keys through `TempUploadKeyPolicy`.
- Addressed automated review feedback by closing owned `SecureDirectoryStream` handles on traversal failures and switching the download filename encoder to `StandardCharsets.UTF_8`.

## Verification
- `git diff --check`
- `./gradlew test --tests com.fairing.fairplay.core.service.LocalFileServiceTest --tests com.fairing.fairplay.core.config.SecurityConfigPublicSurfaceTest --tests com.fairing.fairplay.core.config.UploadStaticResourceSecurityTest --tests com.fairing.fairplay.event.service.EventDetailModificationRequestServiceTest --tests com.fairing.fairplay.settlement.service.SettlementDisputeServiceTest`

## Notes
- Untracked duplicate files left by the worktree (`* 2.java`) initially blocked Java compilation, so they were moved without deletion to `/private/tmp/fairplay-rebase-duplicates/` before verification.
- This PR targets `develop`; no merge to `develop` or `main` was performed.