### PR TITLE
Keep transient uploads out of mini-server static aliases

### DIFF
--- a/deploy/nginx.miniserver.conf
+++ b/deploy/nginx.miniserver.conf
@@ -8,6 +8,54 @@ server {
     gzip_min_length 1024;
     gzip_types text/plain text/css application/javascript application/json image/svg+xml;
 
+    location = /uploads/private {
+        return 404;
+    }
+
+    location ^~ /uploads/private/ {
+        return 404;
+    }
+
+    location = /uploads/temp {
+        return 404;
+    }
+
+    location ^~ /uploads/temp/ {
+        return 404;
+    }
+
+    location = /uploads/tmp {
+        return 404;
+    }
+
+    location ^~ /uploads/tmp/ {
+        return 404;
+    }
+
+    location ~ ^/uploads/tmp[0-9]{4}-[0-9]{2}-[0-9]{2}(/|$) {
+        return 404;
+    }
+
+    location = /uploads/uploads/temp {
+        return 404;
+    }
+
+    location ^~ /uploads/uploads/temp/ {
+        return 404;
+    }
+
+    location = /uploads/uploads/tmp {
+        return 404;
+    }
+
+    location ^~ /uploads/uploads/tmp/ {
+        return 404;
+    }
+
+    location ~ ^/uploads/uploads/tmp[0-9]{4}-[0-9]{2}-[0-9]{2}(/|$) {
+        return 404;
+    }
+
     location /uploads/ {
         alias /var/www/uploads/;
         expires 30d;

--- a/src/test/java/com/fairing/fairplay/core/config/NginxMiniserverUploadDenyOrderTest.java
+++ b/src/test/java/com/fairing/fairplay/core/config/NginxMiniserverUploadDenyOrderTest.java
@@ -1,0 +1,79 @@
+package com.fairing.fairplay.core.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NginxMiniserverUploadDenyOrderTest {
+
+    private static final Path NGINX_CONFIG = Path.of("deploy/nginx.miniserver.conf");
+
+    @Test
+    void uploadDenyLocationsPrecedeBroadUploadAlias() throws IOException {
+        String config = Files.readString(NGINX_CONFIG);
+
+        int privateDeny = config.indexOf("location = /uploads/private");
+        int legacyTempDeny = config.indexOf("location = /uploads/uploads/temp");
+        int broadUploadAlias = config.indexOf("location /uploads/ {");
+
+        assertThat(privateDeny).isNotNegative();
+        assertThat(legacyTempDeny).isNotNegative();
+        assertThat(broadUploadAlias).isNotNegative();
+        assertThat(privateDeny).isLessThan(broadUploadAlias);
+        assertThat(legacyTempDeny).isLessThan(broadUploadAlias);
+    }
+
+    @Test
+    void uploadDenyLocationsCoverPrivateTempAndLegacyTmpPaths() throws IOException {
+        String config = Files.readString(NGINX_CONFIG);
+
+        assertThat(config).contains(
+                "location = /uploads/private",
+                "location ^~ /uploads/private/",
+                "location = /uploads/temp",
+                "location ^~ /uploads/temp/",
+                "location = /uploads/tmp",
+                "location ^~ /uploads/tmp/",
+                "location ~ ^/uploads/tmp[0-9]{4}-[0-9]{2}-[0-9]{2}(/|$)",
+                "location = /uploads/uploads/temp",
+                "location ^~ /uploads/uploads/temp/",
+                "location = /uploads/uploads/tmp",
+                "location ^~ /uploads/uploads/tmp/",
+                "location ~ ^/uploads/uploads/tmp[0-9]{4}-[0-9]{2}-[0-9]{2}(/|$)"
+        );
+
+        assertThat(config).containsPattern("(?s)location = /uploads/private \\{\\s*return 404;\\s*}");
+        assertThat(config).containsPattern("(?s)location \\^~ /uploads/uploads/temp/ \\{\\s*return 404;\\s*}");
+        assertThat(config).containsPattern("(?s)location ~ \\^/uploads/uploads/tmp\\[0-9\\]\\{4}-\\[0-9\\]\\{2}-\\[0-9\\]\\{2}\\(/\\|\\$\\) \\{\\s*return 404;\\s*}");
+    }
+
+    @Test
+    void datedTmpDenyPatternsDoNotCatchPermanentTmpNamedDirectories() {
+        List<Pattern> datedTmpDenyPatterns = List.of(
+                Pattern.compile("^/uploads/tmp[0-9]{4}-[0-9]{2}-[0-9]{2}(/|$)"),
+                Pattern.compile("^/uploads/uploads/tmp[0-9]{4}-[0-9]{2}-[0-9]{2}(/|$)")
+        );
+
+        List<String> deniedPaths = List.of(
+                "/uploads/tmp2026-05-18/source.png",
+                "/uploads/uploads/tmp2026-05-18/source.png"
+        );
+        List<String> publicPaths = List.of(
+                "/uploads/uploads/tmp-assets/source.png",
+                "/uploads/uploads/temporary/source.png"
+        );
+
+        assertThat(deniedPaths).allSatisfy(path ->
+                assertThat(datedTmpDenyPatterns).anySatisfy(pattern ->
+                        assertThat(pattern.matcher(path).find()).isTrue()));
+        assertThat(publicPaths).allSatisfy(path ->
+                assertThat(datedTmpDenyPatterns).allSatisfy(pattern ->
+                        assertThat(pattern.matcher(path).find()).isFalse()));
+    }
+}


### PR DESCRIPTION
## Summary
- Add private/temp/tmp deny locations before the broad `/uploads/` alias in `deploy/nginx.miniserver.conf`.
- Preserve public access for permanent tmp-named directories such as `/uploads/uploads/tmp-assets/...` and `/uploads/uploads/temporary/...`.
- Add a deterministic JUnit config-text test for deny ordering and path invariants.

## Verification
- `git diff --check`
- `./gradlew test --tests com.fairing.fairplay.core.config.NginxMiniserverUploadDenyOrderTest`
- `./gradlew test`

## Not tested
- `nginx -t`: local `nginx` is not installed and Docker daemon is not running in this worker environment.

Production reload/deploy was not performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **보안 개선**
  * 비공개 및 임시 업로드 디렉터리에 대한 무단 접근을 차단하도록 서버 라우팅 규칙이 강화되었습니다.

* **테스트**
  * 업로드 경로 접근 제한이 올바르게 작동하는지 검증하는 테스트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rktclgh/FairPlay_BE/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->