### PR TITLE
Restore backend authorization ownership boundaries

### DIFF
--- a/src/main/java/com/fairing/fairplay/attendee/service/AttendeeService.java
+++ b/src/main/java/com/fairing/fairplay/attendee/service/AttendeeService.java
@@ -12,6 +12,8 @@ import com.fairing.fairplay.attendee.repository.AttendeeTypeCodeRepository;
 import com.fairing.fairplay.attendeeform.entity.AttendeeForm;
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.core.security.CustomUserDetails;
+import com.fairing.fairplay.event.entity.Event;
+import com.fairing.fairplay.event.repository.EventRepository;
 import com.fairing.fairplay.qr.dto.QrTicketEmailTodayRequestDto;
 import com.fairing.fairplay.qr.service.QrTicketService;
 import com.fairing.fairplay.reservation.entity.Reservation;
@@ -23,6 +25,7 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,6 +41,10 @@ public class AttendeeService {
   private final AttendeeFormService attendeeFormService;
   private final ReservationRepository reservationRepository;
   private final QrTicketService qrTicketService;
+  private final EventRepository eventRepository;
+
+  private static final String ROLE_ADMIN = "ADMIN";
+  private static final String ROLE_EVENT_MANAGER = "EVENT_MANAGER";
 
   // 대표자 정보 저장
   @Transactional
@@ -151,14 +158,11 @@ public class AttendeeService {
   // 행사별 예약자 명단 조회 (행사 관리자)
   public List<AttendeeInfoResponseDto> getAttendeesByEvent(Long eventId,
       CustomUserDetails userDetails) {
-    // 행사 관리자 권한 검증
-    if ("COMMON".equals(userDetails.getRoleCode())) {
-      throw new CustomException(HttpStatus.FORBIDDEN, "행사별 예약자 명단을 조회할 권한이 없습니다.");
-    }
     // eventId 유효성 검사
     if (eventId == null || eventId <= 0) {
       throw new CustomException(HttpStatus.BAD_REQUEST, "유효하지 않은 행사 ID입니다.");
     }
+    requireEventAttendeeReadAccess(eventId, userDetails);
 
     List<Attendee> attendees = attendeeRepository.findByEventId(eventId);
     return attendees.stream()
@@ -238,5 +242,27 @@ public class AttendeeService {
   private Reservation findReservation(Long reservationId) {
     return reservationRepository.findById(reservationId).orElseThrow(
         () -> new CustomException(HttpStatus.NOT_FOUND, "예약 정보를 조회할 수 없습니다."));
+  }
+
+  private void requireEventAttendeeReadAccess(Long eventId, CustomUserDetails userDetails) {
+    if (userDetails == null || userDetails.getUserId() == null) {
+      throw new AccessDeniedException("로그인이 필요합니다.");
+    }
+
+    String roleCode = userDetails.getRoleCode();
+    if (ROLE_ADMIN.equals(roleCode)) {
+      return;
+    }
+    if (!ROLE_EVENT_MANAGER.equals(roleCode)) {
+      throw new AccessDeniedException("행사별 예약자 명단을 조회할 권한이 없습니다.");
+    }
+
+    Event event = eventRepository.findById(eventId)
+        .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "행사를 조회할 수 없습니다."));
+    if (event.getManager() == null
+        || event.getManager().getUserId() == null
+        || !event.getManager().getUserId().equals(userDetails.getUserId())) {
+      throw new AccessDeniedException("행사별 예약자 명단을 조회할 권한이 없습니다.");
+    }
   }
 }

--- a/src/main/java/com/fairing/fairplay/booth/controller/BoothExperienceController.java
+++ b/src/main/java/com/fairing/fairplay/booth/controller/BoothExperienceController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -29,19 +30,24 @@ public class BoothExperienceController {
     // 1. 부스 체험 등록 (부스 담당자)
     @Operation(summary = "부스 체험 등록", description = "부스 담당자가 새로운 체험을 등록합니다.")
     @PostMapping("/booths/{boothId}")
+    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     @FunctionAuth("createBoothExperience")
     public ResponseEntity<BoothExperienceResponseDto> createBoothExperience(
             @Parameter(description = "부스 ID") @PathVariable Long boothId,
-            @RequestBody BoothExperienceRequestDto requestDto) {
+            @RequestBody BoothExperienceRequestDto requestDto,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        log.info("부스 체험 등록 요청 - 부스 ID: {}", boothId);
-        BoothExperienceResponseDto response = boothExperienceService.createBoothExperience(boothId, requestDto);
+        log.info("부스 체험 등록 요청 - 부스 ID: {}, 사용자 ID: {}, 권한: {}",
+                boothId, userDetails.getUserId(), userDetails.getRoleCode());
+        BoothExperienceResponseDto response = boothExperienceService.createBoothExperience(
+                boothId, requestDto, userDetails.getUserId(), userDetails.getRoleCode());
         return ResponseEntity.ok(response);
     }
 
     // 2. 부스 체험 목록 조회 (권한 기반)
     @Operation(summary = "부스 체험 목록 조회", description = "사용자 권한에 따라 관리 가능한 부스 체험 목록을 조회합니다.")
     @GetMapping("/booths/{boothId}")
+    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     @FunctionAuth("getBoothExperiences")
     public ResponseEntity<List<BoothExperienceResponseDto>> getBoothExperiences(
             @Parameter(description = "부스 ID") @PathVariable Long boothId,
@@ -90,25 +96,33 @@ public class BoothExperienceController {
     // 4-1. 부스 체험 수정 (부스 담당자)
     @Operation(summary = "부스 체험 수정", description = "부스 담당자가 기존 체험을 수정합니다.")
     @PutMapping("/{experienceId}")
+    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     @FunctionAuth("updateBoothExperience")
     public ResponseEntity<BoothExperienceResponseDto> updateBoothExperience(
             @Parameter(description = "체험 ID") @PathVariable Long experienceId,
-            @RequestBody BoothExperienceRequestDto requestDto) {
+            @RequestBody BoothExperienceRequestDto requestDto,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        log.info("부스 체험 수정 요청 - 체험 ID: {}", experienceId);
-        BoothExperienceResponseDto response = boothExperienceService.updateBoothExperience(experienceId, requestDto);
+        log.info("부스 체험 수정 요청 - 체험 ID: {}, 사용자 ID: {}, 권한: {}",
+                experienceId, userDetails.getUserId(), userDetails.getRoleCode());
+        BoothExperienceResponseDto response = boothExperienceService.updateBoothExperience(
+                experienceId, requestDto, userDetails.getUserId(), userDetails.getRoleCode());
         return ResponseEntity.ok(response);
     }
 
     // 4-2. 부스 체험 삭제 (부스 담당자)
     @Operation(summary = "부스 체험 삭제", description = "부스 담당자가 체험을 삭제합니다.")
     @DeleteMapping("/{experienceId}")
+    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     @FunctionAuth("deleteBoothExperience")
     public ResponseEntity<Void> deleteBoothExperience(
-            @Parameter(description = "체험 ID") @PathVariable Long experienceId) {
+            @Parameter(description = "체험 ID") @PathVariable Long experienceId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        log.info("부스 체험 삭제 요청 - 체험 ID: {}", experienceId);
-        boothExperienceService.deleteBoothExperience(experienceId);
+        log.info("부스 체험 삭제 요청 - 체험 ID: {}, 사용자 ID: {}, 권한: {}",
+                experienceId, userDetails.getUserId(), userDetails.getRoleCode());
+        boothExperienceService.deleteBoothExperience(
+                experienceId, userDetails.getUserId(), userDetails.getRoleCode());
         return ResponseEntity.ok().build();
     }
 
@@ -129,13 +143,16 @@ public class BoothExperienceController {
     // 6. 부스 체험 예약자 목록 조회 (부스 담당자용)
     @Operation(summary = "예약자 목록 조회", description = "특정 체험의 모든 예약자 목록을 조회합니다.")
     @GetMapping("/{experienceId}/reservations")
+    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     @FunctionAuth("getExperienceReservations")
     public ResponseEntity<List<BoothExperienceReservationResponseDto>> getExperienceReservations(
-            @Parameter(description = "체험 ID") @PathVariable Long experienceId) {
+            @Parameter(description = "체험 ID") @PathVariable Long experienceId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        log.info("예약자 목록 조회 - 체험 ID: {}", experienceId);
+        log.info("예약자 목록 조회 - 체험 ID: {}, 사용자 ID: {}, 권한: {}",
+                experienceId, userDetails.getUserId(), userDetails.getRoleCode());
         List<BoothExperienceReservationResponseDto> reservations = boothExperienceService
-                .getExperienceReservations(experienceId);
+                .getExperienceReservations(experienceId, userDetails.getUserId(), userDetails.getRoleCode());
         return ResponseEntity.ok(reservations);
     }
 
@@ -156,14 +173,17 @@ public class BoothExperienceController {
     // 8. 예약 상태 변경 (부스 담당자)
     @Operation(summary = "예약 상태 변경", description = "부스 담당자가 예약의 상태를 변경합니다.")
     @PutMapping("/reservations/{reservationId}/status")
+    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     @FunctionAuth("updateReservationStatus")
     public ResponseEntity<BoothExperienceReservationResponseDto> updateReservationStatus(
             @Parameter(description = "예약 ID") @PathVariable Long reservationId,
-            @RequestBody BoothExperienceStatusUpdateDto updateDto) {
+            @RequestBody BoothExperienceStatusUpdateDto updateDto,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        log.info("예약 상태 변경 - 예약 ID: {}, 상태: {}", reservationId, updateDto.getStatusCode());
+        log.info("예약 상태 변경 - 예약 ID: {}, 상태: {}, 사용자 ID: {}, 권한: {}",
+                reservationId, updateDto.getStatusCode(), userDetails.getUserId(), userDetails.getRoleCode());
         BoothExperienceReservationResponseDto response = boothExperienceService.updateReservationStatus(
-                reservationId, updateDto);
+                reservationId, updateDto, userDetails.getUserId(), userDetails.getRoleCode());
         return ResponseEntity.ok(response);
     }
 
@@ -205,6 +225,7 @@ public class BoothExperienceController {
     // 11. 디버그용 - 모든 체험 조회 (예약 활성화 여부 포함)
     @Operation(summary = "디버그용 모든 체험 조회", description = "예약 활성화 여부와 관계없이 모든 체험을 조회합니다.")
     @GetMapping("/debug/all")
+    @PreAuthorize("hasAuthority('ADMIN')")
     public ResponseEntity<List<BoothExperienceResponseDto>> getAllExperiencesForDebug() {
         log.info("디버그용 모든 체험 조회");
         List<BoothExperienceResponseDto> experiences = boothExperienceService.getAvailableExperiences(
@@ -215,6 +236,7 @@ public class BoothExperienceController {
     // 12. 권한별 관리 가능한 부스 목록 조회 (체험 등록용)
     @Operation(summary = "관리 가능한 부스 목록 조회", description = "사용자 권한에 따라 관리 가능한 부스 목록을 조회합니다.")
     @GetMapping("/manageable-booths")
+    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     @FunctionAuth("getManageableBooths")
     public ResponseEntity<List<BoothResponseDto>> getManageableBooths(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -230,6 +252,7 @@ public class BoothExperienceController {
     // 13. 권한별 관리 가능한 체험 목록 조회 (체험 관리용)
     @Operation(summary = "관리 가능한 체험 목록 조회", description = "사용자 권한에 따라 관리 가능한 모든 체험 목록을 조회합니다.")
     @GetMapping("/manageable-experiences")
+    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     public ResponseEntity<List<BoothExperienceResponseDto>> getManageableExperiences(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
@@ -244,6 +267,7 @@ public class BoothExperienceController {
     // 14. 예약자 관리용 목록 조회 (필터링 지원)
     @Operation(summary = "예약자 관리 목록 조회", description = "행사/부스 담당자가 예약자를 관리하기 위한 목록을 조회합니다.")
     @GetMapping("/reservations/management")
+    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     // @FunctionAuth("getReservationsForManagement") // 임시로 권한 체크 제거
     public ResponseEntity<Page<ReservationManagementResponseDto>> getReservationsForManagement(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -281,18 +305,23 @@ public class BoothExperienceController {
     // 15. 부스 체험 현황 요약 조회
     @Operation(summary = "부스 체험 현황 요약", description = "특정 체험의 현재 상황을 요약해서 조회합니다.")
     @GetMapping("/{experienceId}/summary")
+    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     // @FunctionAuth("getExperienceSummary") // 임시로 권한 체크 제거
     public ResponseEntity<BoothExperienceSummaryDto> getExperienceSummary(
-            @Parameter(description = "체험 ID") @PathVariable Long experienceId) {
+            @Parameter(description = "체험 ID") @PathVariable Long experienceId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        log.info("부스 체험 현황 요약 조회 - 체험 ID: {}", experienceId);
-        BoothExperienceSummaryDto summary = boothExperienceService.getExperienceSummary(experienceId);
+        log.info("부스 체험 현황 요약 조회 - 체험 ID: {}, 사용자 ID: {}, 권한: {}",
+                experienceId, userDetails.getUserId(), userDetails.getRoleCode());
+        BoothExperienceSummaryDto summary = boothExperienceService.getExperienceSummary(
+                experienceId, userDetails.getUserId(), userDetails.getRoleCode());
         return ResponseEntity.ok(summary);
     }
 
     // 16. 예약 관리용 부스 목록 조회
     @Operation(summary = "예약 관리용 부스 목록", description = "예약자 관리 화면에서 사용할 부스 목록을 조회합니다.")
     @GetMapping("/manageable-booths-for-reservation")
+    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     // @FunctionAuth("getManageableBoothsForReservation") // 임시로 권한 체크 제거
     public ResponseEntity<List<BoothResponseDto>> getManageableBoothsForReservation(
             @AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/src/main/java/com/fairing/fairplay/booth/controller/BoothExperienceController.java
+++ b/src/main/java/com/fairing/fairplay/booth/controller/BoothExperienceController.java
@@ -131,12 +131,13 @@ public class BoothExperienceController {
     @PostMapping("/{experienceId}/reservations")
     public ResponseEntity<BoothExperienceReservationResponseDto> createReservation(
             @Parameter(description = "체험 ID") @PathVariable Long experienceId,
-            @Parameter(description = "사용자 ID") @RequestParam Long userId,
-            @RequestBody BoothExperienceReservationRequestDto requestDto) {
+            @RequestBody BoothExperienceReservationRequestDto requestDto,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        log.info("부스 체험 예약 요청 - 체험 ID: {}, 사용자 ID: {}", experienceId, userId);
+        log.info("부스 체험 예약 요청 - 체험 ID: {}, 사용자 ID: {}", experienceId,
+                userDetails != null ? userDetails.getUserId() : null);
         BoothExperienceReservationResponseDto response = boothExperienceService.createReservation(
-                experienceId, userId, requestDto);
+                experienceId, userDetails, requestDto);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/fairing/fairplay/booth/controller/BoothExperienceController.java
+++ b/src/main/java/com/fairing/fairplay/booth/controller/BoothExperienceController.java
@@ -30,7 +30,7 @@ public class BoothExperienceController {
     // 1. 부스 체험 등록 (부스 담당자)
     @Operation(summary = "부스 체험 등록", description = "부스 담당자가 새로운 체험을 등록합니다.")
     @PostMapping("/booths/{boothId}")
-    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
+    @PreAuthorize("hasAuthority('ADMIN') or hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     @FunctionAuth("createBoothExperience")
     public ResponseEntity<BoothExperienceResponseDto> createBoothExperience(
             @Parameter(description = "부스 ID") @PathVariable Long boothId,
@@ -47,7 +47,7 @@ public class BoothExperienceController {
     // 2. 부스 체험 목록 조회 (권한 기반)
     @Operation(summary = "부스 체험 목록 조회", description = "사용자 권한에 따라 관리 가능한 부스 체험 목록을 조회합니다.")
     @GetMapping("/booths/{boothId}")
-    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
+    @PreAuthorize("hasAuthority('ADMIN') or hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     @FunctionAuth("getBoothExperiences")
     public ResponseEntity<List<BoothExperienceResponseDto>> getBoothExperiences(
             @Parameter(description = "부스 ID") @PathVariable Long boothId,
@@ -96,7 +96,7 @@ public class BoothExperienceController {
     // 4-1. 부스 체험 수정 (부스 담당자)
     @Operation(summary = "부스 체험 수정", description = "부스 담당자가 기존 체험을 수정합니다.")
     @PutMapping("/{experienceId}")
-    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
+    @PreAuthorize("hasAuthority('ADMIN') or hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     @FunctionAuth("updateBoothExperience")
     public ResponseEntity<BoothExperienceResponseDto> updateBoothExperience(
             @Parameter(description = "체험 ID") @PathVariable Long experienceId,
@@ -113,7 +113,7 @@ public class BoothExperienceController {
     // 4-2. 부스 체험 삭제 (부스 담당자)
     @Operation(summary = "부스 체험 삭제", description = "부스 담당자가 체험을 삭제합니다.")
     @DeleteMapping("/{experienceId}")
-    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
+    @PreAuthorize("hasAuthority('ADMIN') or hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     @FunctionAuth("deleteBoothExperience")
     public ResponseEntity<Void> deleteBoothExperience(
             @Parameter(description = "체험 ID") @PathVariable Long experienceId,
@@ -144,7 +144,7 @@ public class BoothExperienceController {
     // 6. 부스 체험 예약자 목록 조회 (부스 담당자용)
     @Operation(summary = "예약자 목록 조회", description = "특정 체험의 모든 예약자 목록을 조회합니다.")
     @GetMapping("/{experienceId}/reservations")
-    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
+    @PreAuthorize("hasAuthority('ADMIN') or hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     @FunctionAuth("getExperienceReservations")
     public ResponseEntity<List<BoothExperienceReservationResponseDto>> getExperienceReservations(
             @Parameter(description = "체험 ID") @PathVariable Long experienceId,
@@ -174,7 +174,7 @@ public class BoothExperienceController {
     // 8. 예약 상태 변경 (부스 담당자)
     @Operation(summary = "예약 상태 변경", description = "부스 담당자가 예약의 상태를 변경합니다.")
     @PutMapping("/reservations/{reservationId}/status")
-    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
+    @PreAuthorize("hasAuthority('ADMIN') or hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     @FunctionAuth("updateReservationStatus")
     public ResponseEntity<BoothExperienceReservationResponseDto> updateReservationStatus(
             @Parameter(description = "예약 ID") @PathVariable Long reservationId,
@@ -237,7 +237,7 @@ public class BoothExperienceController {
     // 12. 권한별 관리 가능한 부스 목록 조회 (체험 등록용)
     @Operation(summary = "관리 가능한 부스 목록 조회", description = "사용자 권한에 따라 관리 가능한 부스 목록을 조회합니다.")
     @GetMapping("/manageable-booths")
-    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
+    @PreAuthorize("hasAuthority('ADMIN') or hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     @FunctionAuth("getManageableBooths")
     public ResponseEntity<List<BoothResponseDto>> getManageableBooths(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -253,7 +253,7 @@ public class BoothExperienceController {
     // 13. 권한별 관리 가능한 체험 목록 조회 (체험 관리용)
     @Operation(summary = "관리 가능한 체험 목록 조회", description = "사용자 권한에 따라 관리 가능한 모든 체험 목록을 조회합니다.")
     @GetMapping("/manageable-experiences")
-    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
+    @PreAuthorize("hasAuthority('ADMIN') or hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     public ResponseEntity<List<BoothExperienceResponseDto>> getManageableExperiences(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
@@ -268,7 +268,7 @@ public class BoothExperienceController {
     // 14. 예약자 관리용 목록 조회 (필터링 지원)
     @Operation(summary = "예약자 관리 목록 조회", description = "행사/부스 담당자가 예약자를 관리하기 위한 목록을 조회합니다.")
     @GetMapping("/reservations/management")
-    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
+    @PreAuthorize("hasAuthority('ADMIN') or hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     // @FunctionAuth("getReservationsForManagement") // 임시로 권한 체크 제거
     public ResponseEntity<Page<ReservationManagementResponseDto>> getReservationsForManagement(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -306,7 +306,7 @@ public class BoothExperienceController {
     // 15. 부스 체험 현황 요약 조회
     @Operation(summary = "부스 체험 현황 요약", description = "특정 체험의 현재 상황을 요약해서 조회합니다.")
     @GetMapping("/{experienceId}/summary")
-    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
+    @PreAuthorize("hasAuthority('ADMIN') or hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     // @FunctionAuth("getExperienceSummary") // 임시로 권한 체크 제거
     public ResponseEntity<BoothExperienceSummaryDto> getExperienceSummary(
             @Parameter(description = "체험 ID") @PathVariable Long experienceId,
@@ -322,7 +322,7 @@ public class BoothExperienceController {
     // 16. 예약 관리용 부스 목록 조회
     @Operation(summary = "예약 관리용 부스 목록", description = "예약자 관리 화면에서 사용할 부스 목록을 조회합니다.")
     @GetMapping("/manageable-booths-for-reservation")
-    @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
+    @PreAuthorize("hasAuthority('ADMIN') or hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
     // @FunctionAuth("getManageableBoothsForReservation") // 임시로 권한 체크 제거
     public ResponseEntity<List<BoothResponseDto>> getManageableBoothsForReservation(
             @AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/src/main/java/com/fairing/fairplay/booth/controller/BoothQrController.java
+++ b/src/main/java/com/fairing/fairplay/booth/controller/BoothQrController.java
@@ -22,7 +22,7 @@ public class BoothQrController {
   private final BoothQrService boothQrService;
 
   @PostMapping
-  @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
+  @PreAuthorize("hasAuthority('ADMIN') or hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
   public ResponseEntity<BoothEntryResponseDto> boothEntry(
       @RequestBody BoothEntryRequestDto dto,
       @AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/src/main/java/com/fairing/fairplay/booth/controller/BoothQrController.java
+++ b/src/main/java/com/fairing/fairplay/booth/controller/BoothQrController.java
@@ -4,10 +4,10 @@ import com.fairing.fairplay.booth.dto.BoothEntryRequestDto;
 import com.fairing.fairplay.booth.dto.BoothEntryResponseDto;
 import com.fairing.fairplay.booth.service.BoothQrService;
 import com.fairing.fairplay.core.security.CustomUserDetails;
-import com.fairing.fairplay.qr.dto.scan.CheckResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,7 +22,11 @@ public class BoothQrController {
   private final BoothQrService boothQrService;
 
   @PostMapping
-  public ResponseEntity<BoothEntryResponseDto> boothEntry(@RequestBody BoothEntryRequestDto dto) {
-    return ResponseEntity.status(HttpStatus.OK).body(boothQrService.checkIn(dto));
+  @PreAuthorize("hasAuthority('EVENT_MANAGER') or hasAuthority('BOOTH_MANAGER')")
+  public ResponseEntity<BoothEntryResponseDto> boothEntry(
+      @RequestBody BoothEntryRequestDto dto,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    return ResponseEntity.status(HttpStatus.OK).body(
+        boothQrService.checkIn(dto, userDetails.getUserId(), userDetails.getRoleCode()));
   }
 }

--- a/src/main/java/com/fairing/fairplay/booth/service/BoothExperienceService.java
+++ b/src/main/java/com/fairing/fairplay/booth/service/BoothExperienceService.java
@@ -39,6 +39,7 @@ public class BoothExperienceService {
 
   private static final String ROLE_EVENT_MANAGER = "EVENT_MANAGER";
   private static final String ROLE_BOOTH_MANAGER = "BOOTH_MANAGER";
+  private static final String ROLE_ADMIN = "ADMIN";
 
   private final BoothExperienceRepository boothExperienceRepository;
   private final BoothExperienceReservationRepository reservationRepository;
@@ -811,6 +812,10 @@ public class BoothExperienceService {
   }
 
   private void validateBoothManagementAccess(Booth booth, Long userId, String roleCode) {
+    if (ROLE_ADMIN.equals(roleCode)) {
+      return;
+    }
+
     if (ROLE_EVENT_MANAGER.equals(roleCode)) {
       Long managerId = Optional.ofNullable(booth.getEvent())
           .map(Event::getManager)

--- a/src/main/java/com/fairing/fairplay/booth/service/BoothExperienceService.java
+++ b/src/main/java/com/fairing/fairplay/booth/service/BoothExperienceService.java
@@ -36,6 +36,9 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class BoothExperienceService {
 
+  private static final String ROLE_EVENT_MANAGER = "EVENT_MANAGER";
+  private static final String ROLE_BOOTH_MANAGER = "BOOTH_MANAGER";
+
   private final BoothExperienceRepository boothExperienceRepository;
   private final BoothExperienceReservationRepository reservationRepository;
   private final BoothExperienceStatusCodeRepository statusCodeRepository;
@@ -46,11 +49,12 @@ public class BoothExperienceService {
   // 1. 부스 체험 등록 (부스 담당자)
   @Transactional
   public BoothExperienceResponseDto createBoothExperience(Long boothId,
-      BoothExperienceRequestDto requestDto) {
+      BoothExperienceRequestDto requestDto, Long userId, String roleCode) {
     log.info("부스 체험 등록 시작 - 부스 ID: {}", boothId);
 
     Booth booth = boothRepository.findById(boothId)
         .orElseThrow(() -> new IllegalArgumentException("부스를 찾을 수 없습니다: " + boothId));
+    validateBoothManagementAccess(booth, userId, roleCode);
 
     BoothExperience experience = BoothExperience.builder().booth(booth).title(requestDto.getTitle())
         .description(requestDto.getDescription()).experienceDate(requestDto.getExperienceDate())
@@ -77,14 +81,12 @@ public class BoothExperienceService {
 
     List<BoothExperience> experiences;
 
-    if ("EVENT_MANAGER".equals(roleCode)) {
-      // 행사 담당자: 해당 사용자가 관리하는 행사의 모든 부스 체험 조회
-      experiences = boothExperienceRepository.findByEventManagerId(userId);
-      log.info("EVENT_MANAGER - 관리 행사의 모든 체험 조회: {}개", experiences.size());
-    } else if ("BOOTH_MANAGER".equals(roleCode)) {
-      // 부스 담당자: 해당 사용자가 관리하는 부스의 체험만 조회
-      experiences = boothExperienceRepository.findByBoothAdminId(userId);
-      log.info("BOOTH_MANAGER - 관리 부스의 체험만 조회: {}개", experiences.size());
+    if (ROLE_EVENT_MANAGER.equals(roleCode) || ROLE_BOOTH_MANAGER.equals(roleCode)) {
+      Booth booth = boothRepository.findById(boothId)
+          .orElseThrow(() -> new IllegalArgumentException("부스를 찾을 수 없습니다: " + boothId));
+      validateBoothManagementAccess(booth, userId, roleCode);
+      experiences = boothExperienceRepository.findByBooth_Id(boothId);
+      log.info("관리 가능한 부스 체험 조회: {}개", experiences.size());
     } else {
       // 기타 권한: 빈 목록 반환
       log.warn("권한 없음 - 빈 목록 반환, 권한: {}", roleCode);
@@ -266,11 +268,12 @@ public class BoothExperienceService {
   // 3-2. 부스 체험 수정 (부스 담당자)
   @Transactional
   public BoothExperienceResponseDto updateBoothExperience(Long experienceId,
-      BoothExperienceRequestDto requestDto) {
+      BoothExperienceRequestDto requestDto, Long userId, String roleCode) {
     log.info("부스 체험 수정 시작 - 체험 ID: {}", experienceId);
 
     BoothExperience experience = boothExperienceRepository.findById(experienceId)
         .orElseThrow(() -> new IllegalArgumentException("체험을 찾을 수 없습니다: " + experienceId));
+    validateExperienceManagementAccess(experience, userId, roleCode);
 
     // 기존 예약이 있는 경우 수정 제한 검증
     validateExperienceModification(experience);
@@ -294,11 +297,12 @@ public class BoothExperienceService {
 
   // 3-3. 부스 체험 삭제 (부스 담당자)
   @Transactional
-  public void deleteBoothExperience(Long experienceId) {
+  public void deleteBoothExperience(Long experienceId, Long userId, String roleCode) {
     log.info("부스 체험 삭제 시작 - 체험 ID: {}", experienceId);
 
     BoothExperience experience = boothExperienceRepository.findById(experienceId)
         .orElseThrow(() -> new IllegalArgumentException("체험을 찾을 수 없습니다: " + experienceId));
+    validateExperienceManagementAccess(experience, userId, roleCode);
 
     // 활성 예약이 있는지 확인
     List<BoothExperienceReservation> activeReservations = reservationRepository.findActiveReservationsByExperience(
@@ -382,6 +386,20 @@ public class BoothExperienceService {
 
   // 5. 부스 체험 예약자 목록 조회 (부스 담당자용)
   @Transactional(readOnly = true)
+  public List<BoothExperienceReservationResponseDto> getExperienceReservations(Long experienceId,
+      Long userId, String roleCode) {
+    BoothExperience experience = boothExperienceRepository.findById(experienceId)
+        .orElseThrow(() -> new IllegalArgumentException("체험을 찾을 수 없습니다: " + experienceId));
+    validateExperienceManagementAccess(experience, userId, roleCode);
+
+    List<BoothExperienceReservation> reservations = reservationRepository.findByBoothExperienceOrderByReservedAt(
+        experience);
+
+    return reservations.stream().map(BoothExperienceReservationResponseDto::fromEntity)
+        .collect(Collectors.toList());
+  }
+
+  @Transactional(readOnly = true)
   public List<BoothExperienceReservationResponseDto> getExperienceReservations(Long experienceId) {
     BoothExperience experience = boothExperienceRepository.findById(experienceId)
         .orElseThrow(() -> new IllegalArgumentException("체험을 찾을 수 없습니다: " + experienceId));
@@ -408,11 +426,29 @@ public class BoothExperienceService {
   // 7. 부스 체험 상태 변경 (부스 담당자)
   @Transactional
   public BoothExperienceReservationResponseDto updateReservationStatus(Long reservationId,
+      BoothExperienceStatusUpdateDto updateDto, Long userId, String roleCode) {
+    log.info("예약 상태 변경 권한 확인 - 예약 ID: {}, 사용자 ID: {}, 권한: {}", reservationId, userId, roleCode);
+
+    BoothExperienceReservation reservation = reservationRepository.findById(reservationId)
+        .orElseThrow(() -> new IllegalArgumentException("예약을 찾을 수 없습니다: " + reservationId));
+    validateExperienceManagementAccess(reservation.getBoothExperience(), userId, roleCode);
+
+    return updateReservationStatus(reservation, reservationId, updateDto);
+  }
+
+  @Transactional
+  public BoothExperienceReservationResponseDto updateReservationStatus(Long reservationId,
       BoothExperienceStatusUpdateDto updateDto) {
     log.info("예약 상태 변경 시작 - 예약 ID: {}, 새 상태: {}", reservationId, updateDto.getStatusCode());
 
     BoothExperienceReservation reservation = reservationRepository.findById(reservationId)
         .orElseThrow(() -> new IllegalArgumentException("예약을 찾을 수 없습니다: " + reservationId));
+
+    return updateReservationStatus(reservation, reservationId, updateDto);
+  }
+
+  private BoothExperienceReservationResponseDto updateReservationStatus(
+      BoothExperienceReservation reservation, Long reservationId, BoothExperienceStatusUpdateDto updateDto) {
 
     BoothExperienceStatusCode newStatus = statusCodeRepository.findByCode(updateDto.getStatusCode())
         .orElseThrow(
@@ -718,11 +754,13 @@ public class BoothExperienceService {
 
   // 부스 체험 현황 요약 조회
   @Transactional(readOnly = true)
-  public BoothExperienceSummaryDto getExperienceSummary(Long experienceId) {
+  public BoothExperienceSummaryDto getExperienceSummary(Long experienceId, Long userId,
+      String roleCode) {
     log.info("부스 체험 현황 요약 조회 - 체험 ID: {}", experienceId);
 
     BoothExperience experience = boothExperienceRepository.findById(experienceId)
         .orElseThrow(() -> new IllegalArgumentException("체험을 찾을 수 없습니다: " + experienceId));
+    validateExperienceManagementAccess(experience, userId, roleCode);
 
     // 현재 체험중인 인원 조회
     List<BoothExperienceReservation> currentParticipants = reservationRepository.findByBoothExperienceAndStatusCode(
@@ -756,6 +794,40 @@ public class BoothExperienceService {
         .waitingCount(waitingParticipants.size()).currentParticipantNames(currentParticipantNames)
         .nextParticipantName(nextParticipantName).congestionRate(experience.getCongestionRate())
         .isReservationAvailable(experience.isReservationAvailable()).build();
+  }
+
+  private void validateExperienceManagementAccess(BoothExperience experience, Long userId,
+      String roleCode) {
+    validateBoothManagementAccess(experience.getBooth(), userId, roleCode);
+  }
+
+  private void validateBoothManagementAccess(Booth booth, Long userId, String roleCode) {
+    if (ROLE_EVENT_MANAGER.equals(roleCode)) {
+      Long managerId = Optional.ofNullable(booth.getEvent())
+          .map(Event::getManager)
+          .map(manager -> manager.getUserId())
+          .orElse(null);
+      if (userId != null && userId.equals(managerId)) {
+        return;
+      }
+      log.info("담당 행사 관리자가 아님: boothId={}, managerId={}, userId={}", booth.getId(), managerId,
+          userId);
+      throw new CustomException(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+    }
+
+    if (ROLE_BOOTH_MANAGER.equals(roleCode)) {
+      Long managerId = Optional.ofNullable(booth.getBoothAdmin())
+          .map(boothAdmin -> boothAdmin.getUserId())
+          .orElse(null);
+      if (userId != null && userId.equals(managerId)) {
+        return;
+      }
+      log.info("담당 부스 관리자가 아님: boothId={}, managerId={}, userId={}", booth.getId(), managerId,
+          userId);
+      throw new CustomException(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+    }
+
+    throw new CustomException(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
   }
 
   // 예약 관리용 부스 목록 조회 (간소화된 버전)

--- a/src/main/java/com/fairing/fairplay/booth/service/BoothExperienceService.java
+++ b/src/main/java/com/fairing/fairplay/booth/service/BoothExperienceService.java
@@ -83,7 +83,10 @@ public class BoothExperienceService {
 
     List<BoothExperience> experiences;
 
-    if (ROLE_EVENT_MANAGER.equals(roleCode) || ROLE_BOOTH_MANAGER.equals(roleCode)) {
+    if (ROLE_ADMIN.equals(roleCode)) {
+      experiences = boothExperienceRepository.findByBooth_Id(boothId);
+      log.info("ADMIN - 요청 부스 체험 조회: {}개", experiences.size());
+    } else if (ROLE_EVENT_MANAGER.equals(roleCode) || ROLE_BOOTH_MANAGER.equals(roleCode)) {
       Booth booth = boothRepository.findById(boothId)
           .orElseThrow(() -> new IllegalArgumentException("부스를 찾을 수 없습니다: " + boothId));
       validateBoothManagementAccess(booth, userId, roleCode);
@@ -712,7 +715,11 @@ public class BoothExperienceService {
 
     List<BoothExperience> experiences;
 
-    if ("EVENT_MANAGER".equals(roleCode)) {
+    if (ROLE_ADMIN.equals(roleCode)) {
+      // 관리자: 모든 부스 체험 조회
+      experiences = boothExperienceRepository.findAll();
+      log.info("ADMIN - 모든 체험 조회: {}개", experiences.size());
+    } else if ("EVENT_MANAGER".equals(roleCode)) {
       // 행사 담당자: 해당 사용자가 관리하는 행사의 모든 부스 체험 조회
       experiences = boothExperienceRepository.findByEventManagerId(userId);
       log.info("EVENT_MANAGER - 관리 행사의 모든 체험 조회: {}개", experiences.size());

--- a/src/main/java/com/fairing/fairplay/booth/service/BoothExperienceService.java
+++ b/src/main/java/com/fairing/fairplay/booth/service/BoothExperienceService.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -351,8 +352,10 @@ public class BoothExperienceService {
 
   // 4. 부스 체험 예약 신청 (참여자) - 동시성 처리
   @Transactional
-  public BoothExperienceReservationResponseDto createReservation(Long experienceId, Long userId,
+  public BoothExperienceReservationResponseDto createReservation(Long experienceId, CustomUserDetails userDetails,
       BoothExperienceReservationRequestDto requestDto) {
+    requireAuthenticated(userDetails);
+    Long userId = userDetails.getUserId();
     log.info("부스 체험 예약 시작 - 체험 ID: {}, 사용자 ID: {}", experienceId, userId);
 
     // Pessimistic Lock으로 체험 조회 (동시성 제어)
@@ -382,6 +385,12 @@ public class BoothExperienceService {
     // 현재 내 예약의 순번 실시간 알림
     waitingNotification(userId, savedReservation.getQueuePosition(), "");
     return BoothExperienceReservationResponseDto.fromEntity(savedReservation);
+  }
+
+  private void requireAuthenticated(CustomUserDetails userDetails) {
+    if (userDetails == null || userDetails.getUserId() == null) {
+      throw new AccessDeniedException("로그인이 필요합니다.");
+    }
   }
 
   // 5. 부스 체험 예약자 목록 조회 (부스 담당자용)

--- a/src/main/java/com/fairing/fairplay/booth/service/BoothQrService.java
+++ b/src/main/java/com/fairing/fairplay/booth/service/BoothQrService.java
@@ -8,7 +8,6 @@ import com.fairing.fairplay.booth.entity.BoothExperienceReservation;
 import com.fairing.fairplay.booth.entity.BoothExperienceStatusCode;
 import com.fairing.fairplay.booth.repository.BoothExperienceStatusCodeRepository;
 import com.fairing.fairplay.common.exception.CustomException;
-import com.fairing.fairplay.core.security.CustomUserDetails;
 import com.fairing.fairplay.qr.dto.scan.CheckResponseDto;
 import com.fairing.fairplay.qr.entity.QrTicket;
 import com.fairing.fairplay.qr.service.QrTicketEntryService;
@@ -34,7 +33,7 @@ public class BoothQrService {
 
   // QR 티켓을 통한 부스 입장 처리
   @Transactional
-  public BoothEntryResponseDto checkIn(BoothEntryRequestDto dto) {
+  public BoothEntryResponseDto checkIn(BoothEntryRequestDto dto, Long managerId, String roleCode) {
     // 2. 필수 값 확인
     if (dto.getBoothExperienceId() == null || dto.getBoothId() == null || dto.getEventId() == null
         ||  dto.getQrCode() == null) {
@@ -66,7 +65,9 @@ public class BoothQrService {
         .build();
     BoothExperienceReservationResponseDto boothExperienceReservationResponseDto = boothExperienceService.updateReservationStatus(
         boothExperienceReservation.getReservationId(),
-        boothExperienceStatusUpdateDto);
+        boothExperienceStatusUpdateDto,
+        managerId,
+        roleCode);
     CheckResponseDto checkResponseDto = qrTicketEntryService.processQrEntry(qrTicket);
     BoothEntryResponseDto response = BoothEntryResponseDto.builder()
         .name(boothExperienceReservationResponseDto.getUserName())
@@ -77,19 +78,7 @@ public class BoothQrService {
     return response;
   }
 
-  private Users validateUser(CustomUserDetails userDetails) {
-    if (userDetails == null || userDetails.getUserId() == null) {
-      throw new CustomException(HttpStatus.UNAUTHORIZED, "로그인한 사용자만 QR 스캔할 수 있습니다.");
-    }
-    return userRepository.findById(userDetails.getUserId()).orElseThrow(
-        () -> new CustomException(HttpStatus.NOT_FOUND, "해당 사용자를 찾을 수 없습니다.")
-    );
-  }
-
   private void checkInBooth(Long qrTicketId) {
     messagingTemplate.convertAndSend("/topic/booth/qr/"+qrTicketId, "부스 입장 완료");
   }
 }
-
-
-

--- a/src/main/java/com/fairing/fairplay/event/service/EventManagerService.java
+++ b/src/main/java/com/fairing/fairplay/event/service/EventManagerService.java
@@ -2,6 +2,8 @@ package com.fairing.fairplay.event.service;
 
 import com.fairing.fairplay.event.entity.Event;
 import com.fairing.fairplay.event.repository.EventManagerRepository;
+import com.fairing.fairplay.payment.entity.Refund;
+import com.fairing.fairplay.payment.repository.RefundRepository;
 import com.fairing.fairplay.user.entity.Users;
 import com.fairing.fairplay.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +19,7 @@ public class EventManagerService {
 
     private final EventManagerRepository eventManagerRepository;
     private final UserRepository userRepository;
+    private final RefundRepository refundRepository;
 
     /**
      * 사용자가 관리하는 이벤트 ID 목록 조회
@@ -61,11 +64,16 @@ public class EventManagerService {
      */
     @Transactional(readOnly = true)
     public boolean isRefundInManagedEvent(Long refundId, Long managerId) {
-        List<Long> managedEventIds = getManagedEventIds(managerId);
-        
-        // 환불의 이벤트 ID를 조회하는 쿼리 필요
-        // 현재는 간단한 구현으로 대체
-        return true; // TODO: 실제 검증 로직 구현
+        Refund refund = refundRepository.findById(refundId)
+                .orElseThrow(() -> new IllegalArgumentException("환불 요청을 찾을 수 없습니다: " + refundId));
+
+        if (refund.getPayment() == null || refund.getPayment().getEvent() == null) {
+            return false;
+        }
+
+        Event event = refund.getPayment().getEvent();
+        Long eventManagerUserId = event.getManager() != null ? event.getManager().getUserId() : null;
+        return managerId != null && managerId.equals(eventManagerUserId);
     }
 
     /**

--- a/src/main/java/com/fairing/fairplay/payment/controller/PaymentController.java
+++ b/src/main/java/com/fairing/fairplay/payment/controller/PaymentController.java
@@ -3,6 +3,7 @@ package com.fairing.fairplay.payment.controller;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -181,8 +182,13 @@ public class PaymentController {
     @FunctionAuth("updatePaymentTargetId")
     public ResponseEntity<Void> updatePaymentTargetId(
             @PathVariable String merchantUid,
-            @RequestBody TargetIdUpdateRequest request) {
-        paymentService.updatePaymentTargetId(merchantUid, request.getTargetId());
+            @RequestBody TargetIdUpdateRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        if (userDetails == null) {
+            throw new AccessDeniedException("인증되지 않은 사용자입니다.");
+        }
+
+        paymentService.updatePaymentTargetId(merchantUid, request.getTargetId(), userDetails);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/fairing/fairplay/payment/controller/RefundController.java
+++ b/src/main/java/com/fairing/fairplay/payment/controller/RefundController.java
@@ -1,12 +1,12 @@
 package com.fairing.fairplay.payment.controller;
 
-import com.fairing.fairplay.core.etc.FunctionAuth;
 import com.fairing.fairplay.core.security.CustomUserDetails;
 import com.fairing.fairplay.payment.dto.*;
 import com.fairing.fairplay.payment.service.RefundService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -35,7 +35,7 @@ public class RefundController {
 
     // 2단계: 티켓 환불 승인 (관리자가 환불 승인)
     @PostMapping("/{refundId}/approve")
-    @FunctionAuth("approveRefund")
+    @PreAuthorize("hasAnyAuthority('ADMIN','EVENT_MANAGER')")
     public ResponseEntity<PaymentResponseDto> approveRefund(
             @PathVariable Long refundId,
             @RequestBody RefundApprovalDto approval,
@@ -44,13 +44,13 @@ public class RefundController {
             throw new IllegalArgumentException("인증되지 않은 사용자입니다.");
         }
 
-        PaymentResponseDto approvedRefund = refundService.approveRefund(refundId, approval, userDetails.getUserId());
+        PaymentResponseDto approvedRefund = refundService.approveRefund(refundId, approval, userDetails);
         return ResponseEntity.ok(approvedRefund);
     }
 
     // 티켓 환불 거절 (관리자가 환불 거절)
     @PostMapping("/{refundId}/reject")
-    @FunctionAuth("rejectRefund")
+    @PreAuthorize("hasAnyAuthority('ADMIN','EVENT_MANAGER')")
     public ResponseEntity<PaymentResponseDto> rejectRefund(
             @PathVariable Long refundId,
             @RequestBody(required = false) String rejectReason,
@@ -59,13 +59,13 @@ public class RefundController {
             throw new IllegalArgumentException("인증되지 않은 사용자입니다.");
         }
 
-        PaymentResponseDto rejectedRefund = refundService.rejectRefund(refundId, rejectReason, userDetails.getUserId());
+        PaymentResponseDto rejectedRefund = refundService.rejectRefund(refundId, rejectReason, userDetails);
         return ResponseEntity.ok(rejectedRefund);
     }
 
     // 환불 요청 목록 조회 (관리자용)
     @GetMapping
-    @FunctionAuth("getAllRefunds")
+    @PreAuthorize("hasAnyAuthority('ADMIN','EVENT_MANAGER')")
     public ResponseEntity<List<RefundResponseDto>> getAllRefunds(
             @RequestParam(required = false) Long eventId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -88,7 +88,7 @@ public class RefundController {
 
     // 대기 중인 환불 요청 조회 (관리자용)
     @GetMapping("/pending")
-    @FunctionAuth("getPendingRefunds")
+    @PreAuthorize("hasAnyAuthority('ADMIN','EVENT_MANAGER')")
     public ResponseEntity<List<RefundResponseDto>> getPendingRefunds(
             @RequestParam(required = false) Long eventId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -102,12 +102,12 @@ public class RefundController {
 
     // 환불 목록 조회 (필터링 및 페이징 지원)
     @PostMapping("/list")
-    // @FunctionAuth("getRefundList") // 임시로 주석 처리
+    @PreAuthorize("hasAnyAuthority('ADMIN','EVENT_MANAGER')")
     public ResponseEntity<Page<RefundListResponseDto>> getRefundList(
             @RequestBody RefundListRequestDto request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         
-        Page<RefundListResponseDto> refundList = refundService.getRefundList(request);
+        Page<RefundListResponseDto> refundList = refundService.getRefundList(request, userDetails);
         return ResponseEntity.ok(refundList);
     }
 

--- a/src/main/java/com/fairing/fairplay/payment/dto/RefundResponseDto.java
+++ b/src/main/java/com/fairing/fairplay/payment/dto/RefundResponseDto.java
@@ -39,7 +39,7 @@ public class RefundResponseDto {
         return RefundResponseDto.builder()
                 .refundId(refund.getRefundId())
                 .paymentId(refund.getPayment().getPaymentId())
-                .eventId(refund.getPayment().getEvent().getEventId())
+                .eventId(refund.getPayment().getEvent() != null ? refund.getPayment().getEvent().getEventId() : null)
                 .userId(refund.getPayment().getUser().getUserId())
                 .merchantUid(refund.getPayment().getMerchantUid())
                 .refundAmount(refund.getAmount())

--- a/src/main/java/com/fairing/fairplay/payment/repository/PaymentAdminRepositoryImpl.java
+++ b/src/main/java/com/fairing/fairplay/payment/repository/PaymentAdminRepositoryImpl.java
@@ -71,10 +71,7 @@ public class PaymentAdminRepositoryImpl implements PaymentAdminRepository {
         
         // 권한 체크: EVENT_MANAGER인 경우 managerId 조건 추가
         if (managerId != null) {
-            whereClause.and(
-                payment.event.isNull() // 이벤트와 무관한 결제 (광고 등)
-                .or(payment.event.manager.userId.eq(managerId)) // 또는 본인이 관리하는 이벤트
-            );
+            whereClause.and(payment.event.manager.userId.eq(managerId));
         }
 
         Payment result = queryFactory
@@ -215,10 +212,7 @@ public class PaymentAdminRepositoryImpl implements PaymentAdminRepository {
 
         // 권한 필터링 (EVENT_MANAGER인 경우)
         if (managerId != null) {
-            whereClause.and(
-                payment.event.isNull() // 이벤트와 무관한 결제 (광고 등)
-                .or(payment.event.manager.userId.eq(managerId)) // 또는 본인이 관리하는 이벤트
-            );
+            whereClause.and(payment.event.manager.userId.eq(managerId));
         }
 
         // 결제 타입 필터링

--- a/src/main/java/com/fairing/fairplay/payment/repository/RefundRepository.java
+++ b/src/main/java/com/fairing/fairplay/payment/repository/RefundRepository.java
@@ -30,12 +30,21 @@ public interface RefundRepository extends JpaRepository<Refund, Long> {
     @Query("SELECT r FROM Refund r WHERE r.payment.event.eventId = :eventId")
     List<Refund> findByEventId(@Param("eventId") Long eventId);
 
+    @Query("SELECT r FROM Refund r WHERE r.payment.event.manager.user.userId = :managerUserId")
+    List<Refund> findByEventManagerUserId(@Param("managerUserId") Long managerUserId);
+
     // 특정 상태의 환불 목록 조회 (FK 기반)
     List<Refund> findByRefundStatusCode(RefundStatusCode refundStatusCode);
 
     // 특정 이벤트의 특정 상태 환불 목록 조회 (FK 기반)
     @Query("SELECT r FROM Refund r WHERE r.payment.event.eventId = :eventId AND r.refundStatusCode = :refundStatusCode")
     List<Refund> findByEventIdAndRefundStatusCode(@Param("eventId") Long eventId, @Param("refundStatusCode") RefundStatusCode refundStatusCode);
+
+    @Query("SELECT r FROM Refund r WHERE r.payment.event.manager.user.userId = :managerUserId AND r.refundStatusCode = :refundStatusCode")
+    List<Refund> findByEventManagerUserIdAndRefundStatusCode(
+        @Param("managerUserId") Long managerUserId,
+        @Param("refundStatusCode") RefundStatusCode refundStatusCode
+    );
 
     // 환불 목록 조회 (필터링 및 페이징 지원)
     @Query("""
@@ -74,6 +83,7 @@ public interface RefundRepository extends JpaRepository<Refund, Long> {
         AND (:paymentDateTo IS NULL OR p.paidAt <= :paymentDateTo)
         AND (:refundStatus IS NULL OR rsc.code = :refundStatus)
         AND (:paymentTargetType IS NULL OR ptt.paymentTargetCode = :paymentTargetType)
+        AND (:managerUserId IS NULL OR e.manager.user.userId = :managerUserId)
     """)
     Page<RefundListResponseDto> findRefundsWithFilters(
         @Param("eventName") String eventName,
@@ -81,6 +91,7 @@ public interface RefundRepository extends JpaRepository<Refund, Long> {
         @Param("paymentDateTo") LocalDateTime paymentDateTo,
         @Param("refundStatus") String refundStatus,
         @Param("paymentTargetType") String paymentTargetType,
+        @Param("managerUserId") Long managerUserId,
         Pageable pageable
     );
 

--- a/src/main/java/com/fairing/fairplay/payment/repository/RefundRepository.java
+++ b/src/main/java/com/fairing/fairplay/payment/repository/RefundRepository.java
@@ -140,6 +140,7 @@ public interface RefundRepository extends JpaRepository<Refund, Long> {
         AND (:refundStatus IS NULL OR rsc.code = :refundStatus)
         AND (:paymentTargetType IS NULL OR ptt.paymentTargetCode = :paymentTargetType)
         AND (:eventId IS NULL OR e.eventId = :eventId)
+        AND (:managerUserId IS NULL OR e.manager.user.userId = :managerUserId)
     """)
     Page<AdminRefundListResponseDto> findAdminRefundsWithFilters(
         @Param("eventName") String eventName,
@@ -149,6 +150,7 @@ public interface RefundRepository extends JpaRepository<Refund, Long> {
         @Param("refundStatus") String refundStatus,
         @Param("paymentTargetType") String paymentTargetType,
         @Param("eventId") Long eventId,
+        @Param("managerUserId") Long managerUserId,
         Pageable pageable
     );
 

--- a/src/main/java/com/fairing/fairplay/payment/service/AdminRefundService.java
+++ b/src/main/java/com/fairing/fairplay/payment/service/AdminRefundService.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +26,9 @@ import java.time.format.DateTimeFormatter;
 @Service
 @RequiredArgsConstructor
 public class AdminRefundService {
+
+    private static final String ROLE_ADMIN = "ADMIN";
+    private static final String ROLE_EVENT_MANAGER = "EVENT_MANAGER";
 
     private final RefundRepository refundRepository;
     private final RefundStatusCodeRepository refundStatusCodeRepository;
@@ -43,7 +47,8 @@ public class AdminRefundService {
         validateAdminAccess(userDetails);
         
         // 이벤트 관리자의 경우 자신이 관리하는 이벤트만 조회할 수 있도록 제한
-        Long eventId = getEventIdForUser(request.getEventId(), userDetails);
+        Long eventId = request.getEventId();
+        Long managerUserId = getManagerUserIdForFiltering(userDetails);
         
         // 날짜 파싱
         LocalDateTime paymentDateFrom = parseDateTime(request.getPaymentDateFrom());
@@ -68,6 +73,7 @@ public class AdminRefundService {
             request.getRefundStatus(),
             request.getPaymentTargetType(),
             eventId,
+            managerUserId,
             pageable
         );
     }
@@ -83,6 +89,7 @@ public class AdminRefundService {
         // 환불 정보 조회
         Refund refund = refundRepository.findById(refundId)
                 .orElseThrow(() -> new IllegalArgumentException("환불 요청을 찾을 수 없습니다: " + refundId));
+        validateRefundAccess(refund, userDetails);
         
         // 현재 상태 검증
         if (!"REQUESTED".equals(refund.getRefundStatusCode().getCode())) {
@@ -135,6 +142,7 @@ public class AdminRefundService {
         // 환불 정보 조회
         Refund refund = refundRepository.findById(refundId)
                 .orElseThrow(() -> new IllegalArgumentException("환불 요청을 찾을 수 없습니다: " + refundId));
+        validateRefundAccess(refund, userDetails);
         
         // 현재 상태 검증
         if (!"REQUESTED".equals(refund.getRefundStatusCode().getCode())) {
@@ -203,24 +211,42 @@ public class AdminRefundService {
         }
         
         String roleCode = userDetails.getRoleCode();
-        if (!"ADMIN".equals(roleCode) && !"EVENT_MANAGER".equals(roleCode)) {
-            throw new IllegalArgumentException("환불 관리 권한이 없습니다.");
+        if (!ROLE_ADMIN.equals(roleCode) && !ROLE_EVENT_MANAGER.equals(roleCode)) {
+            throw new AccessDeniedException("환불 관리 권한이 없습니다.");
         }
     }
 
     /**
-     * 사용자 권한에 따른 이벤트 ID 제한
+     * 사용자 권한에 따른 관리자 필터링 값 결정
      */
-    private Long getEventIdForUser(Long requestedEventId, CustomUserDetails userDetails) {
-        if ("ADMIN".equals(userDetails.getRoleCode())) {
-            // 전체 관리자는 모든 이벤트 조회 가능
-            return requestedEventId;
-        } else if ("EVENT_MANAGER".equals(userDetails.getRoleCode())) {
-            // 이벤트 관리자는 특정 이벤트만 조회 가능
-            // TODO: 사용자가 관리하는 이벤트 ID 목록을 가져와서 검증
-            return requestedEventId;
+    private Long getManagerUserIdForFiltering(CustomUserDetails userDetails) {
+        if (ROLE_ADMIN.equals(userDetails.getRoleCode())) {
+            return null;
+        } else if (ROLE_EVENT_MANAGER.equals(userDetails.getRoleCode())) {
+            return userDetails.getUserId();
         }
-        return requestedEventId;
+        throw new AccessDeniedException("환불 관리 권한이 없습니다.");
+    }
+
+    private void validateRefundAccess(Refund refund, CustomUserDetails userDetails) {
+        if (ROLE_ADMIN.equals(userDetails.getRoleCode())) {
+            return;
+        }
+
+        if (!ROLE_EVENT_MANAGER.equals(userDetails.getRoleCode())) {
+            throw new AccessDeniedException("환불 관리 권한이 없습니다.");
+        }
+
+        if (refund.getPayment() == null || refund.getPayment().getEvent() == null) {
+            throw new AccessDeniedException("행사에 연결되지 않은 환불은 전체 관리자만 처리할 수 있습니다.");
+        }
+
+        Long managerUserId = refund.getPayment().getEvent().getManager() != null
+                ? refund.getPayment().getEvent().getManager().getUserId()
+                : null;
+        if (!userDetails.getUserId().equals(managerUserId)) {
+            throw new AccessDeniedException("담당 행사의 환불만 처리할 수 있습니다.");
+        }
     }
 
     /**

--- a/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
+++ b/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
@@ -40,6 +40,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,6 +53,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 
 @Service
@@ -279,10 +281,14 @@ public class PaymentService {
             if (eventId == null) {
                 throw new IllegalArgumentException("행사 관리자는 eventId가 필요합니다.");
             }
-            // TODO: 사용자가 관리하는 이벤트인지 검증 필요
+            Event event = eventRepository.findById(eventId)
+                    .orElseThrow(() -> new IllegalArgumentException("이벤트를 찾을 수 없습니다."));
+            if (!isManagedBy(event, userId)) {
+                throw new AccessDeniedException("담당 행사 결제만 조회할 수 있습니다.");
+            }
             payments = paymentRepository.findByEvent_EventId(eventId);
         } else {
-            throw new IllegalArgumentException("결제 전체 조회 권한이 없습니다.");
+            throw new AccessDeniedException("결제 전체 조회 권한이 없습니다.");
         }
 
         return PaymentResponseDto.fromEntityList(payments);
@@ -309,12 +315,46 @@ public class PaymentService {
 
     // 결제의 targetId 업데이트
     @Transactional
-    public void updatePaymentTargetId(String merchantUid, Long targetId) {
+    public void updatePaymentTargetId(String merchantUid, Long targetId, CustomUserDetails userDetails) {
+        if (userDetails == null) {
+            throw new AccessDeniedException("인증되지 않은 사용자입니다.");
+        }
+
         Payment payment = paymentRepository.findByMerchantUid(merchantUid)
                 .orElseThrow(() -> new IllegalArgumentException("결제 정보를 찾을 수 없습니다: " + merchantUid));
 
+        validatePaymentTargetUpdatePermission(payment, targetId, userDetails);
+
         payment.setTargetId(targetId);
         paymentRepository.save(payment);
+    }
+
+    private void validatePaymentTargetUpdatePermission(Payment payment, Long requestedTargetId, CustomUserDetails userDetails) {
+        Long currentTargetId = payment.getTargetId();
+        if (currentTargetId != null && !Objects.equals(currentTargetId, requestedTargetId)) {
+            throw new AccessDeniedException("이미 다른 대상에 연결된 결제입니다.");
+        }
+
+        String roleCode = userDetails.getRoleCode();
+        if ("ADMIN".equals(roleCode)) {
+            return;
+        }
+
+        if ("COMMON".equals(roleCode)) {
+            Long paymentUserId = payment.getUser() != null ? payment.getUser().getUserId() : null;
+            if (Objects.equals(paymentUserId, userDetails.getUserId())) {
+                return;
+            }
+            throw new AccessDeniedException("본인 결제만 대상 정보를 수정할 수 있습니다.");
+        }
+
+        throw new AccessDeniedException("결제 대상 정보 수정 권한이 없습니다.");
+    }
+
+    private boolean isManagedBy(Event event, Long managerUserId) {
+        return event != null
+                && event.getManager() != null
+                && Objects.equals(event.getManager().getUserId(), managerUserId);
     }
 
     /**

--- a/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
+++ b/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
@@ -343,12 +343,61 @@ public class PaymentService {
         if ("COMMON".equals(roleCode)) {
             Long paymentUserId = payment.getUser() != null ? payment.getUser().getUserId() : null;
             if (Objects.equals(paymentUserId, userDetails.getUserId())) {
+                validateCommonTargetOwnership(payment, requestedTargetId, userDetails.getUserId());
                 return;
             }
             throw new AccessDeniedException("본인 결제만 대상 정보를 수정할 수 있습니다.");
         }
 
         throw new AccessDeniedException("결제 대상 정보 수정 권한이 없습니다.");
+    }
+
+    private void validateCommonTargetOwnership(Payment payment, Long requestedTargetId, Long principalUserId) {
+        if (requestedTargetId == null) {
+            throw new AccessDeniedException("결제 대상 정보가 필요합니다.");
+        }
+
+        String targetCode = payment.getPaymentTargetType() != null
+                ? payment.getPaymentTargetType().getPaymentTargetCode()
+                : null;
+
+        switch (targetCode) {
+            case "RESERVATION" -> validateReservationOwner(requestedTargetId, principalUserId);
+            case "BANNER_APPLICATION" -> validateBannerApplicationOwner(requestedTargetId, principalUserId);
+            case "BOOTH_APPLICATION" -> validateBoothApplicationOwner(requestedTargetId, principalUserId);
+            case "BOOTH", "AD" -> throw new AccessDeniedException("해당 결제 대상은 외부 대상 정보 수정이 허용되지 않습니다.");
+            default -> throw new AccessDeniedException("지원하지 않는 결제 대상 타입입니다.");
+        }
+    }
+
+    private void validateReservationOwner(Long reservationId, Long principalUserId) {
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new AccessDeniedException("본인 예약만 결제 대상에 연결할 수 있습니다."));
+        Long reservationUserId = reservation.getUser() != null ? reservation.getUser().getUserId() : null;
+        if (!Objects.equals(reservationUserId, principalUserId)) {
+            throw new AccessDeniedException("본인 예약만 결제 대상에 연결할 수 있습니다.");
+        }
+    }
+
+    private void validateBannerApplicationOwner(Long bannerApplicationId, Long principalUserId) {
+        BannerApplication bannerApplication = bannerApplicationRepository.findById(bannerApplicationId)
+                .orElseThrow(() -> new AccessDeniedException("본인 배너 신청만 결제 대상에 연결할 수 있습니다."));
+        Long applicantUserId = bannerApplication.getApplicantId() != null
+                ? bannerApplication.getApplicantId().getUserId()
+                : null;
+        if (!Objects.equals(applicantUserId, principalUserId)) {
+            throw new AccessDeniedException("본인 배너 신청만 결제 대상에 연결할 수 있습니다.");
+        }
+    }
+
+    private void validateBoothApplicationOwner(Long boothApplicationId, Long principalUserId) {
+        BoothApplication boothApplication = boothApplicationRepository.findById(boothApplicationId)
+                .orElseThrow(() -> new AccessDeniedException("본인 부스 신청만 결제 대상에 연결할 수 있습니다."));
+        Users boothUser = userRepository.findByEmail(boothApplication.getBoothEmail())
+                .orElseThrow(() -> new AccessDeniedException("본인 부스 신청만 결제 대상에 연결할 수 있습니다."));
+        if (!Objects.equals(boothUser.getUserId(), principalUserId)) {
+            throw new AccessDeniedException("본인 부스 신청만 결제 대상에 연결할 수 있습니다.");
+        }
     }
 
     private boolean isManagedBy(Event event, Long managerUserId) {

--- a/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
+++ b/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
@@ -130,6 +130,7 @@ public class PaymentService {
         PaymentTargetType paymentTargetType = paymentTargetTypeRepository
                 .findByPaymentTargetCode(paymentRequestDto.getPaymentTargetType())
                 .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 결제 대상 타입입니다: " + paymentRequestDto.getPaymentTargetType()));
+        validatePaymentTargetCreationPermission(paymentTargetType, paymentRequestDto.getTargetId(), user);
 
         // 결제 방법
         PaymentTypeCode paymentTypeCode = paymentTypeCodeRepository.getReferenceByCode("CARD");
@@ -366,6 +367,35 @@ public class PaymentService {
             case "BANNER_APPLICATION" -> validateBannerApplicationOwner(requestedTargetId, principalUserId);
             case "BOOTH_APPLICATION" -> validateBoothApplicationOwner(requestedTargetId, principalUserId);
             case "BOOTH", "AD" -> throw new AccessDeniedException("해당 결제 대상은 외부 대상 정보 수정이 허용되지 않습니다.");
+            default -> throw new AccessDeniedException("지원하지 않는 결제 대상 타입입니다.");
+        }
+    }
+
+    private void validatePaymentTargetCreationPermission(PaymentTargetType paymentTargetType, Long requestedTargetId, Users user) {
+        if (requestedTargetId == null) {
+            return;
+        }
+
+        String roleCode = user.getRoleCode() != null ? user.getRoleCode().getCode() : null;
+        if ("ADMIN".equals(roleCode)) {
+            return;
+        }
+
+        if ("EVENT_MANAGER".equals(roleCode)) {
+            throw new AccessDeniedException("행사 관리자는 결제 대상 정보를 직접 지정할 수 없습니다.");
+        }
+
+        String targetCode = paymentTargetType != null
+                ? paymentTargetType.getPaymentTargetCode()
+                : null;
+        Long principalUserId = user.getUserId();
+
+        switch (targetCode) {
+            case "RESERVATION" -> validateReservationOwner(requestedTargetId, principalUserId);
+            case "BANNER_APPLICATION" -> validateBannerApplicationOwner(requestedTargetId, principalUserId);
+            case "BOOTH_APPLICATION" -> validateBoothApplicationOwner(requestedTargetId, principalUserId);
+            // BOOTH/AD 생성 경로에는 사용자 소유권을 증명할 매핑이 없어 외부 지정 targetId를 거부한다.
+            case "BOOTH", "AD" -> throw new AccessDeniedException("해당 결제 대상은 생성 시 외부 대상 지정이 허용되지 않습니다.");
             default -> throw new AccessDeniedException("지원하지 않는 결제 대상 타입입니다.");
         }
     }

--- a/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
+++ b/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
@@ -361,6 +361,9 @@ public class PaymentService {
         String targetCode = payment.getPaymentTargetType() != null
                 ? payment.getPaymentTargetType().getPaymentTargetCode()
                 : null;
+        if (targetCode == null) {
+            throw new AccessDeniedException("지원하지 않는 결제 대상 타입입니다.");
+        }
 
         switch (targetCode) {
             case "RESERVATION" -> validateReservationOwner(requestedTargetId, principalUserId);
@@ -388,6 +391,9 @@ public class PaymentService {
         String targetCode = paymentTargetType != null
                 ? paymentTargetType.getPaymentTargetCode()
                 : null;
+        if (targetCode == null) {
+            throw new AccessDeniedException("지원하지 않는 결제 대상 타입입니다.");
+        }
         Long principalUserId = user.getUserId();
 
         switch (targetCode) {

--- a/src/main/java/com/fairing/fairplay/payment/service/RefundService.java
+++ b/src/main/java/com/fairing/fairplay/payment/service/RefundService.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,6 +37,9 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class RefundService {
+
+    private static final String ROLE_ADMIN = "ADMIN";
+    private static final String ROLE_EVENT_MANAGER = "EVENT_MANAGER";
 
     private final PaymentRepository paymentRepository;
     private final RefundRepository refundRepository;
@@ -86,9 +90,11 @@ public class RefundService {
      * 2단계: 관리자의 환불 승인 - 이때 아임포트에 환불 요청
      */
     @Transactional
-    public PaymentResponseDto approveRefund(Long refundId, RefundApprovalDto approval, Long adminUserId) {
+    public PaymentResponseDto approveRefund(Long refundId, RefundApprovalDto approval, CustomUserDetails userDetails) {
+        validateRefundManagerRole(userDetails);
         Refund refund = refundRepository.findById(refundId)
                 .orElseThrow(() -> new IllegalArgumentException("환불 요청이 없습니다."));
+        validateRefundAccess(refund, userDetails);
 
         // 이미 처리된 요청인지 확인
         if (!"REQUESTED".equals(refund.getRefundStatusCode().getCode())) {
@@ -112,7 +118,7 @@ public class RefundService {
             BigDecimal actualRefundAmount = refund.getAmount().min(availableAmount);
             
             // 아임포트 환불 요청 (금액 지정)
-            refundRequest(accessToken, payment.getMerchantUid(), actualRefundAmount, refund.getReason());
+            processRefundRequest(accessToken, payment.getMerchantUid(), actualRefundAmount, refund.getReason());
             
             // 실제 환불 금액으로 조정
             refund.setAmount(actualRefundAmount);
@@ -141,9 +147,11 @@ public class RefundService {
      * 환불 요청 거절
      */
     @Transactional
-    public PaymentResponseDto rejectRefund(Long refundId, String rejectReason, Long adminUserId) {
+    public PaymentResponseDto rejectRefund(Long refundId, String rejectReason, CustomUserDetails userDetails) {
+        validateRefundManagerRole(userDetails);
         Refund refund = refundRepository.findById(refundId)
                 .orElseThrow(() -> new IllegalArgumentException("환불 요청이 없습니다."));
+        validateRefundAccess(refund, userDetails);
 
         if (!"REQUESTED".equals(refund.getRefundStatusCode().getCode())) {
             throw new IllegalStateException("이미 처리된 환불 요청입니다.");
@@ -240,25 +248,29 @@ public class RefundService {
         conn.disconnect();
     }
 
+    protected void processRefundRequest(String accessToken, String merchantUid, BigDecimal amount, String reason) throws IOException {
+        refundRequest(accessToken, merchantUid, amount, reason);
+    }
+
     /**
      * 모든 환불 요청 조회 (관리자용)
      */
     @Transactional(readOnly = true)
     public List<RefundResponseDto> getAllRefunds(Long eventId, CustomUserDetails userDetails) {
-        // 임시 하드코딩: ADMIN 권한으로 가정
-        String roleCode = "ADMIN";
-        // if(userDetails != null) {
-        //     roleCode = userDetails.getRoleCode();
-        //     if (!"ADMIN".equals(roleCode) && !"EVENT_MANAGER".equals(roleCode)) {
-        //         throw new IllegalArgumentException("권한이 없습니다.");
-        //     }
-        // }
+        validateRefundManagerRole(userDetails);
 
         List<Refund> refunds;
-        if (eventId != null) {
+        if (ROLE_ADMIN.equals(userDetails.getRoleCode())) {
+            if (eventId != null) {
+                refunds = refundRepository.findByEventId(eventId);
+            } else {
+                refunds = refundRepository.findAll();
+            }
+        } else if (eventId != null) {
             refunds = refundRepository.findByEventId(eventId);
+            refunds.forEach(refund -> validateRefundAccess(refund, userDetails));
         } else {
-            refunds = refundRepository.findAll();
+            refunds = refundRepository.findByEventManagerUserId(userDetails.getUserId());
         }
 
         return RefundResponseDto.fromEntityList(refunds);
@@ -323,14 +335,22 @@ public class RefundService {
      */
     @Transactional(readOnly = true)
     public List<RefundResponseDto> getPendingRefunds(Long eventId, CustomUserDetails userDetails) {
+        validateRefundManagerRole(userDetails);
         RefundStatusCode requestedStatus = refundStatusCodeRepository.findByCode("REQUESTED")
                 .orElseThrow(() -> new IllegalStateException("환불 상태 코드를 찾을 수 없습니다: REQUESTED"));
         
         List<Refund> refunds;
-        if (eventId != null) {
+        if (ROLE_ADMIN.equals(userDetails.getRoleCode())) {
+            if (eventId != null) {
+                refunds = refundRepository.findByEventIdAndRefundStatusCode(eventId, requestedStatus);
+            } else {
+                refunds = refundRepository.findByRefundStatusCode(requestedStatus);
+            }
+        } else if (eventId != null) {
             refunds = refundRepository.findByEventIdAndRefundStatusCode(eventId, requestedStatus);
+            refunds.forEach(refund -> validateRefundAccess(refund, userDetails));
         } else {
-            refunds = refundRepository.findByRefundStatusCode(requestedStatus);
+            refunds = refundRepository.findByEventManagerUserIdAndRefundStatusCode(userDetails.getUserId(), requestedStatus);
         }
 
         return RefundResponseDto.fromEntityList(refunds);
@@ -379,7 +399,8 @@ public class RefundService {
      * 환불 목록 조회 (필터링 및 페이징 지원)
      */
     @Transactional(readOnly = true)
-    public Page<RefundListResponseDto> getRefundList(RefundListRequestDto request) {
+    public Page<RefundListResponseDto> getRefundList(RefundListRequestDto request, CustomUserDetails userDetails) {
+        validateRefundManagerRole(userDetails);
         try {
             // 날짜 문자열을 LocalDateTime으로 변환
             LocalDateTime paymentDateFrom = null;
@@ -406,17 +427,51 @@ public class RefundService {
             Pageable pageable = PageRequest.of(request.getPage(), request.getSize(), sort);
 
             // Repository 메서드 호출
+            Long managerUserId = ROLE_EVENT_MANAGER.equals(userDetails.getRoleCode()) ? userDetails.getUserId() : null;
             return refundRepository.findRefundsWithFilters(
                 request.getEventName(),
                 paymentDateFrom,
                 paymentDateTo,
                 request.getRefundStatus(),
                 request.getPaymentTargetType(),
+                managerUserId,
                 pageable
             );
             
         } catch (Exception e) {
             throw new RuntimeException("환불 목록 조회 중 오류가 발생했습니다: " + e.getMessage(), e);
+        }
+    }
+
+    private void validateRefundManagerRole(CustomUserDetails userDetails) {
+        if (userDetails == null) {
+            throw new AccessDeniedException("로그인이 필요합니다.");
+        }
+
+        String roleCode = userDetails.getRoleCode();
+        if (!ROLE_ADMIN.equals(roleCode) && !ROLE_EVENT_MANAGER.equals(roleCode)) {
+            throw new AccessDeniedException("환불 관리 권한이 없습니다.");
+        }
+    }
+
+    private void validateRefundAccess(Refund refund, CustomUserDetails userDetails) {
+        if (ROLE_ADMIN.equals(userDetails.getRoleCode())) {
+            return;
+        }
+
+        if (!ROLE_EVENT_MANAGER.equals(userDetails.getRoleCode())) {
+            throw new AccessDeniedException("환불 관리 권한이 없습니다.");
+        }
+
+        if (refund.getPayment() == null || refund.getPayment().getEvent() == null) {
+            throw new AccessDeniedException("행사에 연결되지 않은 환불은 전체 관리자만 처리할 수 있습니다.");
+        }
+
+        Long managerUserId = refund.getPayment().getEvent().getManager() != null
+                ? refund.getPayment().getEvent().getManager().getUserId()
+                : null;
+        if (!userDetails.getUserId().equals(managerUserId)) {
+            throw new AccessDeniedException("담당 행사의 환불만 처리할 수 있습니다.");
         }
     }
 

--- a/src/main/java/com/fairing/fairplay/reservation/controller/ReservationController.java
+++ b/src/main/java/com/fairing/fairplay/reservation/controller/ReservationController.java
@@ -56,9 +56,10 @@ public class ReservationController {
     // 박람회(행사) 예약 상세 조회
     @GetMapping("/{reservationId}")
     public ResponseEntity<ReservationResponseDto> getReservationById(@PathVariable Long eventId,
-            @PathVariable Long reservationId) {
+            @PathVariable Long reservationId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        Reservation reservation = reservationService.getReservationById(reservationId);
+        Reservation reservation = reservationService.getReservationById(eventId, reservationId, userDetails);
 
         if (reservation == null) {
             throw new IllegalStateException("예약 조회에 실패했습니다.");
@@ -74,7 +75,7 @@ public class ReservationController {
     @FunctionAuth("getReservations")
     public ResponseEntity<List<ReservationResponseDto>> getReservations(@PathVariable Long eventId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        List<Reservation> reservations = reservationService.getReservationsByEvent(eventId);
+        List<Reservation> reservations = reservationService.getReservationsByEvent(eventId, userDetails);
 
         if (reservations == null) {
             throw new IllegalStateException("예약 조회에 실패했습니다.");
@@ -116,7 +117,7 @@ public class ReservationController {
             @PageableDefault(size = 15, sort = "createdAt") Pageable pageable,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         Page<ReservationAttendeeDto> attendees = reservationService.getReservationAttendees(
-                eventId, status, name, phone, reservationId, pageable);
+                eventId, status, name, phone, reservationId, pageable, userDetails);
         return ResponseEntity.ok(attendees);
     }
 
@@ -126,7 +127,7 @@ public class ReservationController {
     public ResponseEntity<byte[]> downloadAttendeesExcel(@PathVariable Long eventId,
             @RequestParam(required = false) String status,
             @AuthenticationPrincipal CustomUserDetails userDetails) throws IOException {
-        byte[] excelData = reservationService.generateAttendeesExcel(eventId, status);
+        byte[] excelData = reservationService.generateAttendeesExcel(eventId, status, userDetails);
 
         String filename = "event_" + eventId + "_attendees.xlsx";
 

--- a/src/main/java/com/fairing/fairplay/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/fairing/fairplay/reservation/repository/ReservationRepository.java
@@ -21,6 +21,8 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
   Optional<Reservation> findByReservationIdAndUser_UserId(Long reservationId, Long userId);
 
+  Optional<Reservation> findByReservationIdAndEvent_EventId(Long reservationId, Long eventId);
+
   // 본인 예약 중 관람 일자가 지난 행사 목록 (행사 제목, 건물, 주소, 관람날짜, 요일, 시작시간, 행사시작날짜, 행사종료날짜)
   @Query(value = """
           SELECT new com.fairing.fairplay.review.dto.PossibleReviewResponseDto(

--- a/src/main/java/com/fairing/fairplay/reservation/service/ReservationService.java
+++ b/src/main/java/com/fairing/fairplay/reservation/service/ReservationService.java
@@ -533,12 +533,11 @@ public class ReservationService {
         }
 
         String roleCode = userDetails.getRoleCode();
-        if (ROLE_ADMIN.equals(roleCode)) {
+        if (reservation.getUser() != null
+                && userDetails.getUserId().equals(reservation.getUser().getUserId())) {
             return;
         }
-        if (ROLE_COMMON.equals(roleCode)
-                && reservation.getUser() != null
-                && userDetails.getUserId().equals(reservation.getUser().getUserId())) {
+        if (ROLE_ADMIN.equals(roleCode)) {
             return;
         }
         if (ROLE_EVENT_MANAGER.equals(roleCode) && isManagedBy(reservation.getEvent(), userDetails.getUserId())) {

--- a/src/main/java/com/fairing/fairplay/reservation/service/ReservationService.java
+++ b/src/main/java/com/fairing/fairplay/reservation/service/ReservationService.java
@@ -2,6 +2,7 @@ package com.fairing.fairplay.reservation.service;
 
 import com.fairing.fairplay.attendee.entity.Attendee;
 import com.fairing.fairplay.attendee.repository.AttendeeRepository;
+import com.fairing.fairplay.core.security.CustomUserDetails;
 import com.fairing.fairplay.event.entity.Event;
 import com.fairing.fairplay.event.repository.EventRepository;
 import com.fairing.fairplay.notification.dto.NotificationRequestDto;
@@ -33,6 +34,7 @@ import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,6 +61,10 @@ public class ReservationService {
     private final ScheduleTicketRepository scheduleTicketRepository;
     private final PaymentRepository paymentRepository;
     private final PaymentStatusCodeRepository paymentStatusCodeRepository;
+
+    private static final String ROLE_ADMIN = "ADMIN";
+    private static final String ROLE_EVENT_MANAGER = "EVENT_MANAGER";
+    private static final String ROLE_COMMON = "COMMON";
 
     // 예약 신청 (결제 데이터 생성 이후 마지막에 결제 완료 상태로 저장)
     @Transactional
@@ -331,16 +337,19 @@ public class ReservationService {
 
     // 예약 상세 조회
     @Transactional(readOnly = true)
-    public Reservation getReservationById(Long reservationId) {
+    public Reservation getReservationById(Long eventId, Long reservationId, CustomUserDetails userDetails) {
 
-        return reservationRepository.findById(reservationId)
+        Reservation reservation = reservationRepository.findByReservationIdAndEvent_EventId(reservationId, eventId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 예약 ID: " + reservationId));
+        requireReservationDetailReadAccess(reservation, eventId, userDetails);
+        return reservation;
     }
 
     // 특정 행사의 전체 예약 조회
     @Transactional(readOnly = true)
-    public List<Reservation> getReservationsByEvent(Long eventId) {
+    public List<Reservation> getReservationsByEvent(Long eventId, CustomUserDetails userDetails) {
 
+        requireEventReservationReadAccess(eventId, userDetails);
         return reservationRepository.findByEvent_EventId(eventId);
     }
 
@@ -406,8 +415,11 @@ public class ReservationService {
     // 참가자 명단 조회 (행사 관리자용) - 페이지네이션 지원
     @Transactional(readOnly = true)
     public Page<ReservationAttendeeDto> getReservationAttendees(
-            Long eventId, String status, String name, String phone, Long reservationId, Pageable pageable) {
+            Long eventId, String status, String name, String phone, Long reservationId, Pageable pageable,
+            CustomUserDetails userDetails) {
         
+        requireEventReservationReadAccess(eventId, userDetails);
+
         // AttendeeRepository에서 페이지네이션과 필터링을 지원하는 메서드 호출
         Page<Attendee> attendeePage = attendeeRepository.findAttendeesWithFilters(
                 eventId, status, name, phone, reservationId, pageable);
@@ -418,7 +430,13 @@ public class ReservationService {
 
     // 참가자 명단 조회 (엑셀 다운로드용)
     @Transactional(readOnly = true)
-    public List<ReservationAttendeeDto> getReservationAttendees(Long eventId, String status) {
+    public List<ReservationAttendeeDto> getReservationAttendees(Long eventId, String status,
+            CustomUserDetails userDetails) {
+        requireEventReservationReadAccess(eventId, userDetails);
+        return getReservationAttendeesForExcel(eventId, status);
+    }
+
+    private List<ReservationAttendeeDto> getReservationAttendeesForExcel(Long eventId, String status) {
         List<Attendee> attendees = attendeeRepository.findAttendeesByEventId(eventId, status);
         
         return attendees.stream()
@@ -428,8 +446,9 @@ public class ReservationService {
 
     // 참가자 명단 엑셀 파일 생성
     @Transactional(readOnly = true)
-    public byte[] generateAttendeesExcel(Long eventId, String status) throws IOException {
-        List<ReservationAttendeeDto> attendees = getReservationAttendees(eventId, status);
+    public byte[] generateAttendeesExcel(Long eventId, String status, CustomUserDetails userDetails) throws IOException {
+        requireEventReservationReadAccess(eventId, userDetails);
+        List<ReservationAttendeeDto> attendees = getReservationAttendeesForExcel(eventId, status);
         
         try (Workbook workbook = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
             Sheet sheet = workbook.createSheet("참가자 명단");
@@ -485,5 +504,60 @@ public class ReservationService {
             workbook.write(out);
             return out.toByteArray();
         }
+    }
+
+    public void requireEventReservationReadAccess(Long eventId, CustomUserDetails userDetails) {
+        requireAuthenticated(userDetails);
+
+        String roleCode = userDetails.getRoleCode();
+        if (ROLE_ADMIN.equals(roleCode)) {
+            return;
+        }
+        if (!ROLE_EVENT_MANAGER.equals(roleCode)) {
+            throw new AccessDeniedException("행사 예약 정보를 조회할 권한이 없습니다.");
+        }
+
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 EVENT ID: " + eventId));
+        if (!isManagedBy(event, userDetails.getUserId())) {
+            throw new AccessDeniedException("행사 예약 정보를 조회할 권한이 없습니다.");
+        }
+    }
+
+    public void requireReservationDetailReadAccess(Reservation reservation, Long eventId,
+            CustomUserDetails userDetails) {
+        requireAuthenticated(userDetails);
+
+        if (reservation.getEvent() == null || !eventId.equals(reservation.getEvent().getEventId())) {
+            throw new IllegalArgumentException("존재하지 않는 예약 ID: " + reservation.getReservationId());
+        }
+
+        String roleCode = userDetails.getRoleCode();
+        if (ROLE_ADMIN.equals(roleCode)) {
+            return;
+        }
+        if (ROLE_COMMON.equals(roleCode)
+                && reservation.getUser() != null
+                && userDetails.getUserId().equals(reservation.getUser().getUserId())) {
+            return;
+        }
+        if (ROLE_EVENT_MANAGER.equals(roleCode) && isManagedBy(reservation.getEvent(), userDetails.getUserId())) {
+            return;
+        }
+
+        throw new AccessDeniedException("예약 상세를 조회할 권한이 없습니다.");
+    }
+
+    private void requireAuthenticated(CustomUserDetails userDetails) {
+        if (userDetails == null || userDetails.getUserId() == null) {
+            throw new AccessDeniedException("로그인이 필요합니다.");
+        }
+    }
+
+    private boolean isManagedBy(Event event, Long userId) {
+        return event != null
+                && event.getManager() != null
+                && event.getManager().getUserId() != null
+                && event.getManager().getUserId().equals(userId);
     }
 }

--- a/src/main/java/com/fairing/fairplay/settlement/controller/SettlementDisputeController.java
+++ b/src/main/java/com/fairing/fairplay/settlement/controller/SettlementDisputeController.java
@@ -103,7 +103,7 @@ public class SettlementDisputeController {
         // 파일 다운로드
         localFileService.downloadFile(fileKey, response);
 
-        log.info("이의신청 파일 다운로드 - FileId: {}, S3Key: {}", fileId, fileKey);
+        log.info("이의신청 파일 다운로드 - FileId: {}", fileId);
     }
 
     /**

--- a/src/main/java/com/fairing/fairplay/settlement/controller/SettlementDisputeController.java
+++ b/src/main/java/com/fairing/fairplay/settlement/controller/SettlementDisputeController.java
@@ -1,11 +1,9 @@
 package com.fairing.fairplay.settlement.controller;
 
-import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.core.etc.FunctionAuth;
+import com.fairing.fairplay.core.security.CustomUserDetails;
 import com.fairing.fairplay.core.service.LocalFileService;
 import com.fairing.fairplay.settlement.dto.SettlementDisputeDto;
-import com.fairing.fairplay.settlement.entity.SettlementDisputeFile;
-import com.fairing.fairplay.settlement.repository.SettlementDisputeFileRepository;
 import com.fairing.fairplay.settlement.service.SettlementDisputeService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +12,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -27,7 +26,6 @@ import java.util.List;
 public class SettlementDisputeController {
 
     private final SettlementDisputeService disputeService;
-    private final SettlementDisputeFileRepository disputeFileRepository;
     private final LocalFileService localFileService;
 
     /**
@@ -36,10 +34,11 @@ public class SettlementDisputeController {
     @PostMapping("/files/upload")
     @FunctionAuth("disputeUploadFiles")
     public ResponseEntity<SettlementDisputeDto.TempUploadResponse> disputeUploadFiles(
-            @RequestParam("files") List<MultipartFile> files) {
+            @RequestParam("files") List<MultipartFile> files,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
 
-        return ResponseEntity.ok(disputeService.uploadDisputeFiles(files));
+        return ResponseEntity.ok(disputeService.uploadDisputeFiles(files, userDetails));
     }
 
     /**
@@ -49,10 +48,9 @@ public class SettlementDisputeController {
     @FunctionAuth("submitDispute")
     public ResponseEntity<SettlementDisputeDto.Response> submitDispute(
             @RequestBody SettlementDisputeDto.CreateRequest request,
-            @RequestHeader("User-Id") Long requesterId,
-            @RequestHeader("User-Name") String requesterName) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        SettlementDisputeDto.Response response = disputeService.submitDispute(request, requesterId);
+        SettlementDisputeDto.Response response = disputeService.submitDispute(request, userDetails);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
@@ -61,8 +59,9 @@ public class SettlementDisputeController {
      */
     @GetMapping("/{disputeId}")
     @FunctionAuth("getDetailDispute")
-    public ResponseEntity<SettlementDisputeDto.Response> getDetailDispute(@PathVariable Long disputeId) {
-        SettlementDisputeDto.Response response = disputeService.getDispute(disputeId);
+    public ResponseEntity<SettlementDisputeDto.Response> getDetailDispute(@PathVariable Long disputeId,
+                                                                          @AuthenticationPrincipal CustomUserDetails userDetails) {
+        SettlementDisputeDto.Response response = disputeService.getDispute(disputeId, userDetails);
         return ResponseEntity.ok(response);
     }
 
@@ -71,8 +70,10 @@ public class SettlementDisputeController {
      */
     @GetMapping
     @FunctionAuth("getDisputeList")
-    public ResponseEntity<Page<SettlementDisputeDto.ListResponse>> getDisputeList(Pageable pageable) {
-        Page<SettlementDisputeDto.ListResponse> response = disputeService.getDisputeList(pageable);
+    public ResponseEntity<Page<SettlementDisputeDto.ListResponse>> getDisputeList(
+            Pageable pageable,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        Page<SettlementDisputeDto.ListResponse> response = disputeService.getDisputeList(pageable, userDetails);
         return ResponseEntity.ok(response);
     }
 
@@ -83,10 +84,9 @@ public class SettlementDisputeController {
     @FunctionAuth("reviewDispute")
     public ResponseEntity<SettlementDisputeDto.Response> reviewDispute(
             @RequestBody SettlementDisputeDto.AdminReviewRequest request,
-            @RequestHeader("Admin-Id") Long adminId,
-            @RequestHeader("Admin-Name") String adminName) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        SettlementDisputeDto.Response response = disputeService.reviewDispute(request, adminId);
+        SettlementDisputeDto.Response response = disputeService.reviewDispute(request, userDetails);
         return ResponseEntity.ok(response);
     }
 
@@ -95,14 +95,15 @@ public class SettlementDisputeController {
      */
     @GetMapping("/files/download")
     @FunctionAuth("downloadDisputeFile")
-    public void downloadDisputeFile(@RequestParam Long fileId, HttpServletResponse response) throws IOException {
-        SettlementDisputeFile file = disputeFileRepository.findById(fileId)
-                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."));
+    public void downloadDisputeFile(@RequestParam Long fileId,
+                                    @AuthenticationPrincipal CustomUserDetails userDetails,
+                                    HttpServletResponse response) throws IOException {
+        String fileKey = disputeService.getAuthorizedFileKey(fileId, userDetails);
 
         // 파일 다운로드
-        localFileService.downloadFile(file.getS3Key(), response);
+        localFileService.downloadFile(fileKey, response);
 
-        log.info("이의신청 파일 다운로드 - FileId: {}, S3Key: {}", fileId, file.getS3Key());
+        log.info("이의신청 파일 다운로드 - FileId: {}, S3Key: {}", fileId, fileKey);
     }
 
     /**
@@ -110,9 +111,11 @@ public class SettlementDisputeController {
      */
     @GetMapping("/settlement/{settlementId}")
     @FunctionAuth("getDisputeBySettlement")
-    public ResponseEntity<SettlementDisputeDto.Response> getDisputeBySettlement(@PathVariable Long settlementId) {
+    public ResponseEntity<SettlementDisputeDto.Response> getDisputeBySettlement(
+            @PathVariable Long settlementId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
         // 해당 정산의 이의신청이 있는지 조회
-        return disputeService.getDisputeBySettlementId(settlementId)
+        return disputeService.getDisputeBySettlementId(settlementId, userDetails)
                 .map(dispute -> ResponseEntity.ok(dispute))
                 .orElse(ResponseEntity.notFound().build());
     }

--- a/src/main/java/com/fairing/fairplay/settlement/entity/SettlementDispute.java
+++ b/src/main/java/com/fairing/fairplay/settlement/entity/SettlementDispute.java
@@ -26,9 +26,6 @@ public class SettlementDispute {
     @Column(name = "requester_id", nullable = false)
     private Long requesterId; // 이의신청자 ID (행사 관리자)
 
-    @Column(name = "requester_name", length = 100)
-    private String requesterName;
-
     @Column(name = "dispute_reason", length = 1000)
     private String disputeReason; // 이의신청 사유 (간단한 텍스트)
 
@@ -43,9 +40,6 @@ public class SettlementDispute {
 
     @Column(name = "admin_id")
     private Long adminId; // 처리한 관리자 ID
-
-    @Column(name = "admin_name", length = 100)
-    private String adminName;
 
     @Column(name = "admin_response", length = 2000)
     private String adminResponse; // 관리자 응답

--- a/src/main/java/com/fairing/fairplay/settlement/entity/SettlementDispute.java
+++ b/src/main/java/com/fairing/fairplay/settlement/entity/SettlementDispute.java
@@ -26,6 +26,8 @@ public class SettlementDispute {
     @Column(name = "requester_id", nullable = false)
     private Long requesterId; // 이의신청자 ID (행사 관리자)
 
+    @Column(name = "requester_name", length = 100)
+    private String requesterName;
 
     @Column(name = "dispute_reason", length = 1000)
     private String disputeReason; // 이의신청 사유 (간단한 텍스트)
@@ -41,6 +43,9 @@ public class SettlementDispute {
 
     @Column(name = "admin_id")
     private Long adminId; // 처리한 관리자 ID
+
+    @Column(name = "admin_name", length = 100)
+    private String adminName;
 
     @Column(name = "admin_response", length = 2000)
     private String adminResponse; // 관리자 응답

--- a/src/main/java/com/fairing/fairplay/settlement/service/SettlementDisputeService.java
+++ b/src/main/java/com/fairing/fairplay/settlement/service/SettlementDisputeService.java
@@ -1,8 +1,10 @@
 package com.fairing.fairplay.settlement.service;
 
 import com.fairing.fairplay.common.exception.CustomException;
+import com.fairing.fairplay.core.security.CustomUserDetails;
 import com.fairing.fairplay.core.service.LocalFileService;
 import com.fairing.fairplay.core.util.TempUploadKeyPolicy;
+import com.fairing.fairplay.event.entity.Event;
 import com.fairing.fairplay.settlement.controller.SettlementDisputeController;
 import com.fairing.fairplay.settlement.dto.SettlementDisputeDto;
 import com.fairing.fairplay.settlement.entity.DisputeStatus;
@@ -12,11 +14,13 @@ import com.fairing.fairplay.settlement.entity.SettlementDisputeFile;
 import com.fairing.fairplay.settlement.repository.SettlementDisputeFileRepository;
 import com.fairing.fairplay.settlement.repository.SettlementDisputeRepository;
 import com.fairing.fairplay.settlement.repository.SettlementRepository;
+import com.fairing.fairplay.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -31,15 +35,22 @@ import java.util.stream.IntStream;
 @Slf4j
 public class SettlementDisputeService {
 
+    private static final String ROLE_ADMIN = "ADMIN";
+    private static final String ROLE_EVENT_MANAGER = "EVENT_MANAGER";
+
     private final SettlementDisputeRepository disputeRepository;
     private final SettlementDisputeFileRepository disputeFileRepository;
     private final SettlementRepository settlementRepository;
     private final LocalFileService localFileService;
+    private final UserRepository userRepository;
 
     /**
      * 이의신청용 파일 임시 업로드
      */
-    public SettlementDisputeDto.TempUploadResponse uploadDisputeFiles(List<MultipartFile> files) {
+    public SettlementDisputeDto.TempUploadResponse uploadDisputeFiles(List<MultipartFile> files,
+                                                                      CustomUserDetails userDetails) {
+        requireEventManager(userDetails);
+
         if (files == null || files.isEmpty()) {
             throw new CustomException(HttpStatus.BAD_REQUEST, "업로드할 파일이 없습니다.");
         }
@@ -75,10 +86,11 @@ public class SettlementDisputeService {
      */
     @Transactional
     public SettlementDisputeDto.Response submitDispute(SettlementDisputeDto.CreateRequest request,
-                                                       Long requesterId) {
+                                                       CustomUserDetails userDetails) {
         // 정산 정보 조회
         Settlement settlement = settlementRepository.findById(request.getSettlementId())
                 .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "정산 정보를 찾을 수 없습니다."));
+        requireManagedSettlementAccess(settlement, userDetails);
 
         // 이미 이의신청이 있는지 확인
         if (disputeRepository.existsBySettlement_SettlementId(request.getSettlementId())) {
@@ -97,7 +109,8 @@ public class SettlementDisputeService {
         // 이의신청 생성
         SettlementDispute dispute = SettlementDispute.builder()
                 .settlement(settlement)
-                .requesterId(requesterId)
+                .requesterId(userDetails.getUserId())
+                .requesterName(resolvePrincipalName(userDetails))
                 .disputeReason(request.getDisputeReason())
                 .status(SettlementDispute.DisputeProcessStatus.RAISED)
                 .build();
@@ -114,7 +127,7 @@ public class SettlementDisputeService {
         settlementRepository.save(settlement);
 
         log.info("정산 이의신청 접수 완료 - DisputeId: {}, SettlementId: {}, RequesterId: {}",
-                dispute.getDisputeId(), settlement.getSettlementId(), requesterId);
+                dispute.getDisputeId(), settlement.getSettlementId(), userDetails.getUserId());
 
         return convertToResponse(dispute);
     }
@@ -201,9 +214,11 @@ public class SettlementDisputeService {
     /**
      * 이의신청 상세 조회
      */
-    public SettlementDisputeDto.Response getDispute(Long disputeId) {
+    @Transactional(readOnly = true)
+    public SettlementDisputeDto.Response getDispute(Long disputeId, CustomUserDetails userDetails) {
         SettlementDispute dispute = disputeRepository.findById(disputeId)
                 .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "이의신청을 찾을 수 없습니다."));
+        requireDisputeReadAccess(dispute, userDetails);
 
         return convertToResponse(dispute);
     }
@@ -211,7 +226,9 @@ public class SettlementDisputeService {
     /**
      * 이의신청 목록 조회 (관리자용)
      */
-    public Page<SettlementDisputeDto.ListResponse> getDisputeList(Pageable pageable) {
+    @Transactional(readOnly = true)
+    public Page<SettlementDisputeDto.ListResponse> getDisputeList(Pageable pageable, CustomUserDetails userDetails) {
+        requireAdmin(userDetails);
         return disputeRepository.findAllWithSettlement(pageable)
                 .map(this::convertToListResponse);
     }
@@ -221,15 +238,17 @@ public class SettlementDisputeService {
      */
     @Transactional
     public SettlementDisputeDto.Response reviewDispute(SettlementDisputeDto.AdminReviewRequest request,
-                                                       Long adminId) {
+                                                       CustomUserDetails userDetails) {
         SettlementDispute dispute = disputeRepository.findById(request.getDisputeId())
                 .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "이의신청을 찾을 수 없습니다."));
+        requireAdmin(userDetails);
 
         // 상태 업데이트
         dispute.setStatus(request.getStatus());
         dispute.setAdminResponse(request.getAdminResponse());
         dispute.setReviewedAt(LocalDateTime.now());
-        dispute.setAdminId(adminId);
+        dispute.setAdminId(userDetails.getUserId());
+        dispute.setAdminName(resolvePrincipalName(userDetails));
 
         // Settlement의 dispute 상태도 업데이트
         Settlement settlement = dispute.getSettlement();
@@ -244,7 +263,7 @@ public class SettlementDisputeService {
         settlementRepository.save(settlement);
 
         log.info("이의신청 검토 완료 - DisputeId: {}, Status: {}, AdminId: {}",
-                dispute.getDisputeId(), request.getStatus(), adminId);
+                dispute.getDisputeId(), request.getStatus(), userDetails.getUserId());
 
         return convertToResponse(dispute);
     }
@@ -252,11 +271,20 @@ public class SettlementDisputeService {
     /**
      * 이의신청 파일 다운로드 URL 생성
      */
+    @Transactional(readOnly = true)
     public String getFileDownloadUrl(Long fileId) {
         SettlementDisputeFile file = disputeFileRepository.findById(fileId)
                 .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."));
 
         return "/api/settlements/disputes/files/download?fileId=" + fileId;
+    }
+
+    @Transactional(readOnly = true)
+    public String getAuthorizedFileKey(Long fileId, CustomUserDetails userDetails) {
+        SettlementDisputeFile file = disputeFileRepository.findById(fileId)
+                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."));
+        requireDisputeReadAccess(file.getDispute(), userDetails);
+        return file.getS3Key();
     }
 
     /**
@@ -279,10 +307,12 @@ public class SettlementDisputeService {
                 .disputeId(dispute.getDisputeId())
                 .settlementId(dispute.getSettlement().getSettlementId())
                 .eventTitle(dispute.getSettlement().getEventTitle())
+                .requesterName(dispute.getRequesterName())
                 .disputeReason(dispute.getDisputeReason())
                 .files(fileInfos)
                 .status(dispute.getStatus())
                 .adminResponse(dispute.getAdminResponse())
+                .adminName(dispute.getAdminName())
                 .submittedAt(dispute.getSubmittedAt())
                 .reviewedAt(dispute.getReviewedAt())
                 .build();
@@ -291,9 +321,18 @@ public class SettlementDisputeService {
     /**
      * 특정 정산의 이의신청 조회
      */
-    public Optional<SettlementDisputeDto.Response> getDisputeBySettlementId(Long settlementId) {
+    @Transactional(readOnly = true)
+    public Optional<SettlementDisputeDto.Response> getDisputeBySettlementId(Long settlementId,
+                                                                            CustomUserDetails userDetails) {
+        Settlement settlement = settlementRepository.findById(settlementId)
+                .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "정산 정보를 찾을 수 없습니다."));
+        requireSettlementReadAccess(settlement, userDetails);
+
         return disputeRepository.findBySettlement_SettlementId(settlementId)
-                .map(this::convertToResponse);
+                .map(dispute -> {
+                    requireDisputeReadAccess(dispute, userDetails);
+                    return convertToResponse(dispute);
+                });
     }
 
     /**
@@ -316,9 +355,79 @@ public class SettlementDisputeService {
                 .disputeId(dispute.getDisputeId())
                 .settlementId(dispute.getSettlement().getSettlementId())
                 .eventTitle(dispute.getSettlement().getEventTitle())
+                .requesterName(dispute.getRequesterName())
                 .status(dispute.getStatus())
                 .fileCount(dispute.getDisputeFiles().size())
                 .submittedAt(dispute.getSubmittedAt())
                 .build();
+    }
+
+    private void requireAuthenticated(CustomUserDetails userDetails) {
+        if (userDetails == null || userDetails.getUserId() == null) {
+            throw new AccessDeniedException("로그인이 필요합니다.");
+        }
+    }
+
+    private void requireAdmin(CustomUserDetails userDetails) {
+        requireAuthenticated(userDetails);
+        if (!ROLE_ADMIN.equals(userDetails.getRoleCode())) {
+            throw new AccessDeniedException("정산 이의신청 관리자 권한이 없습니다.");
+        }
+    }
+
+    private void requireEventManager(CustomUserDetails userDetails) {
+        requireAuthenticated(userDetails);
+        if (!ROLE_EVENT_MANAGER.equals(userDetails.getRoleCode())) {
+            throw new AccessDeniedException("정산 이의신청 권한이 없습니다.");
+        }
+    }
+
+    private void requireManagedSettlementAccess(Settlement settlement, CustomUserDetails userDetails) {
+        requireEventManager(userDetails);
+        if (!isManagedBy(settlement.getEvent(), userDetails.getUserId())) {
+            throw new AccessDeniedException("관리 중인 정산 이의신청만 처리할 수 있습니다.");
+        }
+    }
+
+    private void requireSettlementReadAccess(Settlement settlement, CustomUserDetails userDetails) {
+        requireAuthenticated(userDetails);
+        if (ROLE_ADMIN.equals(userDetails.getRoleCode())) {
+            return;
+        }
+        if (ROLE_EVENT_MANAGER.equals(userDetails.getRoleCode())
+                && isManagedBy(settlement.getEvent(), userDetails.getUserId())) {
+            return;
+        }
+        throw new AccessDeniedException("정산 이의신청을 조회할 권한이 없습니다.");
+    }
+
+    private void requireDisputeReadAccess(SettlementDispute dispute, CustomUserDetails userDetails) {
+        requireAuthenticated(userDetails);
+        if (ROLE_ADMIN.equals(userDetails.getRoleCode())) {
+            return;
+        }
+        if (ROLE_EVENT_MANAGER.equals(userDetails.getRoleCode())
+                && isManagedBy(dispute.getSettlement().getEvent(), userDetails.getUserId())) {
+            return;
+        }
+        throw new AccessDeniedException("정산 이의신청을 조회할 권한이 없습니다.");
+    }
+
+    private boolean isManagedBy(Event event, Long userId) {
+        return event != null
+                && event.getManager() != null
+                && event.getManager().getUserId() != null
+                && event.getManager().getUserId().equals(userId);
+    }
+
+    private String resolvePrincipalName(CustomUserDetails userDetails) {
+        String principalName = userDetails.getName();
+        if (principalName != null && !principalName.isBlank()) {
+            return principalName;
+        }
+        return userRepository.findById(userDetails.getUserId())
+                .map(user -> user.getName())
+                .filter(name -> name != null && !name.isBlank())
+                .orElse(null);
     }
 }

--- a/src/main/java/com/fairing/fairplay/settlement/service/SettlementDisputeService.java
+++ b/src/main/java/com/fairing/fairplay/settlement/service/SettlementDisputeService.java
@@ -238,9 +238,9 @@ public class SettlementDisputeService {
     @Transactional
     public SettlementDisputeDto.Response reviewDispute(SettlementDisputeDto.AdminReviewRequest request,
                                                        CustomUserDetails userDetails) {
+        requireAdmin(userDetails);
         SettlementDispute dispute = disputeRepository.findById(request.getDisputeId())
                 .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "이의신청을 찾을 수 없습니다."));
-        requireAdmin(userDetails);
 
         // 상태 업데이트
         dispute.setStatus(request.getStatus());

--- a/src/main/java/com/fairing/fairplay/settlement/service/SettlementDisputeService.java
+++ b/src/main/java/com/fairing/fairplay/settlement/service/SettlementDisputeService.java
@@ -110,7 +110,6 @@ public class SettlementDisputeService {
         SettlementDispute dispute = SettlementDispute.builder()
                 .settlement(settlement)
                 .requesterId(userDetails.getUserId())
-                .requesterName(resolvePrincipalName(userDetails))
                 .disputeReason(request.getDisputeReason())
                 .status(SettlementDispute.DisputeProcessStatus.RAISED)
                 .build();
@@ -248,7 +247,6 @@ public class SettlementDisputeService {
         dispute.setAdminResponse(request.getAdminResponse());
         dispute.setReviewedAt(LocalDateTime.now());
         dispute.setAdminId(userDetails.getUserId());
-        dispute.setAdminName(resolvePrincipalName(userDetails));
 
         // Settlement의 dispute 상태도 업데이트
         Settlement settlement = dispute.getSettlement();
@@ -307,12 +305,12 @@ public class SettlementDisputeService {
                 .disputeId(dispute.getDisputeId())
                 .settlementId(dispute.getSettlement().getSettlementId())
                 .eventTitle(dispute.getSettlement().getEventTitle())
-                .requesterName(dispute.getRequesterName())
+                .requesterName(resolveUserName(dispute.getRequesterId()))
                 .disputeReason(dispute.getDisputeReason())
                 .files(fileInfos)
                 .status(dispute.getStatus())
                 .adminResponse(dispute.getAdminResponse())
-                .adminName(dispute.getAdminName())
+                .adminName(resolveUserName(dispute.getAdminId()))
                 .submittedAt(dispute.getSubmittedAt())
                 .reviewedAt(dispute.getReviewedAt())
                 .build();
@@ -355,7 +353,7 @@ public class SettlementDisputeService {
                 .disputeId(dispute.getDisputeId())
                 .settlementId(dispute.getSettlement().getSettlementId())
                 .eventTitle(dispute.getSettlement().getEventTitle())
-                .requesterName(dispute.getRequesterName())
+                .requesterName(resolveUserName(dispute.getRequesterId()))
                 .status(dispute.getStatus())
                 .fileCount(dispute.getDisputeFiles().size())
                 .submittedAt(dispute.getSubmittedAt())
@@ -420,12 +418,11 @@ public class SettlementDisputeService {
                 && event.getManager().getUserId().equals(userId);
     }
 
-    private String resolvePrincipalName(CustomUserDetails userDetails) {
-        String principalName = userDetails.getName();
-        if (principalName != null && !principalName.isBlank()) {
-            return principalName;
+    private String resolveUserName(Long userId) {
+        if (userId == null) {
+            return null;
         }
-        return userRepository.findById(userDetails.getUserId())
+        return userRepository.findById(userId)
                 .map(user -> user.getName())
                 .filter(name -> name != null && !name.isBlank())
                 .orElse(null);

--- a/src/test/java/com/fairing/fairplay/attendee/service/AttendeeServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/attendee/service/AttendeeServiceAuthorizationTest.java
@@ -1,0 +1,118 @@
+package com.fairing.fairplay.attendee.service;
+
+import com.fairing.fairplay.attendee.repository.AttendeeRepository;
+import com.fairing.fairplay.attendee.repository.AttendeeRepositoryCustom;
+import com.fairing.fairplay.attendee.repository.AttendeeTypeCodeRepository;
+import com.fairing.fairplay.attendeeform.service.AttendeeFormService;
+import com.fairing.fairplay.core.security.CustomUserDetails;
+import com.fairing.fairplay.event.entity.Event;
+import com.fairing.fairplay.event.repository.EventRepository;
+import com.fairing.fairplay.qr.service.QrTicketService;
+import com.fairing.fairplay.reservation.repository.ReservationRepository;
+import com.fairing.fairplay.user.entity.EventAdmin;
+import com.fairing.fairplay.user.entity.Users;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AttendeeServiceAuthorizationTest {
+
+  @Mock
+  private AttendeeRepository attendeeRepository;
+
+  @Mock
+  private AttendeeTypeCodeRepository attendeeTypeCodeRepository;
+
+  @Mock
+  private AttendeeRepositoryCustom attendeeRepositoryCustom;
+
+  @Mock
+  private AttendeeFormService attendeeFormService;
+
+  @Mock
+  private ReservationRepository reservationRepository;
+
+  @Mock
+  private QrTicketService qrTicketService;
+
+  @Mock
+  private EventRepository eventRepository;
+
+  private AttendeeService attendeeService;
+
+  @BeforeEach
+  void setUp() {
+    attendeeService = new AttendeeService(
+        attendeeRepository,
+        attendeeTypeCodeRepository,
+        attendeeRepositoryCustom,
+        attendeeFormService,
+        reservationRepository,
+        qrTicketService,
+        eventRepository
+    );
+  }
+
+  @Test
+  void eventManagerCanReadAttendeesForOwnEvent() {
+    when(eventRepository.findById(1L)).thenReturn(Optional.of(event(1L, 100L)));
+    when(attendeeRepository.findByEventId(1L)).thenReturn(List.of());
+
+    assertThat(attendeeService.getAttendeesByEvent(1L, user(100L, "EVENT_MANAGER"))).isEmpty();
+  }
+
+  @Test
+  void eventManagerCannotReadAttendeesForOtherEventBeforeQuery() {
+    when(eventRepository.findById(1L)).thenReturn(Optional.of(event(1L, 100L)));
+
+    assertThatThrownBy(() -> attendeeService.getAttendeesByEvent(1L, user(999L, "EVENT_MANAGER")))
+        .isInstanceOf(AccessDeniedException.class);
+
+    verify(attendeeRepository, never()).findByEventId(any());
+  }
+
+  @Test
+  void commonAndBoothManagerCannotReadEventAttendees() {
+    assertThatThrownBy(() -> attendeeService.getAttendeesByEvent(1L, user(300L, "COMMON")))
+        .isInstanceOf(AccessDeniedException.class);
+    assertThatThrownBy(() -> attendeeService.getAttendeesByEvent(1L, user(200L, "BOOTH_MANAGER")))
+        .isInstanceOf(AccessDeniedException.class);
+
+    verify(eventRepository, never()).findById(any());
+    verify(attendeeRepository, never()).findByEventId(any());
+  }
+
+  private Event event(Long eventId, Long managerUserId) {
+    EventAdmin eventAdmin = new EventAdmin();
+    eventAdmin.setUser(new Users(managerUserId));
+    eventAdmin.setUserId(managerUserId);
+
+    Event event = new Event();
+    event.setEventId(eventId);
+    event.setManager(eventAdmin);
+    event.setTitleKr("행사");
+    event.setTitleEng("Event");
+    return event;
+  }
+
+  private CustomUserDetails user(Long userId, String roleCode) {
+    CustomUserDetails userDetails = mock(CustomUserDetails.class);
+    when(userDetails.getUserId()).thenReturn(userId);
+    when(userDetails.getRoleCode()).thenReturn(roleCode);
+    return userDetails;
+  }
+}

--- a/src/test/java/com/fairing/fairplay/booth/controller/BoothExperienceControllerPrincipalTest.java
+++ b/src/test/java/com/fairing/fairplay/booth/controller/BoothExperienceControllerPrincipalTest.java
@@ -4,12 +4,14 @@ import com.fairing.fairplay.booth.dto.BoothExperienceReservationRequestDto;
 import com.fairing.fairplay.booth.dto.BoothExperienceReservationResponseDto;
 import com.fairing.fairplay.booth.service.BoothExperienceService;
 import com.fairing.fairplay.core.security.CustomUserDetails;
+import java.util.Arrays;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -61,5 +63,16 @@ class BoothExperienceControllerPrincipalTest {
     assertThat(method.getParameters())
         .allSatisfy(parameter -> assertThat(parameter.isAnnotationPresent(RequestParam.class)).isFalse());
     assertThat(method.getParameters()[2].isAnnotationPresent(AuthenticationPrincipal.class)).isTrue();
+  }
+
+  @Test
+  void managementPreAuthorizeExpressionsAllowAdmin() {
+    assertThat(Arrays.stream(BoothExperienceController.class.getDeclaredMethods())
+        .map(method -> method.getAnnotation(PreAuthorize.class))
+        .filter(annotation -> annotation != null
+            && annotation.value().contains("EVENT_MANAGER")
+            && annotation.value().contains("BOOTH_MANAGER"))
+        .map(PreAuthorize::value))
+        .allSatisfy(expression -> assertThat(expression).contains("ADMIN"));
   }
 }

--- a/src/test/java/com/fairing/fairplay/booth/controller/BoothExperienceControllerPrincipalTest.java
+++ b/src/test/java/com/fairing/fairplay/booth/controller/BoothExperienceControllerPrincipalTest.java
@@ -1,0 +1,65 @@
+package com.fairing.fairplay.booth.controller;
+
+import com.fairing.fairplay.booth.dto.BoothExperienceReservationRequestDto;
+import com.fairing.fairplay.booth.dto.BoothExperienceReservationResponseDto;
+import com.fairing.fairplay.booth.service.BoothExperienceService;
+import com.fairing.fairplay.core.security.CustomUserDetails;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BoothExperienceControllerPrincipalTest {
+
+  @Mock
+  private BoothExperienceService boothExperienceService;
+
+  private BoothExperienceController controller;
+
+  @BeforeEach
+  void setUp() {
+    controller = new BoothExperienceController(boothExperienceService);
+  }
+
+  @Test
+  void createReservationPassesAuthenticationPrincipalToService() {
+    CustomUserDetails principal = mock(CustomUserDetails.class);
+    BoothExperienceReservationRequestDto request = BoothExperienceReservationRequestDto.builder()
+        .notes("reserve")
+        .build();
+    BoothExperienceReservationResponseDto response = BoothExperienceReservationResponseDto.builder()
+        .reservationId(7L)
+        .userId(300L)
+        .build();
+    when(boothExperienceService.createReservation(1L, principal, request)).thenReturn(response);
+
+    var result = controller.createReservation(1L, request, principal);
+
+    assertThat(result.getBody()).isSameAs(response);
+    verify(boothExperienceService).createReservation(1L, principal, request);
+  }
+
+  @Test
+  void createReservationDoesNotAcceptUserIdRequestParam() throws NoSuchMethodException {
+    Method method = BoothExperienceController.class.getMethod(
+        "createReservation",
+        Long.class,
+        BoothExperienceReservationRequestDto.class,
+        CustomUserDetails.class
+    );
+
+    assertThat(method.getParameters())
+        .allSatisfy(parameter -> assertThat(parameter.isAnnotationPresent(RequestParam.class)).isFalse());
+    assertThat(method.getParameters()[2].isAnnotationPresent(AuthenticationPrincipal.class)).isTrue();
+  }
+}

--- a/src/test/java/com/fairing/fairplay/booth/controller/BoothQrControllerAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/booth/controller/BoothQrControllerAuthorizationTest.java
@@ -1,0 +1,26 @@
+package com.fairing.fairplay.booth.controller;
+
+import com.fairing.fairplay.booth.dto.BoothEntryRequestDto;
+import com.fairing.fairplay.core.security.CustomUserDetails;
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BoothQrControllerAuthorizationTest {
+
+  @Test
+  void boothEntryPreAuthorizeExpressionAllowsAdmin() throws NoSuchMethodException {
+    Method method = BoothQrController.class.getMethod(
+        "boothEntry",
+        BoothEntryRequestDto.class,
+        CustomUserDetails.class
+    );
+
+    PreAuthorize preAuthorize = method.getAnnotation(PreAuthorize.class);
+
+    assertThat(preAuthorize).isNotNull();
+    assertThat(preAuthorize.value()).contains("ADMIN");
+  }
+}

--- a/src/test/java/com/fairing/fairplay/booth/service/BoothExperienceServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/booth/service/BoothExperienceServiceAuthorizationTest.java
@@ -104,6 +104,20 @@ class BoothExperienceServiceAuthorizationTest {
   }
 
   @Test
+  void createBoothExperienceAllowsAdminWithoutBoothOwnership() {
+    Booth booth = booth(10L, 100L, 200L);
+    when(boothRepository.findById(10L)).thenReturn(Optional.of(booth));
+    when(boothExperienceRepository.save(any(BoothExperience.class))).thenAnswer(invocation -> {
+      BoothExperience experience = invocation.getArgument(0);
+      experience.setExperienceId(1L);
+      return experience;
+    });
+
+    assertThat(service.createBoothExperience(10L, request(), 999L, "ADMIN").getExperienceId())
+        .isEqualTo(1L);
+  }
+
+  @Test
   void updateBoothExperienceRejectsBoothManagerFromDifferentBooth() {
     BoothExperience experience = experience(1L, booth(10L, 100L, 200L));
     when(boothExperienceRepository.findById(1L)).thenReturn(Optional.of(experience));
@@ -158,6 +172,21 @@ class BoothExperienceServiceAuthorizationTest {
     updateDto.setStatusCode("READY");
 
     assertThat(service.updateReservationStatus(5L, updateDto, 100L, "EVENT_MANAGER").getReservationId())
+        .isEqualTo(5L);
+  }
+
+  @Test
+  void updateReservationStatusAllowsAdminWithoutBoothOwnership() {
+    BoothExperienceReservation reservation = reservation(5L, experience(1L, booth(10L, 100L, 200L)), "WAITING");
+    BoothExperienceStatusCode ready = status("READY");
+    when(reservationRepository.findById(5L)).thenReturn(Optional.of(reservation));
+    when(statusCodeRepository.findByCode("READY")).thenReturn(Optional.of(ready));
+    when(reservationRepository.save(reservation)).thenReturn(reservation);
+
+    BoothExperienceStatusUpdateDto updateDto = new BoothExperienceStatusUpdateDto();
+    updateDto.setStatusCode("READY");
+
+    assertThat(service.updateReservationStatus(5L, updateDto, 999L, "ADMIN").getReservationId())
         .isEqualTo(5L);
   }
 

--- a/src/test/java/com/fairing/fairplay/booth/service/BoothExperienceServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/booth/service/BoothExperienceServiceAuthorizationTest.java
@@ -231,6 +231,21 @@ class BoothExperienceServiceAuthorizationTest {
   }
 
   @Test
+  void getBoothExperiencesReturnsRequestedBoothForAdmin() {
+    Booth booth = booth(10L, 100L, 200L);
+    BoothExperience experience = experience(1L, booth);
+    when(boothExperienceRepository.findByBooth_Id(10L)).thenReturn(List.of(experience));
+
+    assertThat(service.getBoothExperiences(10L, 999L, "ADMIN"))
+        .extracting("experienceId")
+        .containsExactly(1L);
+
+    verify(boothRepository, never()).findById(any());
+    verify(boothExperienceRepository, never()).findByEventManagerId(any());
+    verify(boothExperienceRepository, never()).findByBoothAdminId(any());
+  }
+
+  @Test
   void createReservationUsesAuthenticatedPrincipalUserId() {
     CustomUserDetails principal = mock(CustomUserDetails.class);
     BoothExperience experience = experience(1L, booth(10L, 100L, 200L));
@@ -277,6 +292,19 @@ class BoothExperienceServiceAuthorizationTest {
   @Test
   void getManageableExperiencesReturnsEmptyForCommonUser() {
     assertThat(service.getManageableExperiences(300L, "COMMON")).isEmpty();
+
+    verify(boothExperienceRepository, never()).findByEventManagerId(any());
+    verify(boothExperienceRepository, never()).findByBoothAdminId(any());
+  }
+
+  @Test
+  void getManageableExperiencesReturnsAllExperiencesForAdmin() {
+    BoothExperience experience = experience(1L, booth(10L, 100L, 200L));
+    when(boothExperienceRepository.findAll()).thenReturn(List.of(experience));
+
+    assertThat(service.getManageableExperiences(999L, "ADMIN"))
+        .extracting("experienceId")
+        .containsExactly(1L);
 
     verify(boothExperienceRepository, never()).findByEventManagerId(any());
     verify(boothExperienceRepository, never()).findByBoothAdminId(any());

--- a/src/test/java/com/fairing/fairplay/booth/service/BoothExperienceServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/booth/service/BoothExperienceServiceAuthorizationTest.java
@@ -1,6 +1,7 @@
 package com.fairing.fairplay.booth.service;
 
 import com.fairing.fairplay.booth.dto.BoothExperienceRequestDto;
+import com.fairing.fairplay.booth.dto.BoothExperienceReservationRequestDto;
 import com.fairing.fairplay.booth.dto.BoothExperienceStatusUpdateDto;
 import com.fairing.fairplay.booth.entity.Booth;
 import com.fairing.fairplay.booth.entity.BoothExperience;
@@ -11,12 +12,14 @@ import com.fairing.fairplay.booth.repository.BoothExperienceReservationRepositor
 import com.fairing.fairplay.booth.repository.BoothExperienceStatusCodeRepository;
 import com.fairing.fairplay.booth.repository.BoothRepository;
 import com.fairing.fairplay.common.exception.CustomException;
+import com.fairing.fairplay.core.security.CustomUserDetails;
 import com.fairing.fairplay.event.entity.Event;
 import com.fairing.fairplay.user.entity.BoothAdmin;
 import com.fairing.fairplay.user.entity.EventAdmin;
 import com.fairing.fairplay.user.entity.Users;
 import com.fairing.fairplay.user.repository.UserRepository;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
@@ -27,10 +30,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.access.AccessDeniedException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -196,6 +202,50 @@ class BoothExperienceServiceAuthorizationTest {
   }
 
   @Test
+  void createReservationUsesAuthenticatedPrincipalUserId() {
+    CustomUserDetails principal = mock(CustomUserDetails.class);
+    BoothExperience experience = experience(1L, booth(10L, 100L, 200L));
+    Users principalUser = user(300L);
+    BoothExperienceStatusCode waiting = status("WAITING");
+    BoothExperienceReservationRequestDto requestDto = BoothExperienceReservationRequestDto.builder()
+        .notes("principal only")
+        .build();
+
+    when(principal.getUserId()).thenReturn(300L);
+    when(boothExperienceRepository.findByIdWithPessimisticLock(1L)).thenReturn(Optional.of(experience));
+    when(userRepository.findById(300L)).thenReturn(Optional.of(principalUser));
+    when(reservationRepository.findByBoothExperienceAndUser(experience, principalUser)).thenReturn(Optional.empty());
+    when(statusCodeRepository.findByCode("WAITING")).thenReturn(Optional.of(waiting));
+    when(reservationRepository.findNextQueuePosition(1L)).thenReturn(1);
+    when(reservationRepository.save(any(BoothExperienceReservation.class))).thenAnswer(invocation -> {
+      BoothExperienceReservation saved = invocation.getArgument(0);
+      saved.setReservationId(77L);
+      saved.setReservedAt(LocalDateTime.now());
+      return saved;
+    });
+
+    assertThat(service.createReservation(1L, principal, requestDto).getUserId()).isEqualTo(300L);
+
+    verify(userRepository).findById(300L);
+    verify(userRepository, never()).findById(eq(999L));
+  }
+
+  @Test
+  void createReservationRejectsNullPrincipalBeforeRepositoryAccess() {
+    BoothExperienceReservationRequestDto requestDto = BoothExperienceReservationRequestDto.builder()
+        .notes("blocked")
+        .build();
+
+    assertThatThrownBy(() -> service.createReservation(1L, null, requestDto))
+        .isInstanceOf(AccessDeniedException.class)
+        .hasMessage("로그인이 필요합니다.");
+
+    verify(boothExperienceRepository, never()).findByIdWithPessimisticLock(any());
+    verify(userRepository, never()).findById(any());
+    verify(reservationRepository, never()).save(any());
+  }
+
+  @Test
   void getManageableExperiencesReturnsEmptyForCommonUser() {
     assertThat(service.getManageableExperiences(300L, "COMMON")).isEmpty();
 
@@ -263,6 +313,17 @@ class BoothExperienceServiceAuthorizationTest {
     booth.setStartDate(LocalDate.now());
     booth.setEndDate(LocalDate.now().plusDays(1));
     return booth;
+  }
+
+  private Users user(Long userId) {
+    return Users.builder()
+        .userId(userId)
+        .email("user" + userId + "@example.com")
+        .name("참가자")
+        .nickname("참가자")
+        .phone("010-0000-0000")
+        .password("pw")
+        .build();
   }
 
   private BoothExperienceReservation reservation(Long reservationId, BoothExperience experience, String statusCode) {

--- a/src/test/java/com/fairing/fairplay/booth/service/BoothExperienceServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/booth/service/BoothExperienceServiceAuthorizationTest.java
@@ -1,0 +1,285 @@
+package com.fairing.fairplay.booth.service;
+
+import com.fairing.fairplay.booth.dto.BoothExperienceRequestDto;
+import com.fairing.fairplay.booth.dto.BoothExperienceStatusUpdateDto;
+import com.fairing.fairplay.booth.entity.Booth;
+import com.fairing.fairplay.booth.entity.BoothExperience;
+import com.fairing.fairplay.booth.entity.BoothExperienceReservation;
+import com.fairing.fairplay.booth.entity.BoothExperienceStatusCode;
+import com.fairing.fairplay.booth.repository.BoothExperienceRepository;
+import com.fairing.fairplay.booth.repository.BoothExperienceReservationRepository;
+import com.fairing.fairplay.booth.repository.BoothExperienceStatusCodeRepository;
+import com.fairing.fairplay.booth.repository.BoothRepository;
+import com.fairing.fairplay.common.exception.CustomException;
+import com.fairing.fairplay.event.entity.Event;
+import com.fairing.fairplay.user.entity.BoothAdmin;
+import com.fairing.fairplay.user.entity.EventAdmin;
+import com.fairing.fairplay.user.entity.Users;
+import com.fairing.fairplay.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BoothExperienceServiceAuthorizationTest {
+
+  @Mock
+  private BoothExperienceRepository boothExperienceRepository;
+
+  @Mock
+  private BoothExperienceReservationRepository reservationRepository;
+
+  @Mock
+  private BoothExperienceStatusCodeRepository statusCodeRepository;
+
+  @Mock
+  private BoothRepository boothRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private SimpMessagingTemplate messagingTemplate;
+
+  private BoothExperienceService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new BoothExperienceService(
+        boothExperienceRepository,
+        reservationRepository,
+        statusCodeRepository,
+        boothRepository,
+        userRepository,
+        messagingTemplate
+    );
+  }
+
+  @Test
+  void createBoothExperienceRejectsEventManagerFromDifferentEvent() {
+    Booth booth = booth(10L, 100L, 200L);
+    when(boothRepository.findById(10L)).thenReturn(Optional.of(booth));
+
+    assertThatThrownBy(() -> service.createBoothExperience(10L, request(), 999L, "EVENT_MANAGER"))
+        .isInstanceOf(CustomException.class)
+        .extracting("status")
+        .isEqualTo(HttpStatus.FORBIDDEN);
+
+    verify(boothExperienceRepository, never()).save(any());
+  }
+
+  @Test
+  void createBoothExperienceAllowsOwningBoothManager() {
+    Booth booth = booth(10L, 100L, 200L);
+    when(boothRepository.findById(10L)).thenReturn(Optional.of(booth));
+    when(boothExperienceRepository.save(any(BoothExperience.class))).thenAnswer(invocation -> {
+      BoothExperience experience = invocation.getArgument(0);
+      experience.setExperienceId(1L);
+      return experience;
+    });
+
+    assertThat(service.createBoothExperience(10L, request(), 200L, "BOOTH_MANAGER").getExperienceId())
+        .isEqualTo(1L);
+  }
+
+  @Test
+  void updateBoothExperienceRejectsBoothManagerFromDifferentBooth() {
+    BoothExperience experience = experience(1L, booth(10L, 100L, 200L));
+    when(boothExperienceRepository.findById(1L)).thenReturn(Optional.of(experience));
+
+    assertThatThrownBy(() -> service.updateBoothExperience(1L, request(), 999L, "BOOTH_MANAGER"))
+        .isInstanceOf(CustomException.class)
+        .extracting("status")
+        .isEqualTo(HttpStatus.FORBIDDEN);
+
+    verify(boothExperienceRepository, never()).save(any());
+  }
+
+  @Test
+  void getExperienceReservationsRejectsEventManagerFromDifferentEvent() {
+    BoothExperience experience = experience(1L, booth(10L, 100L, 200L));
+    when(boothExperienceRepository.findById(1L)).thenReturn(Optional.of(experience));
+
+    assertThatThrownBy(() -> service.getExperienceReservations(1L, 999L, "EVENT_MANAGER"))
+        .isInstanceOf(CustomException.class)
+        .extracting("status")
+        .isEqualTo(HttpStatus.FORBIDDEN);
+
+    verify(reservationRepository, never()).findByBoothExperienceOrderByReservedAt(any());
+  }
+
+  @Test
+  void updateReservationStatusRejectsBoothManagerFromDifferentBooth() {
+    BoothExperienceReservation reservation = reservation(5L, experience(1L, booth(10L, 100L, 200L)), "WAITING");
+    when(reservationRepository.findById(5L)).thenReturn(Optional.of(reservation));
+
+    BoothExperienceStatusUpdateDto updateDto = new BoothExperienceStatusUpdateDto();
+    updateDto.setStatusCode("READY");
+
+    assertThatThrownBy(() -> service.updateReservationStatus(5L, updateDto, 999L, "BOOTH_MANAGER"))
+        .isInstanceOf(CustomException.class)
+        .extracting("status")
+        .isEqualTo(HttpStatus.FORBIDDEN);
+
+    verify(statusCodeRepository, never()).findByCode(any());
+    verify(reservationRepository, never()).save(any());
+  }
+
+  @Test
+  void updateReservationStatusAllowsOwningEventManager() {
+    BoothExperienceReservation reservation = reservation(5L, experience(1L, booth(10L, 100L, 200L)), "WAITING");
+    BoothExperienceStatusCode ready = status("READY");
+    when(reservationRepository.findById(5L)).thenReturn(Optional.of(reservation));
+    when(statusCodeRepository.findByCode("READY")).thenReturn(Optional.of(ready));
+    when(reservationRepository.save(reservation)).thenReturn(reservation);
+
+    BoothExperienceStatusUpdateDto updateDto = new BoothExperienceStatusUpdateDto();
+    updateDto.setStatusCode("READY");
+
+    assertThat(service.updateReservationStatus(5L, updateDto, 100L, "EVENT_MANAGER").getReservationId())
+        .isEqualTo(5L);
+  }
+
+  @Test
+  void deleteBoothExperienceRejectsCommonUserBeforeDelete() {
+    BoothExperience experience = experience(1L, booth(10L, 100L, 200L));
+    when(boothExperienceRepository.findById(1L)).thenReturn(Optional.of(experience));
+
+    assertThatThrownBy(() -> service.deleteBoothExperience(1L, 300L, "COMMON"))
+        .isInstanceOf(CustomException.class)
+        .extracting("status")
+        .isEqualTo(HttpStatus.FORBIDDEN);
+
+    verify(reservationRepository, never()).findActiveReservationsByExperience(any());
+    verify(boothExperienceRepository, never()).delete(any());
+  }
+
+  @Test
+  void deleteBoothExperienceAllowsOwningBoothManager() {
+    BoothExperience experience = experience(1L, booth(10L, 100L, 200L));
+    when(boothExperienceRepository.findById(1L)).thenReturn(Optional.of(experience));
+    when(reservationRepository.findActiveReservationsByExperience(experience)).thenReturn(List.of());
+    when(reservationRepository.findByBoothExperienceOrderByReservedAt(experience)).thenReturn(List.of());
+
+    service.deleteBoothExperience(1L, 200L, "BOOTH_MANAGER");
+
+    verify(boothExperienceRepository).delete(experience);
+  }
+
+  @Test
+  void getBoothExperiencesReturnsOnlyRequestedBoothForOwningEventManager() {
+    Booth booth = booth(10L, 100L, 200L);
+    BoothExperience experience = experience(1L, booth);
+    when(boothRepository.findById(10L)).thenReturn(Optional.of(booth));
+    when(boothExperienceRepository.findByBooth_Id(10L)).thenReturn(List.of(experience));
+
+    assertThat(service.getBoothExperiences(10L, 100L, "EVENT_MANAGER"))
+        .extracting("experienceId")
+        .containsExactly(1L);
+
+    verify(boothExperienceRepository, never()).findByEventManagerId(any());
+  }
+
+  @Test
+  void getManageableExperiencesReturnsEmptyForCommonUser() {
+    assertThat(service.getManageableExperiences(300L, "COMMON")).isEmpty();
+
+    verify(boothExperienceRepository, never()).findByEventManagerId(any());
+    verify(boothExperienceRepository, never()).findByBoothAdminId(any());
+  }
+
+  private BoothExperienceRequestDto request() {
+    BoothExperienceRequestDto requestDto = new BoothExperienceRequestDto();
+    requestDto.setTitle("체험");
+    requestDto.setDescription("설명");
+    requestDto.setExperienceDate(LocalDate.now().plusDays(7));
+    requestDto.setStartTime(LocalTime.of(10, 0));
+    requestDto.setEndTime(LocalTime.of(11, 0));
+    requestDto.setDurationMinutes(10);
+    requestDto.setMaxCapacity(5);
+    requestDto.setAllowWaiting(true);
+    requestDto.setMaxWaitingCount(10);
+    requestDto.setAllowDuplicateReservation(false);
+    requestDto.setIsReservationEnabled(true);
+    return requestDto;
+  }
+
+  private BoothExperience experience(Long experienceId, Booth booth) {
+    return BoothExperience.builder()
+        .experienceId(experienceId)
+        .booth(booth)
+        .title("체험")
+        .description("설명")
+        .experienceDate(LocalDate.now().plusDays(7))
+        .startTime(LocalTime.of(10, 0))
+        .endTime(LocalTime.of(11, 0))
+        .durationMinutes(10)
+        .maxCapacity(5)
+        .allowWaiting(true)
+        .maxWaitingCount(10)
+        .allowDuplicateReservation(false)
+        .isReservationEnabled(true)
+        .reservations(List.of())
+        .build();
+  }
+
+  private Booth booth(Long boothId, Long eventManagerId, Long boothManagerId) {
+    Users eventManager = new Users(eventManagerId);
+    EventAdmin eventAdmin = new EventAdmin();
+    eventAdmin.setUser(eventManager);
+    eventAdmin.setUserId(eventManagerId);
+
+    Event event = new Event();
+    event.setEventId(1L);
+    event.setManager(eventAdmin);
+    event.setTitleKr("행사");
+    event.setTitleEng("Event");
+
+    BoothAdmin boothAdmin = new BoothAdmin();
+    boothAdmin.setUser(new Users(boothManagerId));
+    boothAdmin.setUserId(boothManagerId);
+
+    Booth booth = new Booth();
+    booth.setId(boothId);
+    booth.setEvent(event);
+    booth.setBoothAdmin(boothAdmin);
+    booth.setBoothTitle("부스");
+    booth.setBoothDescription("설명");
+    booth.setStartDate(LocalDate.now());
+    booth.setEndDate(LocalDate.now().plusDays(1));
+    return booth;
+  }
+
+  private BoothExperienceReservation reservation(Long reservationId, BoothExperience experience, String statusCode) {
+    BoothExperienceReservation reservation = BoothExperienceReservation.builder()
+        .boothExperience(experience)
+        .experienceStatusCode(status(statusCode))
+        .user(new Users(300L))
+        .queuePosition(1)
+        .build();
+    reservation.setReservationId(reservationId);
+    return reservation;
+  }
+
+  private BoothExperienceStatusCode status(String code) {
+    BoothExperienceStatusCode statusCode = new BoothExperienceStatusCode();
+    statusCode.setCode(code);
+    statusCode.setName(code);
+    return statusCode;
+  }
+}

--- a/src/test/java/com/fairing/fairplay/booth/service/BoothQrServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/booth/service/BoothQrServiceAuthorizationTest.java
@@ -1,0 +1,248 @@
+package com.fairing.fairplay.booth.service;
+
+import com.fairing.fairplay.attendee.entity.Attendee;
+import com.fairing.fairplay.booth.dto.BoothEntryRequestDto;
+import com.fairing.fairplay.booth.entity.Booth;
+import com.fairing.fairplay.booth.entity.BoothExperience;
+import com.fairing.fairplay.booth.entity.BoothExperienceReservation;
+import com.fairing.fairplay.booth.entity.BoothExperienceStatusCode;
+import com.fairing.fairplay.booth.repository.BoothExperienceRepository;
+import com.fairing.fairplay.booth.repository.BoothExperienceReservationRepository;
+import com.fairing.fairplay.booth.repository.BoothExperienceStatusCodeRepository;
+import com.fairing.fairplay.booth.repository.BoothRepository;
+import com.fairing.fairplay.common.exception.CustomException;
+import com.fairing.fairplay.event.entity.Event;
+import com.fairing.fairplay.qr.dto.scan.CheckResponseDto;
+import com.fairing.fairplay.qr.entity.QrTicket;
+import com.fairing.fairplay.qr.service.QrTicketEntryService;
+import com.fairing.fairplay.reservation.entity.Reservation;
+import com.fairing.fairplay.user.entity.BoothAdmin;
+import com.fairing.fairplay.user.entity.EventAdmin;
+import com.fairing.fairplay.user.entity.Users;
+import com.fairing.fairplay.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BoothQrServiceAuthorizationTest {
+
+  @Mock
+  private BoothExperienceRepository boothExperienceRepository;
+
+  @Mock
+  private BoothExperienceReservationRepository reservationRepository;
+
+  @Mock
+  private BoothExperienceStatusCodeRepository statusCodeRepository;
+
+  @Mock
+  private BoothRepository boothRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private QrTicketEntryService qrTicketEntryService;
+
+  @Mock
+  private SimpMessagingTemplate messagingTemplate;
+
+  private BoothQrService boothQrService;
+
+  @BeforeEach
+  void setUp() {
+    BoothExperienceService boothExperienceService = new BoothExperienceService(
+        boothExperienceRepository,
+        reservationRepository,
+        statusCodeRepository,
+        boothRepository,
+        userRepository,
+        messagingTemplate
+    );
+    boothQrService = new BoothQrService(
+        userRepository,
+        statusCodeRepository,
+        boothExperienceService,
+        qrTicketEntryService,
+        messagingTemplate
+    );
+  }
+
+  @Test
+  void checkInRejectsCommonUserBeforeStatusSave() {
+    BoothExperienceReservation reservation = givenReadyReservationForManagedBooth();
+
+    assertThatThrownBy(() -> boothQrService.checkIn(request(), 300L, "COMMON"))
+        .isInstanceOf(CustomException.class)
+        .extracting("status")
+        .isEqualTo(HttpStatus.FORBIDDEN);
+
+    verify(reservationRepository, never()).save(any());
+    verify(qrTicketEntryService, never()).processQrEntry(any());
+    assertThat(reservation.getExperienceStatusCode().getCode()).isEqualTo("READY");
+  }
+
+  @Test
+  void checkInRejectsBoothManagerFromDifferentBoothBeforeStatusSave() {
+    BoothExperienceReservation reservation = givenReadyReservationForManagedBooth();
+
+    assertThatThrownBy(() -> boothQrService.checkIn(request(), 999L, "BOOTH_MANAGER"))
+        .isInstanceOf(CustomException.class)
+        .extracting("status")
+        .isEqualTo(HttpStatus.FORBIDDEN);
+
+    verify(reservationRepository, never()).save(any());
+    verify(qrTicketEntryService, never()).processQrEntry(any());
+    assertThat(reservation.getExperienceStatusCode().getCode()).isEqualTo("READY");
+  }
+
+  @Test
+  void checkInAllowsOwningEventManagerToMoveReservationInProgress() {
+    BoothExperienceReservation reservation = givenReadyReservationForManagedBooth();
+    when(reservationRepository.save(reservation)).thenReturn(reservation);
+    when(qrTicketEntryService.processQrEntry(any(QrTicket.class))).thenReturn(
+        CheckResponseDto.builder()
+            .message("입장 완료")
+            .checkInTime(LocalDateTime.of(2026, 5, 18, 12, 0))
+            .build()
+    );
+
+    assertThat(boothQrService.checkIn(request(), 100L, "EVENT_MANAGER").getMessage())
+        .isEqualTo("입장 완료");
+
+    verify(reservationRepository).save(reservation);
+    verify(qrTicketEntryService).processQrEntry(any(QrTicket.class));
+    assertThat(reservation.getExperienceStatusCode().getCode()).isEqualTo("IN_PROGRESS");
+  }
+
+  private BoothExperienceReservation givenReadyReservationForManagedBooth() {
+    BoothExperience experience = experience(1L, booth(10L, 100L, 200L));
+    BoothExperienceReservation reservation = reservation(5L, experience, "READY");
+    QrTicket qrTicket = qrTicket(reservation);
+    when(qrTicketEntryService.validateQrTicket(any(BoothEntryRequestDto.class))).thenReturn(qrTicket);
+    when(boothExperienceRepository.findById(1L)).thenReturn(Optional.of(experience));
+    when(reservationRepository.findLatestReadyReservation(1L, 10L, 300L)).thenReturn(Optional.of(reservation));
+    when(reservationRepository.findById(5L)).thenReturn(Optional.of(reservation));
+    when(statusCodeRepository.findByCode("IN_PROGRESS")).thenReturn(Optional.of(status("IN_PROGRESS")));
+    return reservation;
+  }
+
+  private BoothEntryRequestDto request() {
+    return BoothEntryRequestDto.builder()
+        .eventId(1L)
+        .boothId(10L)
+        .boothExperienceId(1L)
+        .qrCode("qr-code")
+        .build();
+  }
+
+  private BoothExperience experience(Long experienceId, Booth booth) {
+    return BoothExperience.builder()
+        .experienceId(experienceId)
+        .booth(booth)
+        .title("체험")
+        .description("설명")
+        .experienceDate(LocalDate.now().plusDays(7))
+        .startTime(LocalTime.of(10, 0))
+        .endTime(LocalTime.of(11, 0))
+        .durationMinutes(10)
+        .maxCapacity(5)
+        .allowWaiting(true)
+        .maxWaitingCount(10)
+        .allowDuplicateReservation(false)
+        .isReservationEnabled(true)
+        .reservations(List.of())
+        .build();
+  }
+
+  private Booth booth(Long boothId, Long eventManagerId, Long boothManagerId) {
+    EventAdmin eventAdmin = new EventAdmin();
+    eventAdmin.setUser(new Users(eventManagerId));
+    eventAdmin.setUserId(eventManagerId);
+
+    Event event = new Event();
+    event.setEventId(1L);
+    event.setManager(eventAdmin);
+    event.setTitleKr("행사");
+    event.setTitleEng("Event");
+
+    BoothAdmin boothAdmin = new BoothAdmin();
+    boothAdmin.setUser(new Users(boothManagerId));
+    boothAdmin.setUserId(boothManagerId);
+
+    Booth booth = new Booth();
+    booth.setId(boothId);
+    booth.setEvent(event);
+    booth.setBoothAdmin(boothAdmin);
+    booth.setBoothTitle("부스");
+    booth.setBoothDescription("설명");
+    booth.setStartDate(LocalDate.now());
+    booth.setEndDate(LocalDate.now().plusDays(1));
+    return booth;
+  }
+
+  private BoothExperienceReservation reservation(Long reservationId, BoothExperience experience,
+      String statusCode) {
+    Users user = Users.builder()
+        .userId(300L)
+        .email("user@example.com")
+        .name("참가자")
+        .nickname("참가자")
+        .phone("010-0000-0000")
+        .password("pw")
+        .build();
+    BoothExperienceReservation reservation = BoothExperienceReservation.builder()
+        .boothExperience(experience)
+        .experienceStatusCode(status(statusCode))
+        .user(user)
+        .queuePosition(1)
+        .build();
+    reservation.setReservationId(reservationId);
+    return reservation;
+  }
+
+  private QrTicket qrTicket(BoothExperienceReservation boothReservation) {
+    Reservation reservation = mock(Reservation.class);
+    when(reservation.getUser()).thenReturn(boothReservation.getUser());
+
+    Attendee attendee = Attendee.builder()
+        .reservation(reservation)
+        .name("참가자")
+        .phone("010-0000-0000")
+        .email("user@example.com")
+        .build();
+
+    return QrTicket.builder()
+        .id(99L)
+        .attendee(attendee)
+        .qrCode("qr-code")
+        .ticketNo("TICKET-1")
+        .expiredAt(LocalDateTime.now().plusDays(1))
+        .build();
+  }
+
+  private BoothExperienceStatusCode status(String code) {
+    BoothExperienceStatusCode statusCode = new BoothExperienceStatusCode();
+    statusCode.setCode(code);
+    statusCode.setName(code);
+    return statusCode;
+  }
+}

--- a/src/test/java/com/fairing/fairplay/booth/service/BoothQrServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/booth/service/BoothQrServiceAuthorizationTest.java
@@ -133,6 +133,25 @@ class BoothQrServiceAuthorizationTest {
     assertThat(reservation.getExperienceStatusCode().getCode()).isEqualTo("IN_PROGRESS");
   }
 
+  @Test
+  void checkInAllowsAdminToMoveReservationInProgress() {
+    BoothExperienceReservation reservation = givenReadyReservationForManagedBooth();
+    when(reservationRepository.save(reservation)).thenReturn(reservation);
+    when(qrTicketEntryService.processQrEntry(any(QrTicket.class))).thenReturn(
+        CheckResponseDto.builder()
+            .message("입장 완료")
+            .checkInTime(LocalDateTime.of(2026, 5, 18, 12, 0))
+            .build()
+    );
+
+    assertThat(boothQrService.checkIn(request(), 999L, "ADMIN").getMessage())
+        .isEqualTo("입장 완료");
+
+    verify(reservationRepository).save(reservation);
+    verify(qrTicketEntryService).processQrEntry(any(QrTicket.class));
+    assertThat(reservation.getExperienceStatusCode().getCode()).isEqualTo("IN_PROGRESS");
+  }
+
   private BoothExperienceReservation givenReadyReservationForManagedBooth() {
     BoothExperience experience = experience(1L, booth(10L, 100L, 200L));
     BoothExperienceReservation reservation = reservation(5L, experience, "READY");

--- a/src/test/java/com/fairing/fairplay/event/service/EventManagerServiceRefundAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/event/service/EventManagerServiceRefundAuthorizationTest.java
@@ -1,0 +1,86 @@
+package com.fairing.fairplay.event.service;
+
+import com.fairing.fairplay.event.entity.Event;
+import com.fairing.fairplay.event.repository.EventManagerRepository;
+import com.fairing.fairplay.payment.entity.Payment;
+import com.fairing.fairplay.payment.entity.Refund;
+import com.fairing.fairplay.payment.repository.RefundRepository;
+import com.fairing.fairplay.user.entity.EventAdmin;
+import com.fairing.fairplay.user.entity.Users;
+import com.fairing.fairplay.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EventManagerServiceRefundAuthorizationTest {
+
+    @Mock
+    private EventManagerRepository eventManagerRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RefundRepository refundRepository;
+
+    private EventManagerService eventManagerService;
+
+    @BeforeEach
+    void setUp() {
+        eventManagerService = new EventManagerService(
+                eventManagerRepository,
+                userRepository,
+                refundRepository
+        );
+    }
+
+    @Test
+    void refundOwnershipUsesRefundPaymentEventManager() {
+        when(refundRepository.findById(1L))
+                .thenReturn(Optional.of(refund(payment(event(10L, 100L)))));
+
+        assertThat(eventManagerService.isRefundInManagedEvent(1L, 100L)).isTrue();
+        assertThat(eventManagerService.isRefundInManagedEvent(1L, 999L)).isFalse();
+    }
+
+    @Test
+    void refundWithoutEventIsNotOwnedByEventManager() {
+        when(refundRepository.findById(1L))
+                .thenReturn(Optional.of(refund(payment(null))));
+
+        assertThat(eventManagerService.isRefundInManagedEvent(1L, 100L)).isFalse();
+    }
+
+    private Refund refund(Payment payment) {
+        return Refund.builder()
+                .refundId(1L)
+                .payment(payment)
+                .build();
+    }
+
+    private Payment payment(Event event) {
+        return Payment.builder()
+                .paymentId(10L)
+                .event(event)
+                .build();
+    }
+
+    private Event event(Long eventId, Long managerUserId) {
+        EventAdmin eventAdmin = new EventAdmin();
+        eventAdmin.setUserId(managerUserId);
+        eventAdmin.setUser(new Users(managerUserId));
+
+        Event event = new Event();
+        event.setEventId(eventId);
+        event.setManager(eventAdmin);
+        return event;
+    }
+}

--- a/src/test/java/com/fairing/fairplay/payment/service/AdminRefundServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/payment/service/AdminRefundServiceAuthorizationTest.java
@@ -1,0 +1,220 @@
+package com.fairing.fairplay.payment.service;
+
+import com.fairing.fairplay.core.security.CustomUserDetails;
+import com.fairing.fairplay.event.entity.Event;
+import com.fairing.fairplay.payment.dto.AdminRefundListRequestDto;
+import com.fairing.fairplay.payment.dto.AdminRefundListResponseDto;
+import com.fairing.fairplay.payment.dto.RefundApprovalDto;
+import com.fairing.fairplay.payment.entity.Payment;
+import com.fairing.fairplay.payment.entity.PaymentTargetType;
+import com.fairing.fairplay.payment.entity.Refund;
+import com.fairing.fairplay.payment.entity.RefundStatusCode;
+import com.fairing.fairplay.payment.repository.RefundRepository;
+import com.fairing.fairplay.payment.repository.RefundStatusCodeRepository;
+import com.fairing.fairplay.user.entity.EventAdmin;
+import com.fairing.fairplay.user.entity.Users;
+import com.fairing.fairplay.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminRefundServiceAuthorizationTest {
+
+    @Mock
+    private RefundRepository refundRepository;
+
+    @Mock
+    private RefundStatusCodeRepository refundStatusCodeRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PaymentService paymentService;
+
+    private AdminRefundService adminRefundService;
+
+    @BeforeEach
+    void setUp() {
+        adminRefundService = new AdminRefundService(
+                refundRepository,
+                refundStatusCodeRepository,
+                userRepository,
+                paymentService
+        );
+    }
+
+    @Test
+    void hostApproveRejectOwnEventRefundsSucceed() {
+        CustomUserDetails manager = user(100L, "EVENT_MANAGER");
+        Users approver = new Users(100L);
+        Refund approveRefund = refund(1L, payment(10L, event(1L, 100L)), status("REQUESTED"));
+        when(refundRepository.findById(1L)).thenReturn(Optional.of(approveRefund));
+        when(userRepository.findById(100L)).thenReturn(Optional.of(approver));
+        when(refundStatusCodeRepository.findByCode("APPROVED")).thenReturn(Optional.of(status("APPROVED")));
+        when(refundRepository.save(any(Refund.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertThat(adminRefundService.approveRefund(1L, RefundApprovalDto.builder().build(), manager).getRefundId())
+                .isEqualTo(1L);
+        assertThat(approveRefund.getRefundStatusCode().getCode()).isEqualTo("APPROVED");
+
+        Refund rejectRefund = refund(2L, payment(11L, event(1L, 100L)), status("REQUESTED"));
+        when(refundRepository.findById(2L)).thenReturn(Optional.of(rejectRefund));
+        when(refundStatusCodeRepository.findByCode("REJECTED")).thenReturn(Optional.of(status("REJECTED")));
+
+        assertThat(adminRefundService.rejectRefund(2L, RefundApprovalDto.builder().build(), manager).getRefundId())
+                .isEqualTo(2L);
+        assertThat(rejectRefund.getRefundStatusCode().getCode()).isEqualTo("REJECTED");
+    }
+
+    @Test
+    void hostApproveRejectOtherEventRefundsAreDeniedBeforeMutation() {
+        CustomUserDetails manager = user(999L, "EVENT_MANAGER");
+        Refund refund = refund(1L, payment(10L, event(1L, 100L)), status("REQUESTED"));
+        when(refundRepository.findById(1L)).thenReturn(Optional.of(refund));
+
+        assertThatThrownBy(() -> adminRefundService.approveRefund(1L, RefundApprovalDto.builder().build(), manager))
+                .isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> adminRefundService.rejectRefund(1L, RefundApprovalDto.builder().build(), manager))
+                .isInstanceOf(AccessDeniedException.class);
+
+        assertThat(refund.getRefundStatusCode().getCode()).isEqualTo("REQUESTED");
+        verify(refundRepository, never()).save(any());
+        verify(userRepository, never()).findById(any());
+        verify(refundStatusCodeRepository, never()).findByCode("APPROVED");
+        verify(refundStatusCodeRepository, never()).findByCode("REJECTED");
+    }
+
+    @Test
+    void hostApproveRejectEventNullRefundsAreDeniedBeforeMutation() {
+        CustomUserDetails manager = user(100L, "EVENT_MANAGER");
+        Refund refund = refund(1L, payment(10L, null), status("REQUESTED"));
+        when(refundRepository.findById(1L)).thenReturn(Optional.of(refund));
+
+        assertThatThrownBy(() -> adminRefundService.approveRefund(1L, RefundApprovalDto.builder().build(), manager))
+                .isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> adminRefundService.rejectRefund(1L, RefundApprovalDto.builder().build(), manager))
+                .isInstanceOf(AccessDeniedException.class);
+
+        assertThat(refund.getRefundStatusCode().getCode()).isEqualTo("REQUESTED");
+        verify(refundRepository, never()).save(any());
+        verify(userRepository, never()).findById(any());
+    }
+
+    @Test
+    void hostListWithoutEventIdScopesByManagerUserId() {
+        CustomUserDetails manager = user(100L, "EVENT_MANAGER");
+        AdminRefundListRequestDto request = defaultListRequest();
+        when(refundRepository.findAdminRefundsWithFilters(
+                eq(null), eq(null), eq(null), eq(null), eq(null), eq(null), eq(null), eq(100L), any(Pageable.class)))
+                .thenReturn(Page.empty());
+
+        assertThat(adminRefundService.getAdminRefundList(request, manager)).isEmpty();
+
+        verify(refundRepository).findAdminRefundsWithFilters(
+                eq(null), eq(null), eq(null), eq(null), eq(null), eq(null), eq(null), eq(100L), any(Pageable.class));
+    }
+
+    @Test
+    void adminCanApproveEventNullRefundAndListWithoutManagerScope() {
+        CustomUserDetails admin = user(1L, "ADMIN");
+        Users approver = new Users(1L);
+        Refund refund = refund(1L, payment(10L, null), status("REQUESTED"));
+        when(refundRepository.findById(1L)).thenReturn(Optional.of(refund));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(approver));
+        when(refundStatusCodeRepository.findByCode("APPROVED")).thenReturn(Optional.of(status("APPROVED")));
+        when(refundRepository.save(any(Refund.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertThat(adminRefundService.approveRefund(1L, RefundApprovalDto.builder().build(), admin).getRefundId())
+                .isEqualTo(1L);
+        assertThat(refund.getRefundStatusCode().getCode()).isEqualTo("APPROVED");
+
+        AdminRefundListRequestDto request = defaultListRequest();
+        when(refundRepository.findAdminRefundsWithFilters(
+                eq(null), eq(null), eq(null), eq(null), eq(null), eq(null), eq(null), eq(null), any(Pageable.class)))
+                .thenReturn(Page.empty());
+
+        assertThat(adminRefundService.getAdminRefundList(request, admin)).isEmpty();
+    }
+
+    private AdminRefundListRequestDto defaultListRequest() {
+        return AdminRefundListRequestDto.builder()
+                .page(0)
+                .size(20)
+                .sortBy("createdAt")
+                .sortDirection("desc")
+                .build();
+    }
+
+    private Refund refund(Long refundId, Payment payment, RefundStatusCode status) {
+        return Refund.builder()
+                .refundId(refundId)
+                .payment(payment)
+                .amount(BigDecimal.TEN)
+                .reason("환불 사유")
+                .refundStatusCode(status)
+                .build();
+    }
+
+    private Payment payment(Long paymentId, Event event) {
+        return Payment.builder()
+                .paymentId(paymentId)
+                .event(event)
+                .user(new Users(300L))
+                .paymentTargetType(PaymentTargetType.builder()
+                        .paymentTargetCode("RESERVATION")
+                        .paymentTargetName("예약")
+                        .build())
+                .merchantUid("merchant-" + paymentId)
+                .quantity(1)
+                .price(BigDecimal.valueOf(100))
+                .amount(BigDecimal.valueOf(100))
+                .build();
+    }
+
+    private Event event(Long eventId, Long managerUserId) {
+        EventAdmin eventAdmin = new EventAdmin();
+        eventAdmin.setUserId(managerUserId);
+        eventAdmin.setUser(new Users(managerUserId));
+
+        Event event = new Event();
+        event.setEventId(eventId);
+        event.setTitleKr("행사");
+        event.setTitleEng("Event");
+        event.setManager(eventAdmin);
+        return event;
+    }
+
+    private RefundStatusCode status(String code) {
+        return RefundStatusCode.builder()
+                .code(code)
+                .name(code)
+                .build();
+    }
+
+    private CustomUserDetails user(Long userId, String roleCode) {
+        CustomUserDetails userDetails = mock(CustomUserDetails.class);
+        lenient().when(userDetails.getUserId()).thenReturn(userId);
+        when(userDetails.getRoleCode()).thenReturn(roleCode);
+        return userDetails;
+    }
+}

--- a/src/test/java/com/fairing/fairplay/payment/service/PaymentAdminServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/payment/service/PaymentAdminServiceAuthorizationTest.java
@@ -1,0 +1,83 @@
+package com.fairing.fairplay.payment.service;
+
+import com.fairing.fairplay.core.security.CustomUserDetails;
+import com.fairing.fairplay.payment.dto.PaymentSearchCriteria;
+import com.fairing.fairplay.payment.repository.PaymentAdminRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentAdminServiceAuthorizationTest {
+
+    @Mock
+    private PaymentAdminRepository paymentAdminRepository;
+
+    private PaymentAdminService paymentAdminService;
+
+    @BeforeEach
+    void setUp() {
+        paymentAdminService = new PaymentAdminService(paymentAdminRepository);
+    }
+
+    @Test
+    void adminListsWithoutManagerScope() {
+        PaymentSearchCriteria criteria = defaultCriteria();
+        when(paymentAdminRepository.findPaymentsWithCriteria(eq(criteria), eq(null), any(Pageable.class)))
+                .thenReturn(org.springframework.data.domain.Page.empty());
+
+        paymentAdminService.getPaymentList(criteria, user(1L, "ADMIN"));
+
+        verify(paymentAdminRepository).findPaymentsWithCriteria(eq(criteria), eq(null), any(Pageable.class));
+    }
+
+    @Test
+    void eventManagerListsWithOwnManagerScope() {
+        PaymentSearchCriteria criteria = defaultCriteria();
+        when(paymentAdminRepository.findPaymentsWithCriteria(eq(criteria), eq(100L), any(Pageable.class)))
+                .thenReturn(org.springframework.data.domain.Page.empty());
+
+        paymentAdminService.getPaymentList(criteria, user(100L, "EVENT_MANAGER"));
+
+        verify(paymentAdminRepository).findPaymentsWithCriteria(eq(criteria), eq(100L), any(Pageable.class));
+    }
+
+    @Test
+    void commonIsDeniedBeforeRepositoryCall() {
+        PaymentSearchCriteria criteria = defaultCriteria();
+
+        assertThatThrownBy(() -> paymentAdminService.getPaymentList(criteria, user(300L, "COMMON")))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(paymentAdminRepository, never()).findPaymentsWithCriteria(any(), any(), any());
+    }
+
+    private PaymentSearchCriteria defaultCriteria() {
+        PaymentSearchCriteria criteria = new PaymentSearchCriteria();
+        criteria.setPage(0);
+        criteria.setSize(20);
+        criteria.setSort("paidAt");
+        criteria.setDirection("desc");
+        return criteria;
+    }
+
+    private CustomUserDetails user(Long userId, String roleCode) {
+        CustomUserDetails userDetails = mock(CustomUserDetails.class);
+        lenient().when(userDetails.getUserId()).thenReturn(userId);
+        when(userDetails.getRoleCode()).thenReturn(roleCode);
+        return userDetails;
+    }
+}

--- a/src/test/java/com/fairing/fairplay/payment/service/PaymentServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/payment/service/PaymentServiceAuthorizationTest.java
@@ -1,7 +1,9 @@
 package com.fairing.fairplay.payment.service;
 
 import com.fairing.fairplay.attendeeform.service.AttendeeFormAttendeeService;
+import com.fairing.fairplay.banner.entity.BannerApplication;
 import com.fairing.fairplay.banner.repository.BannerApplicationRepository;
+import com.fairing.fairplay.booth.entity.BoothApplication;
 import com.fairing.fairplay.booth.repository.BoothApplicationRepository;
 import com.fairing.fairplay.booth.repository.BoothRepository;
 import com.fairing.fairplay.core.email.service.PaymentCompletionEmailService;
@@ -19,6 +21,7 @@ import com.fairing.fairplay.payment.repository.PaymentStatusCodeRepository;
 import com.fairing.fairplay.payment.repository.PaymentTargetTypeRepository;
 import com.fairing.fairplay.payment.repository.PaymentTypeCodeRepository;
 import com.fairing.fairplay.payment.repository.RefundRepository;
+import com.fairing.fairplay.reservation.entity.Reservation;
 import com.fairing.fairplay.reservation.repository.ReservationRepository;
 import com.fairing.fairplay.reservation.repository.ReservationStatusCodeRepository;
 import com.fairing.fairplay.reservation.service.ReservationService;
@@ -123,6 +126,7 @@ class PaymentServiceAuthorizationTest {
         CustomUserDetails owner = user(300L, "COMMON");
         Payment nullTargetPayment = payment("merchant-1", 300L, null, null);
         when(paymentRepository.findByMerchantUid("merchant-1")).thenReturn(Optional.of(nullTargetPayment));
+        when(reservationRepository.findById(10L)).thenReturn(Optional.of(reservation(10L, 300L)));
 
         paymentService.updatePaymentTargetId("merchant-1", 10L, owner);
 
@@ -131,6 +135,7 @@ class PaymentServiceAuthorizationTest {
 
         Payment sameTargetPayment = payment("merchant-2", 300L, 10L, null);
         when(paymentRepository.findByMerchantUid("merchant-2")).thenReturn(Optional.of(sameTargetPayment));
+        when(reservationRepository.findById(10L)).thenReturn(Optional.of(reservation(10L, 300L)));
 
         assertThatCode(() -> paymentService.updatePaymentTargetId("merchant-2", 10L, owner))
                 .doesNotThrowAnyException();
@@ -148,6 +153,83 @@ class PaymentServiceAuthorizationTest {
 
         assertThat(otherPayment.getTargetId()).isNull();
         verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void commonCannotBindOwnPaymentToOtherUserReservation() {
+        CustomUserDetails common = user(300L, "COMMON");
+        Payment payment = payment("merchant-1", 300L, null, null);
+        when(paymentRepository.findByMerchantUid("merchant-1")).thenReturn(Optional.of(payment));
+        when(reservationRepository.findById(10L)).thenReturn(Optional.of(reservation(10L, 301L)));
+
+        assertThatThrownBy(() -> paymentService.updatePaymentTargetId("merchant-1", 10L, common))
+                .isInstanceOf(AccessDeniedException.class);
+
+        assertThat(payment.getTargetId()).isNull();
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void commonCanBindOwnBannerApplicationButCannotBindOtherUserBannerApplication() {
+        CustomUserDetails common = user(300L, "COMMON");
+        Payment ownPayment = payment("merchant-1", 300L, null, "BANNER_APPLICATION", null);
+        when(paymentRepository.findByMerchantUid("merchant-1")).thenReturn(Optional.of(ownPayment));
+        when(bannerApplicationRepository.findById(10L)).thenReturn(Optional.of(bannerApplication(10L, 300L)));
+
+        paymentService.updatePaymentTargetId("merchant-1", 10L, common);
+
+        assertThat(ownPayment.getTargetId()).isEqualTo(10L);
+
+        Payment otherTargetPayment = payment("merchant-2", 300L, null, "BANNER_APPLICATION", null);
+        when(paymentRepository.findByMerchantUid("merchant-2")).thenReturn(Optional.of(otherTargetPayment));
+        when(bannerApplicationRepository.findById(11L)).thenReturn(Optional.of(bannerApplication(11L, 301L)));
+
+        assertThatThrownBy(() -> paymentService.updatePaymentTargetId("merchant-2", 11L, common))
+                .isInstanceOf(AccessDeniedException.class);
+
+        assertThat(otherTargetPayment.getTargetId()).isNull();
+    }
+
+    @Test
+    void commonCanBindOwnBoothApplicationButCannotBindOtherUserBoothApplication() {
+        CustomUserDetails common = user(300L, "COMMON");
+        Payment ownPayment = payment("merchant-1", 300L, null, "BOOTH_APPLICATION", null);
+        when(paymentRepository.findByMerchantUid("merchant-1")).thenReturn(Optional.of(ownPayment));
+        when(boothApplicationRepository.findById(10L)).thenReturn(Optional.of(boothApplication(10L, "owner@example.com")));
+        when(userRepository.findByEmail("owner@example.com")).thenReturn(Optional.of(userEntity(300L, "owner@example.com")));
+
+        paymentService.updatePaymentTargetId("merchant-1", 10L, common);
+
+        assertThat(ownPayment.getTargetId()).isEqualTo(10L);
+
+        Payment otherTargetPayment = payment("merchant-2", 300L, null, "BOOTH_APPLICATION", null);
+        when(paymentRepository.findByMerchantUid("merchant-2")).thenReturn(Optional.of(otherTargetPayment));
+        when(boothApplicationRepository.findById(11L)).thenReturn(Optional.of(boothApplication(11L, "other@example.com")));
+        when(userRepository.findByEmail("other@example.com")).thenReturn(Optional.of(userEntity(301L, "other@example.com")));
+
+        assertThatThrownBy(() -> paymentService.updatePaymentTargetId("merchant-2", 11L, common))
+                .isInstanceOf(AccessDeniedException.class);
+
+        assertThat(otherTargetPayment.getTargetId()).isNull();
+    }
+
+    @Test
+    void commonCannotBindUnsupportedTargetCodes() {
+        CustomUserDetails common = user(300L, "COMMON");
+        Payment boothPayment = payment("merchant-1", 300L, null, "BOOTH", null);
+        when(paymentRepository.findByMerchantUid("merchant-1")).thenReturn(Optional.of(boothPayment));
+
+        assertThatThrownBy(() -> paymentService.updatePaymentTargetId("merchant-1", 10L, common))
+                .isInstanceOf(AccessDeniedException.class);
+
+        Payment adPayment = payment("merchant-2", 300L, null, "AD", null);
+        when(paymentRepository.findByMerchantUid("merchant-2")).thenReturn(Optional.of(adPayment));
+
+        assertThatThrownBy(() -> paymentService.updatePaymentTargetId("merchant-2", 20L, common))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(paymentRepository, never()).save(boothPayment);
+        verify(paymentRepository, never()).save(adPayment);
     }
 
     @Test
@@ -194,13 +276,17 @@ class PaymentServiceAuthorizationTest {
     }
 
     private Payment payment(String merchantUid, Long userId, Long targetId, Event event) {
+        return payment(merchantUid, userId, targetId, "RESERVATION", event);
+    }
+
+    private Payment payment(String merchantUid, Long userId, Long targetId, String targetCode, Event event) {
         return Payment.builder()
                 .paymentId(1L)
                 .event(event)
                 .user(new Users(userId))
                 .paymentTargetType(PaymentTargetType.builder()
-                        .paymentTargetCode("RESERVATION")
-                        .paymentTargetName("예약")
+                        .paymentTargetCode(targetCode)
+                        .paymentTargetName(targetCode)
                         .build())
                 .targetId(targetId)
                 .merchantUid(merchantUid)
@@ -218,6 +304,32 @@ class PaymentServiceAuthorizationTest {
                         .name("완료")
                         .build())
                 .build();
+    }
+
+    private Reservation reservation(Long reservationId, Long userId) {
+        Reservation reservation = new Reservation(null, null, null, new Users(userId), 1, 100);
+        reservation.setReservationId(reservationId);
+        return reservation;
+    }
+
+    private BannerApplication bannerApplication(Long applicationId, Long applicantUserId) {
+        return BannerApplication.builder()
+                .id(applicationId)
+                .applicantId(new Users(applicantUserId))
+                .build();
+    }
+
+    private BoothApplication boothApplication(Long applicationId, String boothEmail) {
+        BoothApplication boothApplication = new BoothApplication();
+        boothApplication.setId(applicationId);
+        boothApplication.setBoothEmail(boothEmail);
+        return boothApplication;
+    }
+
+    private Users userEntity(Long userId, String email) {
+        Users user = new Users(userId);
+        user.setEmail(email);
+        return user;
     }
 
     private Event event(Long eventId, Long managerUserId) {

--- a/src/test/java/com/fairing/fairplay/payment/service/PaymentServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/payment/service/PaymentServiceAuthorizationTest.java
@@ -235,6 +235,20 @@ class PaymentServiceAuthorizationTest {
     }
 
     @Test
+    void commonCannotBindPaymentWithNullTargetCodeButDoesNotThrowNullPointerException() {
+        CustomUserDetails common = user(300L, "COMMON");
+        Payment payment = payment("merchant-1", 300L, null, null, null);
+        when(paymentRepository.findByMerchantUid("merchant-1")).thenReturn(Optional.of(payment));
+
+        assertThatThrownBy(() -> paymentService.updatePaymentTargetId("merchant-1", 10L, common))
+                .isInstanceOf(AccessDeniedException.class)
+                .isNotInstanceOf(NullPointerException.class);
+
+        assertThat(payment.getTargetId()).isNull();
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
     void savePaymentRejectsForeignReservationTargetBeforeSave() {
         Users currentUser = userEntity(300L, "owner@example.com", "COMMON");
         when(userRepository.findById(300L)).thenReturn(Optional.of(currentUser));
@@ -305,6 +319,20 @@ class PaymentServiceAuthorizationTest {
 
         assertThatThrownBy(() -> paymentService.savePayment(paymentRequest("AD", 10L), 300L))
                 .isInstanceOf(AccessDeniedException.class);
+
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void savePaymentRejectsResolvedNullTargetCodeButDoesNotThrowNullPointerException() {
+        Users currentUser = userEntity(300L, "owner@example.com", "COMMON");
+        when(userRepository.findById(300L)).thenReturn(Optional.of(currentUser));
+        when(paymentTargetTypeRepository.findByPaymentTargetCode("RESERVATION"))
+                .thenReturn(Optional.of(targetType(null)));
+
+        assertThatThrownBy(() -> paymentService.savePayment(paymentRequest("RESERVATION", 10L), 300L))
+                .isInstanceOf(AccessDeniedException.class)
+                .isNotInstanceOf(NullPointerException.class);
 
         verify(paymentRepository, never()).save(any());
     }

--- a/src/test/java/com/fairing/fairplay/payment/service/PaymentServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/payment/service/PaymentServiceAuthorizationTest.java
@@ -1,0 +1,246 @@
+package com.fairing.fairplay.payment.service;
+
+import com.fairing.fairplay.attendeeform.service.AttendeeFormAttendeeService;
+import com.fairing.fairplay.banner.repository.BannerApplicationRepository;
+import com.fairing.fairplay.booth.repository.BoothApplicationRepository;
+import com.fairing.fairplay.booth.repository.BoothRepository;
+import com.fairing.fairplay.core.email.service.PaymentCompletionEmailService;
+import com.fairing.fairplay.core.security.CustomUserDetails;
+import com.fairing.fairplay.event.entity.Event;
+import com.fairing.fairplay.event.entity.EventDetail;
+import com.fairing.fairplay.event.repository.EventRepository;
+import com.fairing.fairplay.notification.service.NotificationService;
+import com.fairing.fairplay.payment.entity.Payment;
+import com.fairing.fairplay.payment.entity.PaymentStatusCode;
+import com.fairing.fairplay.payment.entity.PaymentTargetType;
+import com.fairing.fairplay.payment.entity.PaymentTypeCode;
+import com.fairing.fairplay.payment.repository.PaymentRepository;
+import com.fairing.fairplay.payment.repository.PaymentStatusCodeRepository;
+import com.fairing.fairplay.payment.repository.PaymentTargetTypeRepository;
+import com.fairing.fairplay.payment.repository.PaymentTypeCodeRepository;
+import com.fairing.fairplay.payment.repository.RefundRepository;
+import com.fairing.fairplay.reservation.repository.ReservationRepository;
+import com.fairing.fairplay.reservation.repository.ReservationStatusCodeRepository;
+import com.fairing.fairplay.reservation.service.ReservationService;
+import com.fairing.fairplay.ticket.repository.EventScheduleRepository;
+import com.fairing.fairplay.ticket.repository.ScheduleTicketRepository;
+import com.fairing.fairplay.ticket.repository.TicketRepository;
+import com.fairing.fairplay.user.entity.EventAdmin;
+import com.fairing.fairplay.user.entity.Users;
+import com.fairing.fairplay.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceAuthorizationTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+    @Mock
+    private RefundRepository refundRepository;
+    @Mock
+    private EventRepository eventRepository;
+    @Mock
+    private ReservationRepository reservationRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private PaymentStatusCodeRepository paymentStatusCodeRepository;
+    @Mock
+    private PaymentTypeCodeRepository paymentTypeCodeRepository;
+    @Mock
+    private PaymentTargetTypeRepository paymentTargetTypeRepository;
+    @Mock
+    private ReservationStatusCodeRepository reservationStatusCodeRepository;
+    @Mock
+    private TicketRepository ticketRepository;
+    @Mock
+    private EventScheduleRepository eventScheduleRepository;
+    @Mock
+    private ScheduleTicketRepository scheduleTicketRepository;
+    @Mock
+    private NotificationService notificationService;
+    @Mock
+    private PaymentCompletionEmailService paymentCompletionEmailService;
+    @Mock
+    private ReservationService reservationService;
+    @Mock
+    private BoothApplicationRepository boothApplicationRepository;
+    @Mock
+    private BoothRepository boothRepository;
+    @Mock
+    private BannerApplicationRepository bannerApplicationRepository;
+    @Mock
+    private AttendeeFormAttendeeService attendeeFormAttendeeService;
+
+    private PaymentService paymentService;
+
+    @BeforeEach
+    void setUp() {
+        paymentService = new PaymentService(
+                paymentRepository,
+                refundRepository,
+                eventRepository,
+                reservationRepository,
+                userRepository,
+                paymentStatusCodeRepository,
+                paymentTypeCodeRepository,
+                paymentTargetTypeRepository,
+                reservationStatusCodeRepository,
+                ticketRepository,
+                eventScheduleRepository,
+                scheduleTicketRepository,
+                notificationService,
+                paymentCompletionEmailService,
+                reservationService,
+                boothApplicationRepository,
+                boothRepository,
+                bannerApplicationRepository,
+                attendeeFormAttendeeService
+        );
+    }
+
+    @Test
+    void commonOwnerCanBindNullTargetAndRepeatSameTarget() {
+        CustomUserDetails owner = user(300L, "COMMON");
+        Payment nullTargetPayment = payment("merchant-1", 300L, null, null);
+        when(paymentRepository.findByMerchantUid("merchant-1")).thenReturn(Optional.of(nullTargetPayment));
+
+        paymentService.updatePaymentTargetId("merchant-1", 10L, owner);
+
+        assertThat(nullTargetPayment.getTargetId()).isEqualTo(10L);
+        verify(paymentRepository).save(nullTargetPayment);
+
+        Payment sameTargetPayment = payment("merchant-2", 300L, 10L, null);
+        when(paymentRepository.findByMerchantUid("merchant-2")).thenReturn(Optional.of(sameTargetPayment));
+
+        assertThatCode(() -> paymentService.updatePaymentTargetId("merchant-2", 10L, owner))
+                .doesNotThrowAnyException();
+        assertThat(sameTargetPayment.getTargetId()).isEqualTo(10L);
+    }
+
+    @Test
+    void commonCannotBindOtherUserPayment() {
+        CustomUserDetails common = user(300L, "COMMON");
+        Payment otherPayment = payment("merchant-1", 301L, null, null);
+        when(paymentRepository.findByMerchantUid("merchant-1")).thenReturn(Optional.of(otherPayment));
+
+        assertThatThrownBy(() -> paymentService.updatePaymentTargetId("merchant-1", 10L, common))
+                .isInstanceOf(AccessDeniedException.class);
+
+        assertThat(otherPayment.getTargetId()).isNull();
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void nonNullDifferentTargetIdIsRejectedBeforeSave() {
+        CustomUserDetails admin = user(1L, "ADMIN");
+        Payment payment = payment("merchant-1", 300L, 10L, null);
+        lenient().when(paymentRepository.findByMerchantUid("merchant-1")).thenReturn(Optional.of(payment));
+
+        assertThatThrownBy(() -> paymentService.updatePaymentTargetId("merchant-1", 20L, admin))
+                .isInstanceOf(AccessDeniedException.class);
+
+        assertThat(payment.getTargetId()).isEqualTo(10L);
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void eventManagerCannotManageListForOtherEvent() {
+        CustomUserDetails manager = user(100L, "EVENT_MANAGER");
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event(1L, 999L)));
+
+        assertThatThrownBy(() -> paymentService.getAllPayments(1L, manager))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(paymentRepository, never()).findByEvent_EventId(any());
+    }
+
+    @Test
+    void eventManagerCanListOwnEvent() {
+        CustomUserDetails manager = user(100L, "EVENT_MANAGER");
+        Event event = event(1L, 100L);
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
+        when(paymentRepository.findByEvent_EventId(1L)).thenReturn(List.of(payment("merchant-1", 300L, 10L, event)));
+
+        assertThat(paymentService.getAllPayments(1L, manager)).hasSize(1);
+    }
+
+    @Test
+    void commonCannotCallManagementList() {
+        assertThatThrownBy(() -> paymentService.getAllPayments(null, user(300L, "COMMON")))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(paymentRepository, never()).findAll();
+        verify(paymentRepository, never()).findByEvent_EventId(any());
+    }
+
+    private Payment payment(String merchantUid, Long userId, Long targetId, Event event) {
+        return Payment.builder()
+                .paymentId(1L)
+                .event(event)
+                .user(new Users(userId))
+                .paymentTargetType(PaymentTargetType.builder()
+                        .paymentTargetCode("RESERVATION")
+                        .paymentTargetName("예약")
+                        .build())
+                .targetId(targetId)
+                .merchantUid(merchantUid)
+                .quantity(1)
+                .price(BigDecimal.valueOf(100))
+                .amount(BigDecimal.valueOf(100))
+                .paymentTypeCode(PaymentTypeCode.builder()
+                        .paymentTypeCodeId(1)
+                        .code("CARD")
+                        .name("카드")
+                        .build())
+                .paymentStatusCode(PaymentStatusCode.builder()
+                        .paymentStatusCodeId(1)
+                        .code("COMPLETED")
+                        .name("완료")
+                        .build())
+                .build();
+    }
+
+    private Event event(Long eventId, Long managerUserId) {
+        EventAdmin eventAdmin = new EventAdmin();
+        eventAdmin.setUserId(managerUserId);
+        eventAdmin.setUser(new Users(managerUserId));
+
+        Event event = new Event();
+        event.setEventId(eventId);
+        event.setTitleKr("행사");
+        event.setTitleEng("Event");
+        event.setManager(eventAdmin);
+        EventDetail detail = new EventDetail();
+        detail.setStartDate(java.time.LocalDate.now());
+        detail.setEndDate(java.time.LocalDate.now().plusDays(1));
+        event.setEventDetail(detail);
+        return event;
+    }
+
+    private CustomUserDetails user(Long userId, String roleCode) {
+        CustomUserDetails userDetails = mock(CustomUserDetails.class);
+        lenient().when(userDetails.getUserId()).thenReturn(userId);
+        lenient().when(userDetails.getRoleCode()).thenReturn(roleCode);
+        return userDetails;
+    }
+}

--- a/src/test/java/com/fairing/fairplay/payment/service/PaymentServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/payment/service/PaymentServiceAuthorizationTest.java
@@ -12,6 +12,7 @@ import com.fairing.fairplay.event.entity.Event;
 import com.fairing.fairplay.event.entity.EventDetail;
 import com.fairing.fairplay.event.repository.EventRepository;
 import com.fairing.fairplay.notification.service.NotificationService;
+import com.fairing.fairplay.payment.dto.PaymentRequestDto;
 import com.fairing.fairplay.payment.entity.Payment;
 import com.fairing.fairplay.payment.entity.PaymentStatusCode;
 import com.fairing.fairplay.payment.entity.PaymentTargetType;
@@ -29,6 +30,7 @@ import com.fairing.fairplay.ticket.repository.EventScheduleRepository;
 import com.fairing.fairplay.ticket.repository.ScheduleTicketRepository;
 import com.fairing.fairplay.ticket.repository.TicketRepository;
 import com.fairing.fairplay.user.entity.EventAdmin;
+import com.fairing.fairplay.user.entity.UserRoleCode;
 import com.fairing.fairplay.user.entity.Users;
 import com.fairing.fairplay.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -233,6 +235,112 @@ class PaymentServiceAuthorizationTest {
     }
 
     @Test
+    void savePaymentRejectsForeignReservationTargetBeforeSave() {
+        Users currentUser = userEntity(300L, "owner@example.com", "COMMON");
+        when(userRepository.findById(300L)).thenReturn(Optional.of(currentUser));
+        when(paymentTargetTypeRepository.findByPaymentTargetCode("RESERVATION"))
+                .thenReturn(Optional.of(targetType("RESERVATION")));
+        when(reservationRepository.findById(10L)).thenReturn(Optional.of(reservation(10L, 301L)));
+
+        assertThatThrownBy(() -> paymentService.savePayment(paymentRequest("RESERVATION", 10L), 300L))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void savePaymentRejectsForeignBannerApplicationTargetBeforeSave() {
+        Users currentUser = userEntity(300L, "owner@example.com", "COMMON");
+        when(userRepository.findById(300L)).thenReturn(Optional.of(currentUser));
+        when(paymentTargetTypeRepository.findByPaymentTargetCode("BANNER_APPLICATION"))
+                .thenReturn(Optional.of(targetType("BANNER_APPLICATION")));
+        when(bannerApplicationRepository.findById(10L)).thenReturn(Optional.of(bannerApplication(10L, 301L)));
+
+        assertThatThrownBy(() -> paymentService.savePayment(paymentRequest("BANNER_APPLICATION", 10L), 300L))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void savePaymentRejectsForeignBoothApplicationTargetBeforeSave() {
+        Users currentUser = userEntity(300L, "owner@example.com", "COMMON");
+        when(userRepository.findById(300L)).thenReturn(Optional.of(currentUser));
+        when(paymentTargetTypeRepository.findByPaymentTargetCode("BOOTH_APPLICATION"))
+                .thenReturn(Optional.of(targetType("BOOTH_APPLICATION")));
+        when(boothApplicationRepository.findById(10L)).thenReturn(Optional.of(boothApplication(10L, "other@example.com")));
+        when(userRepository.findByEmail("other@example.com")).thenReturn(Optional.of(userEntity(301L, "other@example.com")));
+
+        assertThatThrownBy(() -> paymentService.savePayment(paymentRequest("BOOTH_APPLICATION", 10L), 300L))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void savePaymentAllowsOwnedTargets() {
+        Users currentUser = userEntity(300L, "owner@example.com", "COMMON");
+        when(userRepository.findById(300L)).thenReturn(Optional.of(currentUser));
+        when(paymentTargetTypeRepository.findByPaymentTargetCode("BANNER_APPLICATION"))
+                .thenReturn(Optional.of(targetType("BANNER_APPLICATION")));
+        when(paymentTypeCodeRepository.getReferenceByCode("CARD")).thenReturn(paymentTypeCode());
+        when(paymentStatusCodeRepository.getReferenceByCode("PENDING")).thenReturn(paymentStatusCode("PENDING"));
+        when(bannerApplicationRepository.findById(10L)).thenReturn(Optional.of(bannerApplication(10L, 300L)));
+        when(paymentRepository.save(any(Payment.class))).thenAnswer(invocation -> {
+            Payment payment = invocation.getArgument(0);
+            payment.setPaymentId(1L);
+            return payment;
+        });
+
+        assertThat(paymentService.savePayment(paymentRequest("BANNER_APPLICATION", 10L), 300L).getTargetId())
+                .isEqualTo(10L);
+    }
+
+    @Test
+    void savePaymentRejectsUnsupportedTargetCodeWithTargetIdBeforeSave() {
+        Users currentUser = userEntity(300L, "owner@example.com", "COMMON");
+        when(userRepository.findById(300L)).thenReturn(Optional.of(currentUser));
+        when(paymentTargetTypeRepository.findByPaymentTargetCode("AD"))
+                .thenReturn(Optional.of(targetType("AD")));
+
+        assertThatThrownBy(() -> paymentService.savePayment(paymentRequest("AD", 10L), 300L))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void savePaymentRejectsEventManagerTargetIdBeforeSave() {
+        Users eventManager = userEntity(100L, "manager@example.com", "EVENT_MANAGER");
+        when(userRepository.findById(100L)).thenReturn(Optional.of(eventManager));
+        when(paymentTargetTypeRepository.findByPaymentTargetCode("RESERVATION"))
+                .thenReturn(Optional.of(targetType("RESERVATION")));
+
+        assertThatThrownBy(() -> paymentService.savePayment(paymentRequest("RESERVATION", 10L), 100L))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void savePaymentAllowsAdminTargetId() {
+        Users admin = userEntity(1L, "admin@example.com", "ADMIN");
+        when(userRepository.findById(1L)).thenReturn(Optional.of(admin));
+        when(paymentTargetTypeRepository.findByPaymentTargetCode("AD"))
+                .thenReturn(Optional.of(targetType("AD")));
+        when(paymentTypeCodeRepository.getReferenceByCode("CARD")).thenReturn(paymentTypeCode());
+        when(paymentStatusCodeRepository.getReferenceByCode("PENDING")).thenReturn(paymentStatusCode("PENDING"));
+        when(paymentRepository.save(any(Payment.class))).thenAnswer(invocation -> {
+            Payment payment = invocation.getArgument(0);
+            payment.setPaymentId(1L);
+            return payment;
+        });
+
+        assertThat(paymentService.savePayment(paymentRequest("AD", 10L), 1L).getTargetId())
+                .isEqualTo(10L);
+    }
+
+    @Test
     void nonNullDifferentTargetIdIsRejectedBeforeSave() {
         CustomUserDetails admin = user(1L, "ADMIN");
         Payment payment = payment("merchant-1", 300L, 10L, null);
@@ -306,6 +414,17 @@ class PaymentServiceAuthorizationTest {
                 .build();
     }
 
+    private PaymentRequestDto paymentRequest(String targetCode, Long targetId) {
+        return PaymentRequestDto.builder()
+                .paymentTargetType(targetCode)
+                .targetId(targetId)
+                .quantity(1)
+                .price(BigDecimal.valueOf(100))
+                .pgProvider("html5_inicis")
+                .merchantUid("merchant-create")
+                .build();
+    }
+
     private Reservation reservation(Long reservationId, Long userId) {
         Reservation reservation = new Reservation(null, null, null, new Users(userId), 1, 100);
         reservation.setReservationId(reservationId);
@@ -330,6 +449,37 @@ class PaymentServiceAuthorizationTest {
         Users user = new Users(userId);
         user.setEmail(email);
         return user;
+    }
+
+    private Users userEntity(Long userId, String email, String roleCode) {
+        Users user = userEntity(userId, email);
+        UserRoleCode role = mock(UserRoleCode.class);
+        lenient().when(role.getCode()).thenReturn(roleCode);
+        user.setRoleCode(role);
+        return user;
+    }
+
+    private PaymentTargetType targetType(String targetCode) {
+        return PaymentTargetType.builder()
+                .paymentTargetCode(targetCode)
+                .paymentTargetName(targetCode)
+                .build();
+    }
+
+    private PaymentTypeCode paymentTypeCode() {
+        return PaymentTypeCode.builder()
+                .paymentTypeCodeId(1)
+                .code("CARD")
+                .name("카드")
+                .build();
+    }
+
+    private PaymentStatusCode paymentStatusCode(String code) {
+        return PaymentStatusCode.builder()
+                .paymentStatusCodeId(1)
+                .code(code)
+                .name(code)
+                .build();
     }
 
     private Event event(Long eventId, Long managerUserId) {

--- a/src/test/java/com/fairing/fairplay/payment/service/RefundServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/payment/service/RefundServiceAuthorizationTest.java
@@ -1,0 +1,328 @@
+package com.fairing.fairplay.payment.service;
+
+import com.fairing.fairplay.core.security.CustomUserDetails;
+import com.fairing.fairplay.event.entity.Event;
+import com.fairing.fairplay.event.entity.EventDetail;
+import com.fairing.fairplay.payment.dto.PaymentRequestDto;
+import com.fairing.fairplay.payment.dto.RefundApprovalDto;
+import com.fairing.fairplay.payment.dto.RefundListRequestDto;
+import com.fairing.fairplay.payment.entity.Payment;
+import com.fairing.fairplay.payment.entity.PaymentStatusCode;
+import com.fairing.fairplay.payment.entity.PaymentTargetType;
+import com.fairing.fairplay.payment.entity.PaymentTypeCode;
+import com.fairing.fairplay.payment.entity.Refund;
+import com.fairing.fairplay.payment.entity.RefundStatusCode;
+import com.fairing.fairplay.payment.repository.PaymentRepository;
+import com.fairing.fairplay.payment.repository.PaymentStatusCodeRepository;
+import com.fairing.fairplay.payment.repository.RefundRepository;
+import com.fairing.fairplay.payment.repository.RefundStatusCodeRepository;
+import com.fairing.fairplay.user.entity.EventAdmin;
+import com.fairing.fairplay.user.entity.Users;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class RefundServiceAuthorizationTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private RefundRepository refundRepository;
+
+    @Mock
+    private PaymentStatusCodeRepository paymentStatusCodeRepository;
+
+    @Mock
+    private RefundStatusCodeRepository refundStatusCodeRepository;
+
+    private TestRefundService refundService;
+
+    @BeforeEach
+    void setUp() {
+        refundService = new TestRefundService(
+                paymentRepository,
+                refundRepository,
+                paymentStatusCodeRepository,
+                refundStatusCodeRepository
+        );
+    }
+
+    @Test
+    void commonUserCannotUseAdminRefundEndpointsBeforeMutationOrBroadQuery() {
+        CustomUserDetails common = user(300L, "COMMON");
+
+        assertThatThrownBy(() -> refundService.approveRefund(1L, RefundApprovalDto.builder().build(), common))
+                .isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> refundService.rejectRefund(1L, "거절", common))
+                .isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> refundService.getAllRefunds(null, common))
+                .isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> refundService.getPendingRefunds(null, common))
+                .isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> refundService.getRefundList(defaultListRequest(), common))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(refundRepository, never()).findById(any());
+        verify(refundRepository, never()).findAll();
+        verify(refundRepository, never()).findByRefundStatusCode(any());
+        verify(refundRepository, never()).findRefundsWithFilters(any(), any(), any(), any(), any(), any(), any());
+        verify(refundRepository, never()).save(any());
+    }
+
+    @Test
+    void commonUserCanRequestAndReadOwnRefunds() {
+        Payment payment = payment(10L, 300L, null);
+        when(paymentRepository.findById(10L)).thenReturn(Optional.of(payment));
+        when(refundStatusCodeRepository.findByCode("REQUESTED")).thenReturn(Optional.of(status("REQUESTED")));
+
+        PaymentRequestDto request = new PaymentRequestDto();
+        request.setRefundRequestAmount(BigDecimal.TEN);
+        request.setReason("개인 사유");
+
+        assertThat(refundService.requestRefund(10L, request, 300L).getPaymentId()).isEqualTo(10L);
+        verify(refundRepository).save(any(Refund.class));
+
+        Refund refund = refund(1L, payment, status("REQUESTED"));
+        when(refundRepository.findByUserId(300L)).thenReturn(List.of(refund));
+
+        assertThat(refundService.getMyRefundList(300L)).hasSize(1);
+    }
+
+    @Test
+    void adminCanApproveRejectAndListAnyRefund() {
+        Refund refundForApprove = refund(1L, payment(10L, 300L, event(1L, 100L)), status("REQUESTED"));
+        when(refundRepository.findById(1L)).thenReturn(Optional.of(refundForApprove));
+        when(refundStatusCodeRepository.findByCode("APPROVED")).thenReturn(Optional.of(status("APPROVED")));
+        when(paymentStatusCodeRepository.getReferenceById(5)).thenReturn(paymentStatus(5));
+
+        assertThat(refundService.approveRefund(1L, RefundApprovalDto.builder().build(), user(1L, "ADMIN")).getPaymentId())
+                .isEqualTo(10L);
+        assertThat(refundForApprove.getRefundStatusCode().getCode()).isEqualTo("APPROVED");
+
+        Refund refundForReject = refund(2L, payment(11L, 301L, null), status("REQUESTED"));
+        when(refundRepository.findById(2L)).thenReturn(Optional.of(refundForReject));
+        when(refundStatusCodeRepository.findByCode("REJECTED")).thenReturn(Optional.of(status("REJECTED")));
+
+        assertThat(refundService.rejectRefund(2L, "거절", user(1L, "ADMIN")).getPaymentId()).isEqualTo(11L);
+        assertThat(refundForReject.getRefundStatusCode().getCode()).isEqualTo("REJECTED");
+
+        when(refundRepository.findAll()).thenReturn(List.of(refundForApprove, refundForReject));
+        assertThat(refundService.getAllRefunds(null, user(1L, "ADMIN"))).hasSize(2);
+    }
+
+    @Test
+    void eventManagerCanApproveRejectAndListOwnEventRefunds() {
+        CustomUserDetails manager = user(100L, "EVENT_MANAGER");
+        Refund refundForApprove = refund(1L, payment(10L, 300L, event(1L, 100L)), status("REQUESTED"));
+        when(refundRepository.findById(1L)).thenReturn(Optional.of(refundForApprove));
+        when(refundStatusCodeRepository.findByCode("APPROVED")).thenReturn(Optional.of(status("APPROVED")));
+        when(paymentStatusCodeRepository.getReferenceById(5)).thenReturn(paymentStatus(5));
+
+        assertThat(refundService.approveRefund(1L, RefundApprovalDto.builder().build(), manager).getPaymentId())
+                .isEqualTo(10L);
+        assertThat(refundForApprove.getRefundStatusCode().getCode()).isEqualTo("APPROVED");
+
+        Refund refundForReject = refund(2L, payment(11L, 301L, event(1L, 100L)), status("REQUESTED"));
+        when(refundRepository.findById(2L)).thenReturn(Optional.of(refundForReject));
+        when(refundStatusCodeRepository.findByCode("REJECTED")).thenReturn(Optional.of(status("REJECTED")));
+
+        assertThat(refundService.rejectRefund(2L, "거절", manager).getPaymentId()).isEqualTo(11L);
+        assertThat(refundForReject.getRefundStatusCode().getCode()).isEqualTo("REJECTED");
+
+        when(refundRepository.findByEventManagerUserId(100L)).thenReturn(List.of(refundForApprove));
+        assertThat(refundService.getAllRefunds(null, manager)).hasSize(1);
+
+        when(refundRepository.findRefundsWithFilters(
+                eq(null), eq(null), eq(null), eq(null), eq(null), eq(100L), eq(PageRequest.of(0, 20,
+                        org.springframework.data.domain.Sort.by(org.springframework.data.domain.Sort.Direction.DESC, "createdAt")))))
+                .thenReturn(Page.empty());
+        assertThat(refundService.getRefundList(defaultListRequest(), manager)).isEmpty();
+    }
+
+    @Test
+    void eventManagerCannotMutateOtherEventRefund() {
+        Refund refund = refund(1L, payment(10L, 300L, event(1L, 100L)), status("REQUESTED"));
+        when(refundRepository.findById(1L)).thenReturn(Optional.of(refund));
+
+        assertThatThrownBy(() -> refundService.approveRefund(1L, RefundApprovalDto.builder().build(), user(999L, "EVENT_MANAGER")))
+                .isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> refundService.rejectRefund(1L, "거절", user(999L, "EVENT_MANAGER")))
+                .isInstanceOf(AccessDeniedException.class);
+
+        assertThat(refund.getRefundStatusCode().getCode()).isEqualTo("REQUESTED");
+        verify(refundRepository, never()).save(any());
+        verify(refundStatusCodeRepository, never()).findByCode("APPROVED");
+        verify(refundStatusCodeRepository, never()).findByCode("REJECTED");
+    }
+
+    @Test
+    void eventManagerCannotMutateRefundWithoutEvent() {
+        Refund refund = refund(1L, payment(10L, 300L, null), status("REQUESTED"));
+        when(refundRepository.findById(1L)).thenReturn(Optional.of(refund));
+
+        assertThatThrownBy(() -> refundService.approveRefund(1L, RefundApprovalDto.builder().build(), user(100L, "EVENT_MANAGER")))
+                .isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> refundService.rejectRefund(1L, "거절", user(100L, "EVENT_MANAGER")))
+                .isInstanceOf(AccessDeniedException.class);
+
+        assertThat(refund.getRefundStatusCode().getCode()).isEqualTo("REQUESTED");
+        verify(refundRepository, never()).save(any());
+    }
+
+    @Test
+    void eventManagerPendingListIsScopedToOwnEventsBeforeBroadStatusQuery() {
+        RefundStatusCode requested = status("REQUESTED");
+        when(refundStatusCodeRepository.findByCode("REQUESTED")).thenReturn(Optional.of(requested));
+        when(refundRepository.findByEventManagerUserIdAndRefundStatusCode(100L, requested)).thenReturn(List.of());
+
+        assertThat(refundService.getPendingRefunds(null, user(100L, "EVENT_MANAGER"))).isEmpty();
+
+        verify(refundRepository, never()).findByRefundStatusCode(any());
+    }
+
+    @Test
+    void eventManagerTargetedOtherEventListIsDeniedAfterScopedLookup() {
+        Refund otherEventRefund = refund(1L, payment(10L, 300L, event(1L, 100L)), status("REQUESTED"));
+        when(refundRepository.findByEventId(1L)).thenReturn(List.of(otherEventRefund));
+
+        assertThatThrownBy(() -> refundService.getAllRefunds(1L, user(999L, "EVENT_MANAGER")))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void eventManagerListFiltersByManagerInsteadOfBroadQuery() {
+        CustomUserDetails manager = user(100L, "EVENT_MANAGER");
+        RefundListRequestDto request = defaultListRequest();
+        when(refundRepository.findRefundsWithFilters(
+                eq(null), eq(null), eq(null), eq(null), eq(null), eq(100L), any(PageRequest.class)))
+                .thenReturn(Page.empty());
+
+        assertThatCode(() -> refundService.getRefundList(request, manager)).doesNotThrowAnyException();
+    }
+
+    private RefundListRequestDto defaultListRequest() {
+        return RefundListRequestDto.builder()
+                .page(0)
+                .size(20)
+                .sortBy("createdAt")
+                .sortDirection("desc")
+                .build();
+    }
+
+    private Refund refund(Long refundId, Payment payment, RefundStatusCode status) {
+        return Refund.builder()
+                .refundId(refundId)
+                .payment(payment)
+                .amount(BigDecimal.TEN)
+                .reason("환불 사유")
+                .refundStatusCode(status)
+                .build();
+    }
+
+    private Payment payment(Long paymentId, Long userId, Event event) {
+        return Payment.builder()
+                .paymentId(paymentId)
+                .event(event)
+                .user(new Users(userId))
+                .paymentTargetType(PaymentTargetType.builder()
+                        .paymentTargetCode("RESERVATION")
+                        .paymentTargetName("예약")
+                        .build())
+                .targetId(20L)
+                .merchantUid("merchant-" + paymentId)
+                .impUid("imp-" + paymentId)
+                .quantity(1)
+                .price(BigDecimal.valueOf(100))
+                .amount(BigDecimal.valueOf(100))
+                .refundedAmount(BigDecimal.ZERO)
+                .paymentTypeCode(PaymentTypeCode.builder().paymentTypeCodeId(1).code("CARD").name("카드").build())
+                .paymentStatusCode(paymentStatus(2))
+                .build();
+    }
+
+    private Event event(Long eventId, Long managerUserId) {
+        EventAdmin eventAdmin = new EventAdmin();
+        eventAdmin.setUserId(managerUserId);
+        eventAdmin.setUser(new Users(managerUserId));
+
+        Event event = new Event();
+        event.setEventId(eventId);
+        event.setTitleKr("행사");
+        event.setTitleEng("Event");
+        event.setManager(eventAdmin);
+
+        EventDetail detail = new EventDetail();
+        detail.setStartDate(LocalDate.now());
+        detail.setEndDate(LocalDate.now().plusDays(1));
+        event.setEventDetail(detail);
+        return event;
+    }
+
+    private RefundStatusCode status(String code) {
+        return RefundStatusCode.builder()
+                .code(code)
+                .name(code)
+                .build();
+    }
+
+    private PaymentStatusCode paymentStatus(Integer id) {
+        return PaymentStatusCode.builder()
+                .paymentStatusCodeId(id)
+                .code("STATUS")
+                .name("상태")
+                .build();
+    }
+
+    private CustomUserDetails user(Long userId, String roleCode) {
+        CustomUserDetails userDetails = mock(CustomUserDetails.class);
+        lenient().when(userDetails.getUserId()).thenReturn(userId);
+        when(userDetails.getRoleCode()).thenReturn(roleCode);
+        return userDetails;
+    }
+
+    private static class TestRefundService extends RefundService {
+
+        TestRefundService(
+                PaymentRepository paymentRepository,
+                RefundRepository refundRepository,
+                PaymentStatusCodeRepository paymentStatusCodeRepository,
+                RefundStatusCodeRepository refundStatusCodeRepository
+        ) {
+            super(paymentRepository, refundRepository, paymentStatusCodeRepository, refundStatusCodeRepository);
+        }
+
+        @Override
+        public String getToken() {
+            return "token";
+        }
+
+        @Override
+        protected void processRefundRequest(String accessToken, String merchantUid, BigDecimal amount, String reason) throws IOException {
+            // Unit tests assert authorization and mutation boundaries without calling the external PG API.
+        }
+    }
+}

--- a/src/test/java/com/fairing/fairplay/reservation/service/ReservationServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/reservation/service/ReservationServiceAuthorizationTest.java
@@ -1,0 +1,215 @@
+package com.fairing.fairplay.reservation.service;
+
+import com.fairing.fairplay.attendee.repository.AttendeeRepository;
+import com.fairing.fairplay.core.security.CustomUserDetails;
+import com.fairing.fairplay.event.entity.Event;
+import com.fairing.fairplay.event.repository.EventRepository;
+import com.fairing.fairplay.notification.service.NotificationService;
+import com.fairing.fairplay.payment.repository.PaymentRepository;
+import com.fairing.fairplay.payment.repository.PaymentStatusCodeRepository;
+import com.fairing.fairplay.reservation.entity.Reservation;
+import com.fairing.fairplay.reservation.repository.ReservationLogRepository;
+import com.fairing.fairplay.reservation.repository.ReservationRepository;
+import com.fairing.fairplay.ticket.repository.EventScheduleRepository;
+import com.fairing.fairplay.ticket.repository.ScheduleTicketRepository;
+import com.fairing.fairplay.ticket.repository.TicketRepository;
+import com.fairing.fairplay.user.entity.EventAdmin;
+import com.fairing.fairplay.user.entity.Users;
+import com.fairing.fairplay.user.repository.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.access.AccessDeniedException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceAuthorizationTest {
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @Mock
+    private AttendeeRepository attendeeRepository;
+
+    @Mock
+    private EventRepository eventRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ReservationLogRepository reservationLogRepository;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @Mock
+    private EventScheduleRepository eventScheduleRepository;
+
+    @Mock
+    private TicketRepository ticketRepository;
+
+    @Mock
+    private ScheduleTicketRepository scheduleTicketRepository;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private PaymentStatusCodeRepository paymentStatusCodeRepository;
+
+    private ReservationService reservationService;
+
+    @BeforeEach
+    void setUp() {
+        reservationService = new ReservationService(
+                reservationRepository,
+                attendeeRepository,
+                eventRepository,
+                userRepository,
+                reservationLogRepository,
+                notificationService,
+                eventScheduleRepository,
+                ticketRepository,
+                scheduleTicketRepository,
+                paymentRepository,
+                paymentStatusCodeRepository
+        );
+    }
+
+    @Test
+    void commonUserCanReadOnlyOwnReservationDetail() {
+        Reservation reservation = reservation(10L, 1L, 300L, 100L);
+        when(reservationRepository.findByReservationIdAndEvent_EventId(10L, 1L))
+                .thenReturn(Optional.of(reservation));
+
+        assertThat(reservationService.getReservationById(1L, 10L, user(300L, "COMMON")))
+                .isSameAs(reservation);
+    }
+
+    @Test
+    void commonUserCannotReadOtherReservationDetail() {
+        Reservation reservation = reservation(10L, 1L, 301L, 100L);
+        when(reservationRepository.findByReservationIdAndEvent_EventId(10L, 1L))
+                .thenReturn(Optional.of(reservation));
+
+        assertThatThrownBy(() -> reservationService.getReservationById(1L, 10L, user(300L, "COMMON")))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void commonUserCannotReadEventReservationCollections() {
+        assertThatThrownBy(() -> reservationService.getReservationsByEvent(1L, user(300L, "COMMON")))
+                .isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> reservationService.getReservationAttendees(
+                1L, null, null, null, null, PageRequest.of(0, 15), user(300L, "COMMON")))
+                .isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> reservationService.generateAttendeesExcel(1L, null, user(300L, "COMMON")))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(reservationRepository, never()).findByEvent_EventId(any());
+        verify(attendeeRepository, never()).findAttendeesWithFilters(any(), any(), any(), any(), any(), any());
+        verify(attendeeRepository, never()).findAttendeesByEventId(any(), any());
+    }
+
+    @Test
+    void eventManagerCanReadOwnEventReservationsAndAttendees() {
+        Event event = event(1L, 100L);
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
+        when(reservationRepository.findByEvent_EventId(1L)).thenReturn(List.of());
+        when(attendeeRepository.findAttendeesWithFilters(1L, null, null, null, null, PageRequest.of(0, 15)))
+                .thenReturn(org.springframework.data.domain.Page.empty());
+
+        assertThat(reservationService.getReservationsByEvent(1L, user(100L, "EVENT_MANAGER"))).isEmpty();
+        assertThat(reservationService.getReservationAttendees(
+                1L, null, null, null, null, PageRequest.of(0, 15), user(100L, "EVENT_MANAGER"))).isEmpty();
+    }
+
+    @Test
+    void eventManagerCannotReadOtherEventBeforePersonalDataQuery() {
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event(1L, 100L)));
+
+        assertThatThrownBy(() -> reservationService.getReservationAttendees(
+                1L, null, null, null, null, PageRequest.of(0, 15), user(999L, "EVENT_MANAGER")))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(attendeeRepository, never()).findAttendeesWithFilters(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void eventManagerCannotDownloadOtherEventExcelBeforePersonalDataQuery() {
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event(1L, 100L)));
+
+        assertThatThrownBy(() -> reservationService.generateAttendeesExcel(1L, null, user(999L, "EVENT_MANAGER")))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(attendeeRepository, never()).findAttendeesByEventId(any(), any());
+    }
+
+    @Test
+    void boothManagerCannotReadEventReservationPersonalData() {
+        assertThatThrownBy(() -> reservationService.getReservationAttendees(
+                1L, null, null, null, null, PageRequest.of(0, 15), user(200L, "BOOTH_MANAGER")))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(attendeeRepository, never()).findAttendeesWithFilters(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void adminCanReadAnyEventReservationCollections() throws Exception {
+        when(reservationRepository.findByEvent_EventId(1L)).thenReturn(List.of());
+        when(attendeeRepository.findAttendeesByEventId(1L, null)).thenReturn(List.of());
+
+        assertThat(reservationService.getReservationsByEvent(1L, user(1L, "ADMIN"))).isEmpty();
+        assertThat(reservationService.generateAttendeesExcel(1L, null, user(1L, "ADMIN"))).isNotEmpty();
+
+        verify(eventRepository, never()).findById(any());
+    }
+
+    @Test
+    void reservationDetailUsesEventScopedLookup() {
+        when(reservationRepository.findByReservationIdAndEvent_EventId(10L, 2L))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> reservationService.getReservationById(2L, 10L, mock(CustomUserDetails.class)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private Reservation reservation(Long reservationId, Long eventId, Long reservationUserId, Long eventManagerId) {
+        Reservation reservation = new Reservation(event(eventId, eventManagerId), null, null, new Users(reservationUserId), 1, 1000);
+        reservation.setReservationId(reservationId);
+        return reservation;
+    }
+
+    private Event event(Long eventId, Long managerUserId) {
+        EventAdmin eventAdmin = new EventAdmin();
+        eventAdmin.setUser(new Users(managerUserId));
+        eventAdmin.setUserId(managerUserId);
+
+        Event event = new Event();
+        event.setEventId(eventId);
+        event.setManager(eventAdmin);
+        event.setTitleKr("행사");
+        event.setTitleEng("Event");
+        return event;
+    }
+
+    private CustomUserDetails user(Long userId, String roleCode) {
+        CustomUserDetails userDetails = mock(CustomUserDetails.class);
+        when(userDetails.getUserId()).thenReturn(userId);
+        when(userDetails.getRoleCode()).thenReturn(roleCode);
+        return userDetails;
+    }
+}

--- a/src/test/java/com/fairing/fairplay/reservation/service/ReservationServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/reservation/service/ReservationServiceAuthorizationTest.java
@@ -110,6 +110,46 @@ class ReservationServiceAuthorizationTest {
     }
 
     @Test
+    void eventManagerCanReadOwnReservationDetailForUnmanagedEvent() {
+        Reservation reservation = reservation(10L, 1L, 100L, 999L);
+        when(reservationRepository.findByReservationIdAndEvent_EventId(10L, 1L))
+                .thenReturn(Optional.of(reservation));
+
+        assertThat(reservationService.getReservationById(1L, 10L, user(100L, "EVENT_MANAGER")))
+                .isSameAs(reservation);
+    }
+
+    @Test
+    void boothManagerCanReadOwnReservationDetailForUnmanagedEvent() {
+        Reservation reservation = reservation(10L, 1L, 200L, 999L);
+        when(reservationRepository.findByReservationIdAndEvent_EventId(10L, 1L))
+                .thenReturn(Optional.of(reservation));
+
+        assertThat(reservationService.getReservationById(1L, 10L, user(200L, "BOOTH_MANAGER")))
+                .isSameAs(reservation);
+    }
+
+    @Test
+    void eventManagerCannotReadOthersReservationDetailForUnmanagedEvent() {
+        Reservation reservation = reservation(10L, 1L, 301L, 999L);
+        when(reservationRepository.findByReservationIdAndEvent_EventId(10L, 1L))
+                .thenReturn(Optional.of(reservation));
+
+        assertThatThrownBy(() -> reservationService.getReservationById(1L, 10L, user(100L, "EVENT_MANAGER")))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void boothManagerCannotReadOthersReservationDetail() {
+        Reservation reservation = reservation(10L, 1L, 301L, 999L);
+        when(reservationRepository.findByReservationIdAndEvent_EventId(10L, 1L))
+                .thenReturn(Optional.of(reservation));
+
+        assertThatThrownBy(() -> reservationService.getReservationById(1L, 10L, user(200L, "BOOTH_MANAGER")))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
     void commonUserCannotReadEventReservationCollections() {
         assertThatThrownBy(() -> reservationService.getReservationsByEvent(1L, user(300L, "COMMON")))
                 .isInstanceOf(AccessDeniedException.class);

--- a/src/test/java/com/fairing/fairplay/settlement/controller/SettlementDisputeControllerPrincipalTest.java
+++ b/src/test/java/com/fairing/fairplay/settlement/controller/SettlementDisputeControllerPrincipalTest.java
@@ -1,0 +1,89 @@
+package com.fairing.fairplay.settlement.controller;
+
+import com.fairing.fairplay.core.security.CustomUserDetails;
+import com.fairing.fairplay.core.service.LocalFileService;
+import com.fairing.fairplay.settlement.dto.SettlementDisputeDto;
+import com.fairing.fairplay.settlement.entity.SettlementDispute;
+import com.fairing.fairplay.settlement.service.SettlementDisputeService;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SettlementDisputeControllerPrincipalTest {
+
+    @Mock
+    private SettlementDisputeService disputeService;
+
+    @Mock
+    private LocalFileService localFileService;
+
+    private SettlementDisputeController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new SettlementDisputeController(disputeService, localFileService);
+    }
+
+    @Test
+    void submitDisputeUsesAuthenticationPrincipal() {
+        CustomUserDetails principal = mock(CustomUserDetails.class);
+        SettlementDisputeDto.CreateRequest request = SettlementDisputeDto.CreateRequest.builder()
+                .settlementId(7L)
+                .disputeReason("정산 금액 확인")
+                .build();
+        SettlementDisputeDto.Response response = SettlementDisputeDto.Response.builder()
+                .disputeId(1L)
+                .settlementId(7L)
+                .build();
+        when(disputeService.submitDispute(request, principal)).thenReturn(response);
+
+        var result = controller.submitDispute(request, principal);
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(result.getBody()).isSameAs(response);
+        verify(disputeService).submitDispute(request, principal);
+    }
+
+    @Test
+    void reviewDisputeUsesAuthenticationPrincipal() {
+        CustomUserDetails principal = mock(CustomUserDetails.class);
+        SettlementDisputeDto.AdminReviewRequest request = SettlementDisputeDto.AdminReviewRequest.builder()
+                .disputeId(1L)
+                .status(SettlementDispute.DisputeProcessStatus.RESOLVED)
+                .adminResponse("확인")
+                .build();
+        SettlementDisputeDto.Response response = SettlementDisputeDto.Response.builder()
+                .disputeId(1L)
+                .build();
+        when(disputeService.reviewDispute(request, principal)).thenReturn(response);
+
+        var result = controller.reviewDispute(request, principal);
+
+        assertThat(result.getBody()).isSameAs(response);
+        verify(disputeService).reviewDispute(request, principal);
+    }
+
+    @Test
+    void downloadDisputeFileGetsAuthorizedKeyFromPrincipalBeforeDownload() throws IOException {
+        CustomUserDetails principal = mock(CustomUserDetails.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(disputeService.getAuthorizedFileKey(10L, principal)).thenReturn("uploads/disputes/1/evidence.pdf");
+
+        controller.downloadDisputeFile(10L, principal, response);
+
+        verify(disputeService).getAuthorizedFileKey(10L, principal);
+        verify(localFileService).downloadFile("uploads/disputes/1/evidence.pdf", response);
+    }
+}

--- a/src/test/java/com/fairing/fairplay/settlement/controller/SettlementDisputeControllerPrincipalTest.java
+++ b/src/test/java/com/fairing/fairplay/settlement/controller/SettlementDisputeControllerPrincipalTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.http.HttpStatus;
 
 import java.io.IOException;
@@ -20,7 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
+@ExtendWith({MockitoExtension.class, OutputCaptureExtension.class})
 class SettlementDisputeControllerPrincipalTest {
 
     @Mock
@@ -85,5 +87,17 @@ class SettlementDisputeControllerPrincipalTest {
 
         verify(disputeService).getAuthorizedFileKey(10L, principal);
         verify(localFileService).downloadFile("uploads/disputes/1/evidence.pdf", response);
+    }
+
+    @Test
+    void downloadDisputeFileDoesNotLogStorageKeyAtInfo(CapturedOutput output) throws IOException {
+        CustomUserDetails principal = mock(CustomUserDetails.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        when(disputeService.getAuthorizedFileKey(10L, principal)).thenReturn("uploads/disputes/1/evidence.pdf");
+
+        controller.downloadDisputeFile(10L, principal, response);
+
+        assertThat(output.getOut()).doesNotContain("uploads/disputes/1/evidence.pdf");
+        assertThat(output.getErr()).doesNotContain("uploads/disputes/1/evidence.pdf");
     }
 }

--- a/src/test/java/com/fairing/fairplay/settlement/service/SettlementDisputeServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/settlement/service/SettlementDisputeServiceAuthorizationTest.java
@@ -1,0 +1,277 @@
+package com.fairing.fairplay.settlement.service;
+
+import com.fairing.fairplay.core.security.CustomUserDetails;
+import com.fairing.fairplay.core.service.LocalFileService;
+import com.fairing.fairplay.event.entity.Event;
+import com.fairing.fairplay.settlement.dto.SettlementDisputeDto;
+import com.fairing.fairplay.settlement.entity.Settlement;
+import com.fairing.fairplay.settlement.entity.SettlementDispute;
+import com.fairing.fairplay.settlement.entity.SettlementDisputeFile;
+import com.fairing.fairplay.settlement.repository.SettlementDisputeFileRepository;
+import com.fairing.fairplay.settlement.repository.SettlementDisputeRepository;
+import com.fairing.fairplay.settlement.repository.SettlementRepository;
+import com.fairing.fairplay.user.entity.EventAdmin;
+import com.fairing.fairplay.user.entity.Users;
+import com.fairing.fairplay.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.security.access.AccessDeniedException;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SettlementDisputeServiceAuthorizationTest {
+
+    @Mock
+    private SettlementDisputeRepository disputeRepository;
+
+    @Mock
+    private SettlementDisputeFileRepository disputeFileRepository;
+
+    @Mock
+    private SettlementRepository settlementRepository;
+
+    @Mock
+    private LocalFileService localFileService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private SettlementDisputeService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SettlementDisputeService(
+                disputeRepository,
+                disputeFileRepository,
+                settlementRepository,
+                localFileService,
+                userRepository
+        );
+    }
+
+    @Test
+    void foreignEventManagerSubmitIsDeniedBeforeSave() {
+        Settlement settlement = settlement(7L, 100L);
+        when(settlementRepository.findById(7L)).thenReturn(Optional.of(settlement));
+
+        assertThatThrownBy(() -> service.submitDispute(createRequest(7L), user(999L, "EVENT_MANAGER", "foreign")))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(disputeRepository, never()).save(any());
+    }
+
+    @Test
+    void ownerEventManagerSubmitIsAllowedAndRequesterComesFromPrincipal() {
+        Settlement settlement = settlement(7L, 100L);
+        when(settlementRepository.findById(7L)).thenReturn(Optional.of(settlement));
+        when(disputeRepository.existsBySettlement_SettlementId(7L)).thenReturn(false);
+        when(disputeRepository.save(any(SettlementDispute.class))).thenAnswer(invocation -> {
+            SettlementDispute dispute = invocation.getArgument(0);
+            dispute.setDisputeId(1L);
+            return dispute;
+        });
+        when(settlementRepository.save(settlement)).thenReturn(settlement);
+
+        service.submitDispute(createRequest(7L), user(100L, "EVENT_MANAGER", "owner"));
+
+        ArgumentCaptor<SettlementDispute> disputeCaptor = ArgumentCaptor.forClass(SettlementDispute.class);
+        verify(disputeRepository).save(disputeCaptor.capture());
+        assertThat(disputeCaptor.getValue().getRequesterId()).isEqualTo(100L);
+        assertThat(disputeCaptor.getValue().getRequesterName()).isEqualTo("owner");
+    }
+
+    @Test
+    void commonUserIsDeniedForDisputeSurfaces() {
+        CustomUserDetails common = user(300L, "COMMON", "common");
+        SettlementDispute dispute = dispute(1L, settlement(7L, 100L));
+        SettlementDisputeFile file = disputeFile(10L, dispute);
+
+        when(settlementRepository.findById(7L)).thenReturn(Optional.of(dispute.getSettlement()));
+        when(disputeRepository.findById(1L)).thenReturn(Optional.of(dispute));
+        when(disputeFileRepository.findById(10L)).thenReturn(Optional.of(file));
+
+        assertThatThrownBy(() -> service.submitDispute(createRequest(7L), common))
+                .isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> service.getDispute(1L, common))
+                .isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> service.getDisputeBySettlementId(7L, common))
+                .isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> service.getAuthorizedFileKey(10L, common))
+                .isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> service.getDisputeList(PageRequest.of(0, 20), common))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void ownerEventManagerCanReadOwnDetailSettlementAndDownloadButForeignManagerCannot() {
+        SettlementDispute dispute = dispute(1L, settlement(7L, 100L));
+        SettlementDisputeFile file = disputeFile(10L, dispute);
+        dispute.getDisputeFiles().add(file);
+
+        when(disputeRepository.findById(1L)).thenReturn(Optional.of(dispute));
+        when(settlementRepository.findById(7L)).thenReturn(Optional.of(dispute.getSettlement()));
+        when(disputeRepository.findBySettlement_SettlementId(7L)).thenReturn(Optional.of(dispute));
+        when(disputeFileRepository.findById(10L)).thenReturn(Optional.of(file));
+
+        CustomUserDetails owner = user(100L, "EVENT_MANAGER", "owner");
+        assertThat(service.getDispute(1L, owner).getDisputeId()).isEqualTo(1L);
+        assertThat(service.getDisputeBySettlementId(7L, owner)).isPresent();
+        assertThat(service.getAuthorizedFileKey(10L, owner)).isEqualTo("uploads/disputes/1/evidence.pdf");
+
+        CustomUserDetails foreign = user(999L, "EVENT_MANAGER", "foreign");
+        assertThatThrownBy(() -> service.getDispute(1L, foreign))
+                .isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> service.getDisputeBySettlementId(7L, foreign))
+                .isInstanceOf(AccessDeniedException.class);
+        assertThatThrownBy(() -> service.getAuthorizedFileKey(10L, foreign))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void bySettlementChecksOwnershipEvenWhenNoDisputeExists() {
+        Settlement settlement = settlement(7L, 100L);
+        when(settlementRepository.findById(7L)).thenReturn(Optional.of(settlement));
+
+        assertThatThrownBy(() -> service.getDisputeBySettlementId(7L, user(999L, "EVENT_MANAGER", "foreign")))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void adminCanListReviewDetailAndDownloadAndReviewAdminComesFromPrincipal() {
+        SettlementDispute dispute = dispute(1L, settlement(7L, 100L));
+        SettlementDisputeFile file = disputeFile(10L, dispute);
+        dispute.getDisputeFiles().add(file);
+        CustomUserDetails admin = user(1L, "ADMIN", "admin");
+        SettlementDisputeDto.AdminReviewRequest request = SettlementDisputeDto.AdminReviewRequest.builder()
+                .disputeId(1L)
+                .status(SettlementDispute.DisputeProcessStatus.RESOLVED)
+                .adminResponse("확인 완료")
+                .build();
+
+        when(disputeRepository.findById(1L)).thenReturn(Optional.of(dispute));
+        when(disputeRepository.findAllWithSettlement(PageRequest.of(0, 20))).thenReturn(Page.empty());
+        when(disputeFileRepository.findById(10L)).thenReturn(Optional.of(file));
+        when(disputeRepository.save(dispute)).thenReturn(dispute);
+        when(settlementRepository.save(dispute.getSettlement())).thenReturn(dispute.getSettlement());
+
+        assertThat(service.getDisputeList(PageRequest.of(0, 20), admin)).isEmpty();
+        assertThat(service.getDispute(1L, admin).getDisputeId()).isEqualTo(1L);
+        assertThat(service.getAuthorizedFileKey(10L, admin)).isEqualTo("uploads/disputes/1/evidence.pdf");
+
+        service.reviewDispute(request, admin);
+
+        assertThat(dispute.getAdminId()).isEqualTo(1L);
+        assertThat(dispute.getAdminName()).isEqualTo("admin");
+    }
+
+    @Test
+    void reviewUsesUserLookupWhenPrincipalNameIsMissing() {
+        SettlementDispute dispute = dispute(1L, settlement(7L, 100L));
+        CustomUserDetails admin = user(1L, "ADMIN", null);
+        Users adminUser = new Users(1L);
+        adminUser.setName("lookup admin");
+        SettlementDisputeDto.AdminReviewRequest request = SettlementDisputeDto.AdminReviewRequest.builder()
+                .disputeId(1L)
+                .status(SettlementDispute.DisputeProcessStatus.UNDER_REVIEW)
+                .build();
+
+        when(disputeRepository.findById(1L)).thenReturn(Optional.of(dispute));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(adminUser));
+        when(disputeRepository.save(dispute)).thenReturn(dispute);
+        when(settlementRepository.save(dispute.getSettlement())).thenReturn(dispute.getSettlement());
+
+        service.reviewDispute(request, admin);
+
+        assertThat(dispute.getAdminId()).isEqualTo(1L);
+        assertThat(dispute.getAdminName()).isEqualTo("lookup admin");
+    }
+
+    @Test
+    void reviewIsAdminOnly() {
+        SettlementDispute dispute = dispute(1L, settlement(7L, 100L));
+        SettlementDisputeDto.AdminReviewRequest request = SettlementDisputeDto.AdminReviewRequest.builder()
+                .disputeId(1L)
+                .status(SettlementDispute.DisputeProcessStatus.RESOLVED)
+                .build();
+        when(disputeRepository.findById(1L)).thenReturn(Optional.of(dispute));
+
+        assertThatThrownBy(() -> service.reviewDispute(request, user(100L, "EVENT_MANAGER", "owner")))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(disputeRepository, never()).save(any());
+    }
+
+    private SettlementDisputeDto.CreateRequest createRequest(Long settlementId) {
+        return SettlementDisputeDto.CreateRequest.builder()
+                .settlementId(settlementId)
+                .disputeReason("정산 금액 확인이 필요합니다.")
+                .build();
+    }
+
+    private SettlementDispute dispute(Long disputeId, Settlement settlement) {
+        return SettlementDispute.builder()
+                .disputeId(disputeId)
+                .settlement(settlement)
+                .requesterId(100L)
+                .requesterName("owner")
+                .disputeReason("정산 금액 확인이 필요합니다.")
+                .status(SettlementDispute.DisputeProcessStatus.RAISED)
+                .build();
+    }
+
+    private SettlementDisputeFile disputeFile(Long fileId, SettlementDispute dispute) {
+        return SettlementDisputeFile.builder()
+                .fileId(fileId)
+                .dispute(dispute)
+                .s3Key("uploads/disputes/1/evidence.pdf")
+                .originalFilename("evidence.pdf")
+                .fileSize(123L)
+                .fileType(SettlementDisputeFile.DisputeFileType.PDF)
+                .uploadOrder(1)
+                .build();
+    }
+
+    private Settlement settlement(Long settlementId, Long managerUserId) {
+        EventAdmin eventAdmin = new EventAdmin();
+        eventAdmin.setUserId(managerUserId);
+        eventAdmin.setUser(new Users(managerUserId));
+
+        Event event = new Event();
+        event.setEventId(70L);
+        event.setManager(eventAdmin);
+
+        return Settlement.builder()
+                .settlementId(settlementId)
+                .event(event)
+                .eventTitle("정산 행사")
+                .totalAmount(BigDecimal.valueOf(10000))
+                .feeAmount(BigDecimal.valueOf(1000))
+                .finalAmount(BigDecimal.valueOf(9000))
+                .build();
+    }
+
+    private CustomUserDetails user(Long userId, String roleCode, String name) {
+        CustomUserDetails userDetails = mock(CustomUserDetails.class);
+        lenient().when(userDetails.getUserId()).thenReturn(userId);
+        lenient().when(userDetails.getRoleCode()).thenReturn(roleCode);
+        lenient().when(userDetails.getName()).thenReturn(name);
+        return userDetails;
+    }
+}

--- a/src/test/java/com/fairing/fairplay/settlement/service/SettlementDisputeServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/settlement/service/SettlementDisputeServiceAuthorizationTest.java
@@ -231,16 +231,15 @@ class SettlementDisputeServiceAuthorizationTest {
 
     @Test
     void reviewIsAdminOnly() {
-        SettlementDispute dispute = dispute(1L, settlement(7L, 100L));
         SettlementDisputeDto.AdminReviewRequest request = SettlementDisputeDto.AdminReviewRequest.builder()
                 .disputeId(1L)
                 .status(SettlementDispute.DisputeProcessStatus.RESOLVED)
                 .build();
-        when(disputeRepository.findById(1L)).thenReturn(Optional.of(dispute));
 
         assertThatThrownBy(() -> service.reviewDispute(request, user(100L, "EVENT_MANAGER", "owner")))
                 .isInstanceOf(AccessDeniedException.class);
 
+        verify(disputeRepository, never()).findById(any());
         verify(disputeRepository, never()).save(any());
     }
 

--- a/src/test/java/com/fairing/fairplay/settlement/service/SettlementDisputeServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/settlement/service/SettlementDisputeServiceAuthorizationTest.java
@@ -94,7 +94,6 @@ class SettlementDisputeServiceAuthorizationTest {
         ArgumentCaptor<SettlementDispute> disputeCaptor = ArgumentCaptor.forClass(SettlementDispute.class);
         verify(disputeRepository).save(disputeCaptor.capture());
         assertThat(disputeCaptor.getValue().getRequesterId()).isEqualTo(100L);
-        assertThat(disputeCaptor.getValue().getRequesterName()).isEqualTo("owner");
     }
 
     @Test
@@ -145,6 +144,31 @@ class SettlementDisputeServiceAuthorizationTest {
     }
 
     @Test
+    void responseNamesAreResolvedFromStoredPrincipalIds() {
+        SettlementDispute dispute = SettlementDispute.builder()
+                .disputeId(1L)
+                .settlement(settlement(7L, 100L))
+                .requesterId(100L)
+                .adminId(1L)
+                .disputeReason("정산 금액 확인이 필요합니다.")
+                .status(SettlementDispute.DisputeProcessStatus.RESOLVED)
+                .build();
+        Users requester = new Users(100L);
+        requester.setName("lookup owner");
+        Users admin = new Users(1L);
+        admin.setName("lookup admin");
+
+        when(disputeRepository.findById(1L)).thenReturn(Optional.of(dispute));
+        when(userRepository.findById(100L)).thenReturn(Optional.of(requester));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(admin));
+
+        SettlementDisputeDto.Response response = service.getDispute(1L, user(1L, "ADMIN", "admin"));
+
+        assertThat(response.getRequesterName()).isEqualTo("lookup owner");
+        assertThat(response.getAdminName()).isEqualTo("lookup admin");
+    }
+
+    @Test
     void bySettlementChecksOwnershipEvenWhenNoDisputeExists() {
         Settlement settlement = settlement(7L, 100L);
         when(settlementRepository.findById(7L)).thenReturn(Optional.of(settlement));
@@ -154,7 +178,7 @@ class SettlementDisputeServiceAuthorizationTest {
     }
 
     @Test
-    void adminCanListReviewDetailAndDownloadAndReviewAdminComesFromPrincipal() {
+    void adminCanListReviewDetailAndDownloadAndReviewAdminComesFromPrincipalId() {
         SettlementDispute dispute = dispute(1L, settlement(7L, 100L));
         SettlementDisputeFile file = disputeFile(10L, dispute);
         dispute.getDisputeFiles().add(file);
@@ -178,13 +202,14 @@ class SettlementDisputeServiceAuthorizationTest {
         service.reviewDispute(request, admin);
 
         assertThat(dispute.getAdminId()).isEqualTo(1L);
-        assertThat(dispute.getAdminName()).isEqualTo("admin");
     }
 
     @Test
-    void reviewUsesUserLookupWhenPrincipalNameIsMissing() {
+    void reviewResponseUsesUserLookupWhenAdminNameIsNeeded() {
         SettlementDispute dispute = dispute(1L, settlement(7L, 100L));
         CustomUserDetails admin = user(1L, "ADMIN", null);
+        Users requester = new Users(100L);
+        requester.setName("lookup owner");
         Users adminUser = new Users(1L);
         adminUser.setName("lookup admin");
         SettlementDisputeDto.AdminReviewRequest request = SettlementDisputeDto.AdminReviewRequest.builder()
@@ -193,14 +218,15 @@ class SettlementDisputeServiceAuthorizationTest {
                 .build();
 
         when(disputeRepository.findById(1L)).thenReturn(Optional.of(dispute));
+        when(userRepository.findById(100L)).thenReturn(Optional.of(requester));
         when(userRepository.findById(1L)).thenReturn(Optional.of(adminUser));
         when(disputeRepository.save(dispute)).thenReturn(dispute);
         when(settlementRepository.save(dispute.getSettlement())).thenReturn(dispute.getSettlement());
 
-        service.reviewDispute(request, admin);
+        SettlementDisputeDto.Response response = service.reviewDispute(request, admin);
 
         assertThat(dispute.getAdminId()).isEqualTo(1L);
-        assertThat(dispute.getAdminName()).isEqualTo("lookup admin");
+        assertThat(response.getAdminName()).isEqualTo("lookup admin");
     }
 
     @Test
@@ -230,7 +256,6 @@ class SettlementDisputeServiceAuthorizationTest {
                 .disputeId(disputeId)
                 .settlement(settlement)
                 .requesterId(100L)
-                .requesterName("owner")
                 .disputeReason("정산 금액 확인이 필요합니다.")
                 .status(SettlementDispute.DisputeProcessStatus.RAISED)
                 .build();

--- a/src/test/java/com/fairing/fairplay/settlement/service/SettlementDisputeServiceTest.java
+++ b/src/test/java/com/fairing/fairplay/settlement/service/SettlementDisputeServiceTest.java
@@ -1,6 +1,8 @@
 package com.fairing.fairplay.settlement.service;
 
+import com.fairing.fairplay.core.security.CustomUserDetails;
 import com.fairing.fairplay.core.service.LocalFileService;
+import com.fairing.fairplay.event.entity.Event;
 import com.fairing.fairplay.settlement.dto.SettlementDisputeDto;
 import com.fairing.fairplay.settlement.entity.Settlement;
 import com.fairing.fairplay.settlement.entity.SettlementDispute;
@@ -8,6 +10,9 @@ import com.fairing.fairplay.settlement.entity.SettlementDisputeFile;
 import com.fairing.fairplay.settlement.repository.SettlementDisputeFileRepository;
 import com.fairing.fairplay.settlement.repository.SettlementDisputeRepository;
 import com.fairing.fairplay.settlement.repository.SettlementRepository;
+import com.fairing.fairplay.user.entity.EventAdmin;
+import com.fairing.fairplay.user.entity.Users;
+import com.fairing.fairplay.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -41,6 +47,9 @@ class SettlementDisputeServiceTest {
     @Mock
     private LocalFileService localFileService;
 
+    @Mock
+    private UserRepository userRepository;
+
     private SettlementDisputeService service;
 
     @BeforeEach
@@ -49,7 +58,8 @@ class SettlementDisputeServiceTest {
                 disputeRepository,
                 disputeFileRepository,
                 settlementRepository,
-                localFileService
+                localFileService,
+                userRepository
         );
     }
 
@@ -77,7 +87,7 @@ class SettlementDisputeServiceTest {
                 .thenAnswer(invocation -> invocation.getArgument(0));
         lenient().when(settlementRepository.save(settlement)).thenReturn(settlement);
 
-        assertThatCode(() -> service.submitDispute(request, 55L))
+        assertThatCode(() -> service.submitDispute(request, user(55L, "EVENT_MANAGER", "행사 관리자")))
                 .doesNotThrowAnyException();
 
         verify(localFileService).moveToPermanent(tempKey, "disputes/900");
@@ -89,12 +99,29 @@ class SettlementDisputeServiceTest {
     }
 
     private Settlement settlement() {
+        EventAdmin eventAdmin = new EventAdmin();
+        eventAdmin.setUserId(55L);
+        eventAdmin.setUser(new Users(55L));
+
+        Event event = new Event();
+        event.setEventId(77L);
+        event.setManager(eventAdmin);
+
         return Settlement.builder()
                 .settlementId(7L)
+                .event(event)
                 .eventTitle("정산 행사")
                 .totalAmount(BigDecimal.valueOf(10000))
                 .feeAmount(BigDecimal.valueOf(1000))
                 .finalAmount(BigDecimal.valueOf(9000))
                 .build();
+    }
+
+    private CustomUserDetails user(Long userId, String roleCode, String name) {
+        CustomUserDetails userDetails = mock(CustomUserDetails.class);
+        lenient().when(userDetails.getUserId()).thenReturn(userId);
+        lenient().when(userDetails.getRoleCode()).thenReturn(roleCode);
+        lenient().when(userDetails.getName()).thenReturn(name);
+        return userDetails;
     }
 }


### PR DESCRIPTION
## Summary
- Restores P0-02 backend authorization ownership boundaries for booth experience/QR ownership.
- Enforces reservation event ownership boundaries.
- Separates refund admin and host authorization boundaries.
- Applies payment target ownership checks during creation and update.
- Protects settlement dispute principal/header/file download paths.
- Restores booth reservation principal checks.

## Verification
- `./gradlew test --rerun-tasks`: 136 tests, 0 failures, 0 errors.
- Targeted authorization suites: 71 tests.
- `git diff --check`: pass.

## Deferred / Non-blocking
- SSH/mini-server smoke is deferred because it depends on the external environment.
- Payment complete callback integrity is deferred to P0-03.
- CodeRabbit rate-limit or stale notices are non-blocking unless concrete Critical/High/Important findings appear.

Do not merge yet. Do not promote to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 플랫폼 전반에 걸쳐 역할 기반 접근 제어가 강화되어 예약, 부스 체험, 환불, 정산, 예약자 명단 등 주요 API의 인증·인가가 엄격해졌습니다.
  * 컨트롤러/서비스에서 인증 주체가 전달되어 파일 다운로드 등 민감 작업에 대해 사전 권한 확인이 수행됩니다.

* **Tests**
  * 인증·인가 로직을 검증하는 다수의 단위 테스트가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rktclgh/FairPlay_BE/pull/43?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->