### PR TITLE
P0-03 결제 완료 무결성 검증 강화

### DIFF
--- a/src/main/java/com/fairing/fairplay/banner/controller/BannerPaymentController.java
+++ b/src/main/java/com/fairing/fairplay/banner/controller/BannerPaymentController.java
@@ -55,7 +55,8 @@ public class BannerPaymentController {
     public ResponseEntity<PaymentResponseDto> completeBannerPayment(
             @RequestBody PaymentRequestDto paymentRequestDto) {
         
-        PaymentResponseDto completedPayment = paymentService.completePayment(paymentRequestDto);
+        PaymentResponseDto completedPayment = paymentService.completePublicPayment(
+                paymentRequestDto, "BANNER_APPLICATION");
         PaymentStatusCode paymentStatusCode = paymentStatusCodeRepository.findById(completedPayment.getPaymentStatusCodeId())
                 .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "해당 결제 상태 코드를 찾을 수 없습니다."));
 

--- a/src/main/java/com/fairing/fairplay/booth/controller/BoothPaymentController.java
+++ b/src/main/java/com/fairing/fairplay/booth/controller/BoothPaymentController.java
@@ -58,7 +58,8 @@ public class BoothPaymentController {
     public ResponseEntity<PaymentResponseDto> completeBoothPayment(
             @RequestBody PaymentRequestDto paymentRequestDto) {
         
-        PaymentResponseDto completedPayment = paymentService.completePayment(paymentRequestDto);
+        PaymentResponseDto completedPayment = paymentService.completePublicPayment(
+                paymentRequestDto, "BOOTH_APPLICATION");
         PaymentStatusCode paymentStatusCode = paymentStatusCodeRepository.findById(completedPayment.getPaymentStatusCodeId())
                 .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "해당 결제 상태 코드를 찾을 수 없습니다."));
 

--- a/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
+++ b/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
@@ -111,7 +111,6 @@ public class SecurityConfig {
                                 "/api/chat/rooms/**", // 채팅방 목록 조회만 허용
                                 "/api/chat/presence/status/**", // 사용자 온라인 상태 조회 허용
                                 "/uploads/**", // 로컬 파일 시스템의 정적 파일 서빙
-                                "/api/payments/complete", // PG사에서 호출하는 결제 완료 웹훅
                                 "/api/events/apply", // 행사 등록 신청
                                 "/api/events/apply/check",
                                 "/api/qr-tickets/reissue/guest",

--- a/src/main/java/com/fairing/fairplay/payment/controller/PaymentController.java
+++ b/src/main/java/com/fairing/fairplay/payment/controller/PaymentController.java
@@ -97,8 +97,12 @@ public class PaymentController {
     @FunctionAuth("completePayment")
     public ResponseEntity<PaymentResponseDto> completePayment(@RequestBody PaymentRequestDto paymentRequestDto,
                                                               @AuthenticationPrincipal CustomUserDetails userDetails) {
+        if (userDetails == null) {
+            throw new AccessDeniedException("인증되지 않은 사용자입니다.");
+        }
+
         try {
-            PaymentResponseDto completedPayment = paymentService.completePayment(paymentRequestDto);
+            PaymentResponseDto completedPayment = paymentService.completePayment(paymentRequestDto, userDetails);
             
             // 결제 완료 시 락 해제 (사용자별 + merchantUid별 모두)
             if (userDetails != null) {

--- a/src/main/java/com/fairing/fairplay/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/fairing/fairplay/payment/repository/PaymentRepository.java
@@ -4,7 +4,9 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -13,6 +15,10 @@ import com.fairing.fairplay.payment.entity.Payment;
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     Optional<Payment> findByMerchantUid(String merchantUid);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Payment p WHERE p.merchantUid = :merchantUid")
+    Optional<Payment> findByMerchantUidForUpdate(@Param("merchantUid") String merchantUid);
 
     List<Payment> findByEvent_EventId(Long eventId);
 

--- a/src/main/java/com/fairing/fairplay/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/fairing/fairplay/payment/repository/PaymentRepository.java
@@ -35,6 +35,9 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     // imp_uid 중복 검증용
     boolean existsByImpUidAndPaymentStatusCode_Code(String impUid, String paymentStatusCode);
 
+    boolean existsByImpUidAndPaymentStatusCode_CodeAndMerchantUidNot(String impUid, String paymentStatusCode,
+            String merchantUid);
+
     // 특정 target_id와 payment_target_type으로 결제 정보 조회
     Optional<Payment> findByTargetIdAndPaymentTargetType_PaymentTargetCode(Long targetId, String paymentTargetCode);
 

--- a/src/main/java/com/fairing/fairplay/payment/service/DefaultIamportPaymentVerifier.java
+++ b/src/main/java/com/fairing/fairplay/payment/service/DefaultIamportPaymentVerifier.java
@@ -1,28 +1,61 @@
 package com.fairing.fairplay.payment.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
 
-import javax.net.ssl.HttpsURLConnection;
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
 import java.math.BigDecimal;
-import java.net.URL;
+import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 
 @Component
 public class DefaultIamportPaymentVerifier implements IamportPaymentVerifier {
+
+    static final Duration IAMPORT_CONNECT_TIMEOUT = Duration.ofSeconds(5);
+    static final Duration IAMPORT_READ_TIMEOUT = Duration.ofSeconds(10);
+
+    private static final String IAMPORT_TOKEN_PATH = "/users/getToken";
+    private static final String IAMPORT_PAYMENT_PATH = "/payments/";
+    private static final ParameterizedTypeReference<Map<String, Object>> MAP_RESPONSE_TYPE =
+            new ParameterizedTypeReference<>() {
+            };
 
     @Value("${iamport.api-key}")
     private String iamportApiKey;
 
     @Value("${iamport.secret-key}")
     private String iamportSecretKey;
+
+    @Value("${iamport.base-url:https://api.iamport.kr}")
+    private String iamportBaseUrl = "https://api.iamport.kr";
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    public DefaultIamportPaymentVerifier() {
+        this(createIamportRestTemplate(), new ObjectMapper());
+    }
+
+    DefaultIamportPaymentVerifier(RestTemplate restTemplate, ObjectMapper objectMapper) {
+        this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    static RestTemplate createIamportRestTemplate() {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(IAMPORT_CONNECT_TIMEOUT);
+        requestFactory.setReadTimeout(IAMPORT_READ_TIMEOUT);
+        return new RestTemplate(requestFactory);
+    }
 
     @Override
     public IamportPaymentInfo findPayment(String impUid) {
@@ -40,59 +73,55 @@ public class DefaultIamportPaymentVerifier implements IamportPaymentVerifier {
         }
     }
 
-    private String getIamportAccessToken() throws IOException {
-        URL url = new URL("https://api.iamport.kr/users/getToken");
-        HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
+    private String getIamportAccessToken() {
+        Map<String, String> requestBody = Map.of(
+                "imp_key", iamportApiKey,
+                "imp_secret", iamportSecretKey
+        );
+        HttpEntity<Map<String, String>> request = new HttpEntity<>(requestBody, jsonHeaders());
 
-        conn.setRequestMethod("POST");
-        conn.setRequestProperty("Content-Type", "application/json");
-        conn.setRequestProperty("Accept", "application/json");
-        conn.setDoOutput(true);
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                iamportBaseUrl + IAMPORT_TOKEN_PATH,
+                HttpMethod.POST,
+                request,
+                MAP_RESPONSE_TYPE
+        );
 
-        ObjectMapper mapper = new ObjectMapper();
-        ObjectNode objectNode = mapper.createObjectNode();
-        objectNode.put("imp_key", iamportApiKey);
-        objectNode.put("imp_secret", iamportSecretKey);
-
-        try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()))) {
-            bw.write(mapper.writeValueAsString(objectNode));
-            bw.flush();
-        }
-
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()))) {
-            String jsonLine = br.readLine();
-            Map<String, Object> topLevelMap = mapper.readValue(jsonLine, Map.class);
-            Map<String, Object> responseMap = (Map<String, Object>) topLevelMap.get("response");
-            return responseMap.get("access_token").toString();
-        } finally {
-            conn.disconnect();
-        }
+        Map<String, Object> responseMap = responseMap(response.getBody());
+        return responseMap.get("access_token").toString();
     }
 
-    private Map<String, Object> getPaymentInfoFromIamport(String impUid, String accessToken) throws IOException {
-        URL url = new URL("https://api.iamport.kr/payments/" + impUid);
-        HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
+    private Map<String, Object> getPaymentInfoFromIamport(String impUid, String accessToken) {
+        HttpHeaders headers = jsonHeaders();
+        headers.setBearerAuth(accessToken);
+        HttpEntity<Void> request = new HttpEntity<>(headers);
 
-        conn.setRequestMethod("GET");
-        conn.setRequestProperty("Content-Type", "application/json");
-        conn.setRequestProperty("Accept", "application/json");
-        conn.setRequestProperty("Authorization", "Bearer " + accessToken);
+        ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                iamportBaseUrl + IAMPORT_PAYMENT_PATH + impUid,
+                HttpMethod.GET,
+                request,
+                MAP_RESPONSE_TYPE
+        );
 
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()))) {
-            String jsonLine = br.readLine();
-
-            ObjectMapper objectMapper = new ObjectMapper();
-            Map<String, Object> topLevelMap = objectMapper.readValue(jsonLine, Map.class);
-
-            Integer code = (Integer) topLevelMap.get("code");
-            if (code == null || code != 0) {
-                throw new IllegalStateException("아임포트 API 응답 오류: " + topLevelMap.get("message"));
-            }
-
-            return (Map<String, Object>) topLevelMap.get("response");
-        } finally {
-            conn.disconnect();
+        Map<String, Object> topLevelMap = response.getBody();
+        Integer code = objectMapper.convertValue(topLevelMap.get("code"), Integer.class);
+        if (code == null || code != 0) {
+            throw new IllegalStateException("아임포트 API 응답 오류: " + topLevelMap.get("message"));
         }
+
+        return responseMap(topLevelMap);
+    }
+
+    private HttpHeaders jsonHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        return headers;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> responseMap(Map<String, Object> topLevelMap) {
+        return objectMapper.convertValue(topLevelMap.get("response"), Map.class);
     }
 
     private String asString(Object value) {

--- a/src/main/java/com/fairing/fairplay/payment/service/DefaultIamportPaymentVerifier.java
+++ b/src/main/java/com/fairing/fairplay/payment/service/DefaultIamportPaymentVerifier.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -135,8 +136,11 @@ public class DefaultIamportPaymentVerifier implements IamportPaymentVerifier {
         if (value instanceof BigDecimal bigDecimal) {
             return bigDecimal;
         }
+        if (value instanceof BigInteger bigInteger) {
+            return new BigDecimal(bigInteger);
+        }
         if (value instanceof Number number) {
-            return BigDecimal.valueOf(number.doubleValue());
+            return new BigDecimal(number.toString());
         }
         return new BigDecimal(value.toString());
     }

--- a/src/main/java/com/fairing/fairplay/payment/service/DefaultIamportPaymentVerifier.java
+++ b/src/main/java/com/fairing/fairplay/payment/service/DefaultIamportPaymentVerifier.java
@@ -1,0 +1,114 @@
+package com.fairing.fairplay.payment.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.net.ssl.HttpsURLConnection;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.math.BigDecimal;
+import java.net.URL;
+import java.util.Map;
+
+@Component
+public class DefaultIamportPaymentVerifier implements IamportPaymentVerifier {
+
+    @Value("${iamport.api-key}")
+    private String iamportApiKey;
+
+    @Value("${iamport.secret-key}")
+    private String iamportSecretKey;
+
+    @Override
+    public IamportPaymentInfo findPayment(String impUid) {
+        try {
+            String accessToken = getIamportAccessToken();
+            Map<String, Object> paymentInfo = getPaymentInfoFromIamport(impUid, accessToken);
+            return new IamportPaymentInfo(
+                    asString(paymentInfo.get("imp_uid")),
+                    asString(paymentInfo.get("merchant_uid")),
+                    asString(paymentInfo.get("status")),
+                    toBigDecimal(paymentInfo.get("amount"))
+            );
+        } catch (Exception e) {
+            throw new IllegalStateException("아임포트 결제 조회 실패: " + e.getMessage(), e);
+        }
+    }
+
+    private String getIamportAccessToken() throws IOException {
+        URL url = new URL("https://api.iamport.kr/users/getToken");
+        HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
+
+        conn.setRequestMethod("POST");
+        conn.setRequestProperty("Content-Type", "application/json");
+        conn.setRequestProperty("Accept", "application/json");
+        conn.setDoOutput(true);
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode objectNode = mapper.createObjectNode();
+        objectNode.put("imp_key", iamportApiKey);
+        objectNode.put("imp_secret", iamportSecretKey);
+
+        try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()))) {
+            bw.write(mapper.writeValueAsString(objectNode));
+            bw.flush();
+        }
+
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()))) {
+            String jsonLine = br.readLine();
+            Map<String, Object> topLevelMap = mapper.readValue(jsonLine, Map.class);
+            Map<String, Object> responseMap = (Map<String, Object>) topLevelMap.get("response");
+            return responseMap.get("access_token").toString();
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    private Map<String, Object> getPaymentInfoFromIamport(String impUid, String accessToken) throws IOException {
+        URL url = new URL("https://api.iamport.kr/payments/" + impUid);
+        HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
+
+        conn.setRequestMethod("GET");
+        conn.setRequestProperty("Content-Type", "application/json");
+        conn.setRequestProperty("Accept", "application/json");
+        conn.setRequestProperty("Authorization", "Bearer " + accessToken);
+
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()))) {
+            String jsonLine = br.readLine();
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            Map<String, Object> topLevelMap = objectMapper.readValue(jsonLine, Map.class);
+
+            Integer code = (Integer) topLevelMap.get("code");
+            if (code == null || code != 0) {
+                throw new IllegalStateException("아임포트 API 응답 오류: " + topLevelMap.get("message"));
+            }
+
+            return (Map<String, Object>) topLevelMap.get("response");
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    private String asString(Object value) {
+        return value != null ? value.toString() : null;
+    }
+
+    private BigDecimal toBigDecimal(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof BigDecimal bigDecimal) {
+            return bigDecimal;
+        }
+        if (value instanceof Number number) {
+            return BigDecimal.valueOf(number.doubleValue());
+        }
+        return new BigDecimal(value.toString());
+    }
+}

--- a/src/main/java/com/fairing/fairplay/payment/service/IamportPaymentInfo.java
+++ b/src/main/java/com/fairing/fairplay/payment/service/IamportPaymentInfo.java
@@ -1,0 +1,11 @@
+package com.fairing.fairplay.payment.service;
+
+import java.math.BigDecimal;
+
+public record IamportPaymentInfo(
+        String impUid,
+        String merchantUid,
+        String status,
+        BigDecimal amount
+) {
+}

--- a/src/main/java/com/fairing/fairplay/payment/service/IamportPaymentVerifier.java
+++ b/src/main/java/com/fairing/fairplay/payment/service/IamportPaymentVerifier.java
@@ -1,0 +1,6 @@
+package com.fairing.fairplay.payment.service;
+
+public interface IamportPaymentVerifier {
+
+    IamportPaymentInfo findPayment(String impUid);
+}

--- a/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
+++ b/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
@@ -93,6 +93,7 @@ public class PaymentService {
     private final AttendeeFormAttendeeService attendeeFormAttendeeService;
 
     private final IamportPaymentVerifier iamportPaymentVerifier;
+    private final ReservationPaymentIntentStore reservationPaymentIntentStore;
 
     // 결제 요청 정보 저장 (예약/부스/광고 통합)
     @Transactional
@@ -122,15 +123,17 @@ public class PaymentService {
                 .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 결제 대상 타입입니다: " + paymentRequestDto.getPaymentTargetType()));
         validatePaymentTargetCreationPermission(paymentTargetType, paymentRequestDto.getTargetId(), user);
 
-        // 결제 방법
-        PaymentTypeCode paymentTypeCode = paymentTypeCodeRepository.getReferenceByCode("CARD");
-        // 결제 상태
-        PaymentStatusCode paymentStatusCode = paymentStatusCodeRepository.getReferenceByCode("PENDING");
-
         // merchantUid는 외부에서 제공되거나 자체 생성
         String merchantUid = paymentRequestDto.getMerchantUid() != null
                 ? paymentRequestDto.getMerchantUid()
                 : generateMerchantUid(paymentRequestDto.getPaymentTargetType());
+        ReservationPaymentIntent reservationIntent = validateReservationPaymentIntentRequest(
+                paymentRequestDto, paymentTargetType, event, userId, merchantUid);
+
+        // 결제 방법
+        PaymentTypeCode paymentTypeCode = paymentTypeCodeRepository.getReferenceByCode("CARD");
+        // 결제 상태
+        PaymentStatusCode paymentStatusCode = paymentStatusCodeRepository.getReferenceByCode("PENDING");
 
         // 결제 후 메인 데이터 생성
 
@@ -141,8 +144,12 @@ public class PaymentService {
                 .targetId(paymentRequestDto.getTargetId()) // DTO에서 제공된 경우에만 설정
                 .merchantUid(merchantUid)
                 .quantity(paymentRequestDto.getQuantity())
-                .price(paymentRequestDto.getPrice())
-                .amount(paymentRequestDto.getPrice().multiply(new BigDecimal(paymentRequestDto.getQuantity())))
+                .price(reservationIntent != null
+                        ? unitPriceFrom(reservationIntent)
+                        : paymentRequestDto.getPrice())
+                .amount(reservationIntent != null
+                        ? reservationIntent.amount()
+                        : paymentRequestDto.getPrice().multiply(new BigDecimal(paymentRequestDto.getQuantity())))
                 .pgProvider(paymentRequestDto.getPgProvider())
                 .paymentTypeCode(paymentTypeCode)
                 .paymentStatusCode(paymentStatusCode) // 초기 상태: PENDING
@@ -150,6 +157,9 @@ public class PaymentService {
                 .build();
 
         Payment saved = paymentRepository.save(payment);
+        if (reservationIntent != null) {
+            reservationPaymentIntentStore.save(reservationIntent);
+        }
         return PaymentResponseDto.fromEntity(saved);
     }
 
@@ -247,8 +257,9 @@ public class PaymentService {
             throw new IllegalStateException("이미 사용된 결제 ID입니다: " + paymentRequestDto.getImpUid());
         }
 
+        ReservationPaymentIntent reservationIntent = validateReservationCompletionRequest(
+                payment, paymentRequestDto, userDetails);
         validatePaymentWithIamport(paymentRequestDto.getImpUid(), payment);
-        validateReservationCompletionRequest(payment, paymentRequestDto.getScheduleId(), paymentRequestDto.getTicketId());
 
         PaymentStatusCode completedStatus = paymentStatusCodeRepository.findByCode("COMPLETED")
                 .orElseThrow(() -> new IllegalStateException("COMPLETED 상태 코드를 찾을 수 없습니다."));
@@ -261,7 +272,13 @@ public class PaymentService {
 
         System.out.println("🔵 [PaymentService] completePayment - 받은 scheduleId: " + paymentRequestDto.getScheduleId() + 
                 ", ticketId: " + paymentRequestDto.getTicketId());
-        processPaymentCompletionActions(savedPayment, paymentRequestDto.getScheduleId(), paymentRequestDto.getTicketId());
+        Long completionScheduleId = reservationIntent != null ? reservationIntent.scheduleId() : paymentRequestDto.getScheduleId();
+        Long completionTicketId = reservationIntent != null ? reservationIntent.ticketId() : paymentRequestDto.getTicketId();
+        processPaymentCompletionActions(savedPayment, completionScheduleId, completionTicketId);
+
+        if (reservationIntent != null) {
+            reservationPaymentIntentStore.delete(payment.getMerchantUid(), reservationIntent.userId());
+        }
 
         Payment updatedPayment = paymentRepository.findById(savedPayment.getPaymentId())
                 .orElse(savedPayment);
@@ -785,21 +802,113 @@ public class PaymentService {
         }
     }
 
-    private void validateReservationCompletionRequest(Payment payment, Long scheduleId, Long ticketId) {
+    private ReservationPaymentIntent validateReservationPaymentIntentRequest(
+            PaymentRequestDto paymentRequestDto,
+            PaymentTargetType paymentTargetType,
+            Event event,
+            Long userId,
+            String merchantUid
+    ) {
+        String targetType = paymentTargetType != null
+                ? paymentTargetType.getPaymentTargetCode()
+                : null;
+        if (!"RESERVATION".equals(targetType)) {
+            return null;
+        }
+        if (event == null || event.getEventId() == null) {
+            throw new IllegalArgumentException("예약 결제 요청에는 eventId가 필요합니다.");
+        }
+        if (paymentRequestDto.getScheduleId() == null || paymentRequestDto.getTicketId() == null) {
+            throw new IllegalArgumentException("예약 결제 요청에는 scheduleId와 ticketId가 필요합니다.");
+        }
+
+        ScheduleTicket scheduleTicket = validateReservationScheduleTicket(
+                event,
+                paymentRequestDto.getScheduleId(),
+                paymentRequestDto.getTicketId());
+        Ticket ticket = scheduleTicket.getTicket();
+        validateTicketMaxPurchase(ticket, paymentRequestDto.getQuantity());
+
+        BigDecimal unitPrice = BigDecimal.valueOf(ticket.getPrice());
+        BigDecimal expectedAmount = unitPrice.multiply(BigDecimal.valueOf(paymentRequestDto.getQuantity()));
+        if (paymentRequestDto.getPrice().compareTo(unitPrice) != 0) {
+            throw new IllegalArgumentException("티켓 가격과 결제 요청 가격이 일치하지 않습니다.");
+        }
+        if (paymentRequestDto.getAmount() != null && paymentRequestDto.getAmount().compareTo(expectedAmount) != 0) {
+            throw new IllegalArgumentException("티켓 가격과 결제 요청 총액이 일치하지 않습니다.");
+        }
+
+        return new ReservationPaymentIntent(
+                event.getEventId(),
+                paymentRequestDto.getScheduleId(),
+                paymentRequestDto.getTicketId(),
+                paymentRequestDto.getQuantity(),
+                expectedAmount,
+                targetType,
+                userId,
+                merchantUid);
+    }
+
+    private ReservationPaymentIntent validateReservationCompletionRequest(
+            Payment payment,
+            PaymentRequestDto paymentRequestDto,
+            CustomUserDetails userDetails
+    ) {
         String targetType = payment.getPaymentTargetType() != null
                 ? payment.getPaymentTargetType().getPaymentTargetCode()
                 : null;
         if (!"RESERVATION".equals(targetType)) {
-            return;
+            return null;
         }
-        if (scheduleId == null || ticketId == null) {
+        if (paymentRequestDto.getScheduleId() == null || paymentRequestDto.getTicketId() == null) {
             throw new IllegalArgumentException("예약 결제 완료에는 scheduleId와 ticketId가 필요합니다.");
         }
         Event event = payment.getEvent();
         if (event == null || event.getEventId() == null) {
             throw new IllegalArgumentException("예약 결제에 이벤트 정보가 없습니다.");
         }
+        Long paymentUserId = payment.getUser() != null ? payment.getUser().getUserId() : null;
+        Long principalUserId = userDetails != null ? userDetails.getUserId() : null;
+        ReservationPaymentIntent intent = reservationPaymentIntentStore
+                .find(payment.getMerchantUid(), paymentUserId)
+                .orElseThrow(() -> new IllegalArgumentException("예약 결제 intent가 없습니다."));
+        if (!Objects.equals(intent.userId(), paymentUserId)
+                || !Objects.equals(intent.userId(), principalUserId)
+                || !Objects.equals(intent.merchantUid(), payment.getMerchantUid())
+                || !"RESERVATION".equals(intent.targetType())) {
+            throw new AccessDeniedException("예약 결제 intent가 결제 정보와 일치하지 않습니다.");
+        }
+        if (!Objects.equals(intent.eventId(), event.getEventId())
+                || !Objects.equals(intent.scheduleId(), paymentRequestDto.getScheduleId())
+                || !Objects.equals(intent.ticketId(), paymentRequestDto.getTicketId())) {
+            throw new IllegalArgumentException("예약 결제 intent와 완료 요청이 일치하지 않습니다.");
+        }
+        if (!Objects.equals(intent.quantity(), payment.getQuantity())
+                || intent.amount().compareTo(payment.getAmount()) != 0) {
+            throw new IllegalArgumentException("예약 결제 intent와 결제 금액 또는 수량이 일치하지 않습니다.");
+        }
+        if (paymentRequestDto.getQuantity() != null && !Objects.equals(paymentRequestDto.getQuantity(), intent.quantity())) {
+            throw new IllegalArgumentException("예약 결제 intent와 완료 요청 수량이 일치하지 않습니다.");
+        }
+        if (paymentRequestDto.getAmount() != null && paymentRequestDto.getAmount().compareTo(intent.amount()) != 0) {
+            throw new IllegalArgumentException("예약 결제 intent와 완료 요청 금액이 일치하지 않습니다.");
+        }
+        if (paymentRequestDto.getPrice() != null && paymentRequestDto.getPrice().compareTo(unitPriceFrom(intent)) != 0) {
+            throw new IllegalArgumentException("예약 결제 intent와 완료 요청 가격이 일치하지 않습니다.");
+        }
 
+        ScheduleTicket scheduleTicket = validateReservationScheduleTicket(event, intent.scheduleId(), intent.ticketId());
+        validateTicketMaxPurchase(scheduleTicket.getTicket(), intent.quantity());
+        BigDecimal expectedAmount = BigDecimal.valueOf(scheduleTicket.getTicket().getPrice())
+                .multiply(BigDecimal.valueOf(intent.quantity()));
+        if (expectedAmount.compareTo(intent.amount()) != 0) {
+            throw new IllegalArgumentException("티켓 가격과 결제 금액이 일치하지 않습니다.");
+        }
+
+        return intent;
+    }
+
+    private ScheduleTicket validateReservationScheduleTicket(Event event, Long scheduleId, Long ticketId) {
         EventSchedule schedule = eventScheduleRepository.findById(scheduleId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스케줄 ID: " + scheduleId));
         Long scheduleEventId = schedule.getEvent() != null ? schedule.getEvent().getEventId() : null;
@@ -813,12 +922,17 @@ public class PaymentService {
         if (ticket == null || ticket.getPrice() == null) {
             throw new IllegalArgumentException("티켓 가격 정보가 없습니다.");
         }
+        return scheduleTicket;
+    }
 
-        BigDecimal expectedAmount = BigDecimal.valueOf(ticket.getPrice())
-                .multiply(BigDecimal.valueOf(payment.getQuantity()));
-        if (expectedAmount.compareTo(payment.getAmount()) != 0) {
-            throw new IllegalArgumentException("티켓 가격과 결제 금액이 일치하지 않습니다.");
+    private void validateTicketMaxPurchase(Ticket ticket, Integer quantity) {
+        if (ticket.getMaxPurchase() != null && quantity != null && quantity > ticket.getMaxPurchase()) {
+            throw new IllegalArgumentException("티켓 최대 구매 수량을 초과했습니다.");
         }
+    }
+
+    private BigDecimal unitPriceFrom(ReservationPaymentIntent intent) {
+        return intent.amount().divide(BigDecimal.valueOf(intent.quantity()));
     }
 
     /**

--- a/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
+++ b/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
@@ -44,6 +44,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
@@ -288,7 +289,7 @@ public class PaymentService {
             ReservationPaymentIntent reservationIntentSnapshot,
             IamportPaymentInfo paymentInfo
     ) {
-        return writeTransactionTemplate().execute(status -> {
+        PaymentCompletionResult result = writeTransactionTemplate().execute(status -> {
             Payment payment = paymentRepository.findByMerchantUidForUpdate(paymentRequestDto.getMerchantUid())
                     .orElseThrow(() -> new IllegalArgumentException("결제 정보가 없습니다: " + paymentRequestDto.getMerchantUid()));
             validateCompletionEligibility(payment, paymentRequestDto, userDetails, expectedPublicTargetType);
@@ -312,28 +313,41 @@ public class PaymentService {
             Long completionTicketId = reservationIntent != null ? reservationIntent.ticketId() : paymentRequestDto.getTicketId();
             processPaymentCompletionActions(savedPayment, completionScheduleId, completionTicketId);
 
-            if (reservationIntent != null) {
-                reservationPaymentIntentStore.delete(payment.getMerchantUid(), reservationIntent.userId());
-            }
-
             Payment updatedPayment = paymentRepository.findById(savedPayment.getPaymentId())
                     .orElse(savedPayment);
 
             System.out.println("🟢 [PaymentService] completePayment 반환 - paymentId: " + updatedPayment.getPaymentId() +
                     ", targetId: " + updatedPayment.getTargetId());
 
-            return PaymentResponseDto.fromEntity(updatedPayment);
+            return new PaymentCompletionResult(
+                    PaymentResponseDto.fromEntity(updatedPayment),
+                    payment.getMerchantUid(),
+                    reservationIntent);
         });
+        if (result.reservationIntent() != null) {
+            reservationPaymentIntentStore.delete(result.merchantUid(), result.reservationIntent().userId());
+        }
+        return result.response();
     }
 
     private TransactionTemplate readOnlyTransactionTemplate() {
         TransactionTemplate template = new TransactionTemplate(transactionManager);
+        template.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
         template.setReadOnly(true);
         return template;
     }
 
     private TransactionTemplate writeTransactionTemplate() {
-        return new TransactionTemplate(transactionManager);
+        TransactionTemplate template = new TransactionTemplate(transactionManager);
+        template.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        return template;
+    }
+
+    private record PaymentCompletionResult(
+            PaymentResponseDto response,
+            String merchantUid,
+            ReservationPaymentIntent reservationIntent
+    ) {
     }
 
     private void validateCompletionEligibility(

--- a/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
+++ b/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
@@ -195,6 +195,9 @@ public class PaymentService {
 
         // 6. 결제 완료 후 후속 처리 (예약 생성 등) - PaymentRequestDto의 scheduleId, ticketId 전달
         processPaymentCompletionActions(savedPaymentEntity, paymentRequestDto.getScheduleId(), paymentRequestDto.getTicketId());
+        if (isReservationPayment(savedPaymentEntity)) {
+            reservationPaymentIntentStore.delete(payment.getMerchantUid(), userId);
+        }
 
         return PaymentResponseDto.fromEntity(savedPaymentEntity);
     }
@@ -296,6 +299,13 @@ public class PaymentService {
         if (!Objects.equals(actualTargetType, expectedTargetType)) {
             throw new AccessDeniedException("허용되지 않은 공개 결제 완료 대상입니다.");
         }
+    }
+
+    private boolean isReservationPayment(Payment payment) {
+        String targetType = payment.getPaymentTargetType() != null
+                ? payment.getPaymentTargetType().getPaymentTargetCode()
+                : null;
+        return "RESERVATION".equals(targetType);
     }
 
     // 티켓 결제 전체 조회 (전체 관리자, 행사 관리자)

--- a/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
+++ b/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
@@ -29,30 +29,25 @@ import com.fairing.fairplay.reservation.repository.ReservationStatusCodeReposito
 import com.fairing.fairplay.reservation.service.ReservationService;
 import com.fairing.fairplay.attendeeform.service.AttendeeFormAttendeeService;
 import com.fairing.fairplay.ticket.entity.EventSchedule;
+import com.fairing.fairplay.ticket.entity.ScheduleTicket;
+import com.fairing.fairplay.ticket.entity.ScheduleTicketId;
 import com.fairing.fairplay.ticket.entity.Ticket;
 import com.fairing.fairplay.ticket.repository.EventScheduleRepository;
 import com.fairing.fairplay.ticket.repository.ScheduleTicketRepository;
 import com.fairing.fairplay.ticket.repository.TicketRepository;
 import com.fairing.fairplay.user.entity.Users;
 import com.fairing.fairplay.user.repository.UserRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.net.ssl.HttpsURLConnection;
-import java.io.*;
 import java.math.BigDecimal;
-import java.net.URL;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
 
@@ -97,12 +92,7 @@ public class PaymentService {
     // 참석자 생성 및 폼 링크 생성
     private final AttendeeFormAttendeeService attendeeFormAttendeeService;
 
-    // 아임포트 API 설정
-    @Value("${iamport.api-key}")
-    private String iamportApiKey;
-
-    @Value("${iamport.secret-key}")
-    private String iamportSecretKey;
+    private final IamportPaymentVerifier iamportPaymentVerifier;
 
     // 결제 요청 정보 저장 (예약/부스/광고 통합)
     @Transactional
@@ -202,38 +192,44 @@ public class PaymentService {
     // 티켓 결제 완료 처리 (PG사 결제 후 호출)
     @Transactional
     public PaymentResponseDto completePayment(PaymentRequestDto paymentRequestDto) {
+        return completePayment(paymentRequestDto, null);
+    }
+
+    // 티켓 결제 완료 처리 (PG사 결제 후 호출)
+    @Transactional
+    public PaymentResponseDto completePayment(PaymentRequestDto paymentRequestDto, CustomUserDetails userDetails) {
+        if (paymentRequestDto == null) {
+            throw new IllegalArgumentException("결제 요청 데이터가 없습니다.");
+        }
+        if (userDetails == null) {
+            throw new AccessDeniedException("인증되지 않은 사용자입니다.");
+        }
+        if (paymentRequestDto.getImpUid() == null || paymentRequestDto.getImpUid().isBlank()) {
+            throw new IllegalArgumentException("impUid는 필수입니다.");
+        }
 
         Payment payment = paymentRepository.findByMerchantUid(paymentRequestDto.getMerchantUid())
                 .orElseThrow(() -> new IllegalArgumentException("결제 정보가 없습니다: " + paymentRequestDto.getMerchantUid()));
 
-        // 1. 결제 상태 검증 - 이미 완료된 결제인지 확인
-        if ("COMPLETED".equals(payment.getPaymentStatusCode().getCode())) {
-            throw new IllegalStateException("이미 완료된 결제입니다: " + paymentRequestDto.getMerchantUid());
+        Long paymentUserId = payment.getUser() != null ? payment.getUser().getUserId() : null;
+        if (!Objects.equals(paymentUserId, userDetails.getUserId())) {
+            throw new AccessDeniedException("본인 결제만 완료할 수 있습니다.");
         }
 
-//        // 2. 결제 금액 검증 - 요청 금액과 실제 결제 금액 비교
-//        if (paymentRequestDto.getAmount() != null &&
-//            !payment.getAmount().equals(paymentRequestDto.getAmount())) {
-//            throw new IllegalArgumentException(
-//                String.format("결제 금액이 일치하지 않습니다. 요청: %s, 실제: %s",
-//                    paymentRequestDto.getAmount(), payment.getAmount()));
-//        }
-
-        // 3. imp_uid 중복 검증 (이미 사용된 PG 결제 ID인지 확인)
-        if (paymentRequestDto.getImpUid() != null) {
-            boolean duplicateImpUid = paymentRepository.existsByImpUidAndPaymentStatusCode_Code(
-                    paymentRequestDto.getImpUid(), "COMPLETED");
-            if (duplicateImpUid) {
-                throw new IllegalStateException("이미 사용된 결제 ID입니다: " + paymentRequestDto.getImpUid());
-            }
+        String currentStatus = payment.getPaymentStatusCode() != null ? payment.getPaymentStatusCode().getCode() : null;
+        if (!"PENDING".equals(currentStatus)) {
+            throw new IllegalStateException("대기 상태 결제만 완료할 수 있습니다: " + currentStatus);
         }
 
-        // 4. PG사 결제 검증 (실제 결제가 완료되었는지 아임포트 API로 확인)
-        if (paymentRequestDto.getImpUid() != null) {
-            validatePaymentWithIamport(paymentRequestDto.getImpUid(), payment.getAmount());
+        boolean duplicateImpUid = paymentRepository.existsByImpUidAndPaymentStatusCode_CodeAndMerchantUidNot(
+                paymentRequestDto.getImpUid(), "COMPLETED", payment.getMerchantUid());
+        if (duplicateImpUid) {
+            throw new IllegalStateException("이미 사용된 결제 ID입니다: " + paymentRequestDto.getImpUid());
         }
 
-        // 5. 결제 완료 처리
+        validatePaymentWithIamport(paymentRequestDto.getImpUid(), payment);
+        validateReservationCompletionRequest(payment, paymentRequestDto.getScheduleId(), paymentRequestDto.getTicketId());
+
         PaymentStatusCode completedStatus = paymentStatusCodeRepository.findByCode("COMPLETED")
                 .orElseThrow(() -> new IllegalStateException("COMPLETED 상태 코드를 찾을 수 없습니다."));
 
@@ -243,12 +239,10 @@ public class PaymentService {
 
         Payment savedPayment = paymentRepository.save(payment);
 
-        // 6. 결제 완료 후 후속 처리 (PaymentRequestDto의 scheduleId, ticketId 사용)
         System.out.println("🔵 [PaymentService] completePayment - 받은 scheduleId: " + paymentRequestDto.getScheduleId() + 
                 ", ticketId: " + paymentRequestDto.getTicketId());
         processPaymentCompletionActions(savedPayment, paymentRequestDto.getScheduleId(), paymentRequestDto.getTicketId());
 
-        // 7. 후속 처리로 업데이트된 payment 정보를 다시 조회하여 반환
         Payment updatedPayment = paymentRepository.findById(savedPayment.getPaymentId())
                 .orElse(savedPayment);
         
@@ -516,9 +510,11 @@ public class PaymentService {
                     System.out.println("알 수 없는 결제 타입: " + targetType);
             }
         } catch (Exception e) {
-            // 후속 처리 실패 시 로그 남기고 계속 진행 (결제는 이미 완료됨)
             System.err.println("결제 완료 후속 처리 실패 - paymentId: " + payment.getPaymentId() +
                     ", targetType: " + targetType + ", error: " + e.getMessage());
+            if ("RESERVATION".equals(targetType)) {
+                throw e;
+            }
         }
     }
 
@@ -545,38 +541,10 @@ public class PaymentService {
             }
             
 
-            EventSchedule schedule = null;
-            Ticket ticket = null;
-            
-            // scheduleId가 직접 전달된 경우 해당 스케줄 사용
-            if (scheduleId != null) {
-                schedule = eventScheduleRepository.findById(scheduleId)
-                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스케줄 ID: " + scheduleId));
-                System.out.println("🟢 [PaymentService] 전달받은 scheduleId 사용: " + scheduleId);
-            } else {
-                // 기존 로직: 첫 번째 스케줄 사용
-                List<EventSchedule> schedules = eventScheduleRepository.findByEvent_EventId(event.getEventId());
-                if (schedules.isEmpty()) {
-                    throw new IllegalStateException("이벤트에 스케줄이 없습니다.");
-                }
-                schedule = schedules.get(0);
-                System.out.println("🟡 [PaymentService] 기본 스케줄 사용: " + schedule.getScheduleId());
-            }
-            
-            // ticketId가 직접 전달된 경우 해당 티켓 사용
-            if (ticketId != null) {
-                ticket = ticketRepository.findById(ticketId)
-                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 티켓 ID: " + ticketId));
-                System.out.println("🟢 [PaymentService] 전달받은 ticketId 사용: " + ticketId);
-            } else {
-                // 기존 로직: 첫 번째 티켓 사용
-                List<Ticket> tickets = ticketRepository.findTicketsByEventId(event.getEventId());
-                if (tickets.isEmpty()) {
-                    throw new IllegalStateException("이벤트에 티켓이 없습니다.");
-                }
-                ticket = tickets.get(0);
-                System.out.println("🟡 [PaymentService] 기본 티켓 사용: " + ticket.getTicketId());
-            }
+            EventSchedule schedule = eventScheduleRepository.findById(scheduleId)
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스케줄 ID: " + scheduleId));
+            Ticket ticket = ticketRepository.findById(ticketId)
+                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 티켓 ID: " + ticketId));
             
             // ReservationRequestDto 생성
             ReservationRequestDto reservationRequest = new ReservationRequestDto();
@@ -765,20 +733,22 @@ public class PaymentService {
      * 아임포트 API를 통한 결제 검증
      * PG사에서 실제로 결제가 완료되었는지 확인
      */
-    private void validatePaymentWithIamport(String impUid, BigDecimal expectedAmount) {
+    private void validatePaymentWithIamport(String impUid, Payment payment) {
         try {
-            System.out.println("아임포트 결제 검증 시작 - impUid: " + impUid + ", 예상금액: " + expectedAmount);
+            System.out.println("아임포트 결제 검증 시작 - impUid: " + impUid + ", 예상금액: " + payment.getAmount());
 
-            // 1. 아임포트 액세스 토큰 획득
-            String accessToken = getIamportAccessToken();
-
-            // 2. imp_uid로 결제 정보 조회
-            Map<String, Object> paymentInfo = getPaymentInfoFromIamport(impUid, accessToken);
-
-            // 3. 결제 상태 검증
-            String status = (String) paymentInfo.get("status");
-            if (!"paid".equals(status)) {
-                throw new IllegalStateException("아임포트에서 결제가 완료되지 않았습니다. 상태: " + status);
+            IamportPaymentInfo paymentInfo = iamportPaymentVerifier.findPayment(impUid);
+            if (!Objects.equals(impUid, paymentInfo.impUid())) {
+                throw new IllegalStateException("아임포트 결제 ID가 일치하지 않습니다.");
+            }
+            if (!Objects.equals(payment.getMerchantUid(), paymentInfo.merchantUid())) {
+                throw new IllegalStateException("아임포트 주문번호가 일치하지 않습니다.");
+            }
+            if (!"paid".equals(paymentInfo.status())) {
+                throw new IllegalStateException("아임포트에서 결제가 완료되지 않았습니다. 상태: " + paymentInfo.status());
+            }
+            if (paymentInfo.amount() == null || paymentInfo.amount().compareTo(payment.getAmount()) != 0) {
+                throw new IllegalStateException("아임포트 결제 금액이 일치하지 않습니다.");
             }
 
         } catch (Exception e) {
@@ -786,73 +756,40 @@ public class PaymentService {
         }
     }
 
-    /**
-     * 아임포트 액세스 토큰 획득
-     */
-    private String getIamportAccessToken() throws IOException {
-        URL url = new URL("https://api.iamport.kr/users/getToken");
-        HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
-
-        conn.setRequestMethod("POST");
-        conn.setRequestProperty("Content-Type", "application/json");
-        conn.setRequestProperty("Accept", "application/json");
-        conn.setDoOutput(true);
-
-        ObjectMapper mapper = new ObjectMapper();
-        ObjectNode objectNode = mapper.createObjectNode();
-        objectNode.put("imp_key", iamportApiKey);
-        objectNode.put("imp_secret", iamportSecretKey);
-
-        String json = mapper.writeValueAsString(objectNode);
-
-        try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()))) {
-            bw.write(json);
-            bw.flush();
+    private void validateReservationCompletionRequest(Payment payment, Long scheduleId, Long ticketId) {
+        String targetType = payment.getPaymentTargetType() != null
+                ? payment.getPaymentTargetType().getPaymentTargetCode()
+                : null;
+        if (!"RESERVATION".equals(targetType)) {
+            return;
+        }
+        if (scheduleId == null || ticketId == null) {
+            throw new IllegalArgumentException("예약 결제 완료에는 scheduleId와 ticketId가 필요합니다.");
+        }
+        Event event = payment.getEvent();
+        if (event == null || event.getEventId() == null) {
+            throw new IllegalArgumentException("예약 결제에 이벤트 정보가 없습니다.");
         }
 
-        String accessToken;
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()))) {
-            String jsonLine = br.readLine();
-
-            ObjectMapper objectMapper = new ObjectMapper();
-            Map<String, Object> topLevelMap = objectMapper.readValue(jsonLine, Map.class);
-            Map<String, Object> responseMap = (Map<String, Object>) topLevelMap.get("response");
-            accessToken = responseMap.get("access_token").toString();
+        EventSchedule schedule = eventScheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스케줄 ID: " + scheduleId));
+        Long scheduleEventId = schedule.getEvent() != null ? schedule.getEvent().getEventId() : null;
+        if (!Objects.equals(scheduleEventId, event.getEventId())) {
+            throw new IllegalArgumentException("스케줄이 결제 이벤트에 속하지 않습니다.");
         }
 
-        conn.disconnect();
-        return accessToken;
-    }
-
-    /**
-     * 아임포트에서 결제 정보 조회
-     */
-    private Map<String, Object> getPaymentInfoFromIamport(String impUid, String accessToken) throws IOException {
-        URL url = new URL("https://api.iamport.kr/payments/" + impUid);
-        HttpsURLConnection conn = (HttpsURLConnection) url.openConnection();
-
-        conn.setRequestMethod("GET");
-        conn.setRequestProperty("Content-Type", "application/json");
-        conn.setRequestProperty("Accept", "application/json");
-        conn.setRequestProperty("Authorization", "Bearer " + accessToken);
-
-        Map<String, Object> paymentInfo;
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream()))) {
-            String jsonLine = br.readLine();
-
-            ObjectMapper objectMapper = new ObjectMapper();
-            Map<String, Object> topLevelMap = objectMapper.readValue(jsonLine, Map.class);
-
-            Integer code = (Integer) topLevelMap.get("code");
-            if (code == null || code != 0) {
-                throw new IllegalStateException("아임포트 API 응답 오류: " + topLevelMap.get("message"));
-            }
-
-            paymentInfo = (Map<String, Object>) topLevelMap.get("response");
+        ScheduleTicket scheduleTicket = scheduleTicketRepository.findById(new ScheduleTicketId(ticketId, scheduleId))
+                .orElseThrow(() -> new IllegalArgumentException("스케줄에 등록된 티켓이 아닙니다."));
+        Ticket ticket = scheduleTicket.getTicket();
+        if (ticket == null || ticket.getPrice() == null) {
+            throw new IllegalArgumentException("티켓 가격 정보가 없습니다.");
         }
 
-        conn.disconnect();
-        return paymentInfo;
+        BigDecimal expectedAmount = BigDecimal.valueOf(ticket.getPrice())
+                .multiply(BigDecimal.valueOf(payment.getQuantity()));
+        if (expectedAmount.compareTo(payment.getAmount()) != 0) {
+            throw new IllegalArgumentException("티켓 가격과 결제 금액이 일치하지 않습니다.");
+        }
     }
 
     /**

--- a/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
+++ b/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
@@ -38,22 +38,39 @@ import com.fairing.fairplay.ticket.repository.TicketRepository;
 import com.fairing.fairplay.user.entity.Users;
 import com.fairing.fairplay.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class PaymentService {
+
+    private static final String IMP_UID_LOCK_PREFIX = "payment:impUid:lock:";
+    private static final Duration IMP_UID_LOCK_TTL = Duration.ofSeconds(30);
+    private static final DefaultRedisScript<Long> RELEASE_IMP_UID_LOCK_SCRIPT = new DefaultRedisScript<>(
+            """
+                    if redis.call('get', KEYS[1]) == ARGV[1] then
+                        return redis.call('del', KEYS[1])
+                    end
+                    return 0
+                    """,
+            Long.class);
 
     private final PaymentRepository paymentRepository;
     private final RefundRepository refundRepository;
@@ -94,6 +111,7 @@ public class PaymentService {
 
     private final IamportPaymentVerifier iamportPaymentVerifier;
     private final ReservationPaymentIntentStore reservationPaymentIntentStore;
+    private final StringRedisTemplate redisTemplate;
 
     // 결제 요청 정보 저장 (예약/부스/광고 통합)
     @Transactional
@@ -237,9 +255,60 @@ public class PaymentService {
             throw new IllegalArgumentException("impUid는 필수입니다.");
         }
 
-        Payment payment = paymentRepository.findByMerchantUidForUpdate(paymentRequestDto.getMerchantUid())
-                .orElseThrow(() -> new IllegalArgumentException("결제 정보가 없습니다: " + paymentRequestDto.getMerchantUid()));
+        String lockToken = acquireImpUidLock(paymentRequestDto.getImpUid());
+        try {
+            Payment paymentSnapshot = paymentRepository.findByMerchantUid(paymentRequestDto.getMerchantUid())
+                    .orElseThrow(() -> new IllegalArgumentException("결제 정보가 없습니다: " + paymentRequestDto.getMerchantUid()));
+            validateCompletionEligibility(paymentSnapshot, paymentRequestDto, userDetails, expectedPublicTargetType);
+            ReservationPaymentIntent reservationIntentSnapshot = validateReservationCompletionRequest(
+                    paymentSnapshot, paymentRequestDto, userDetails);
+            IamportPaymentInfo paymentInfo = validatePaymentWithIamport(paymentRequestDto.getImpUid(), paymentSnapshot);
 
+            Payment payment = paymentRepository.findByMerchantUidForUpdate(paymentRequestDto.getMerchantUid())
+                    .orElseThrow(() -> new IllegalArgumentException("결제 정보가 없습니다: " + paymentRequestDto.getMerchantUid()));
+            validateCompletionEligibility(payment, paymentRequestDto, userDetails, expectedPublicTargetType);
+            ReservationPaymentIntent reservationIntent = validateReservationCompletionRequest(
+                    payment, paymentRequestDto, userDetails);
+            validateReservationIntentUnchanged(reservationIntentSnapshot, reservationIntent);
+            validatePaymentWithIamportInfo(paymentRequestDto.getImpUid(), payment, paymentInfo);
+
+            PaymentStatusCode completedStatus = paymentStatusCodeRepository.findByCode("COMPLETED")
+                    .orElseThrow(() -> new IllegalStateException("COMPLETED 상태 코드를 찾을 수 없습니다."));
+
+            payment.setImpUid(paymentRequestDto.getImpUid());
+            payment.setPaymentStatusCode(completedStatus);
+            payment.setPaidAt(LocalDateTime.now());
+
+            Payment savedPayment = paymentRepository.save(payment);
+
+            System.out.println("🔵 [PaymentService] completePayment - 받은 scheduleId: " + paymentRequestDto.getScheduleId() +
+                    ", ticketId: " + paymentRequestDto.getTicketId());
+            Long completionScheduleId = reservationIntent != null ? reservationIntent.scheduleId() : paymentRequestDto.getScheduleId();
+            Long completionTicketId = reservationIntent != null ? reservationIntent.ticketId() : paymentRequestDto.getTicketId();
+            processPaymentCompletionActions(savedPayment, completionScheduleId, completionTicketId);
+
+            if (reservationIntent != null) {
+                reservationPaymentIntentStore.delete(payment.getMerchantUid(), reservationIntent.userId());
+            }
+
+            Payment updatedPayment = paymentRepository.findById(savedPayment.getPaymentId())
+                    .orElse(savedPayment);
+
+            System.out.println("🟢 [PaymentService] completePayment 반환 - paymentId: " + updatedPayment.getPaymentId() +
+                    ", targetId: " + updatedPayment.getTargetId());
+
+            return PaymentResponseDto.fromEntity(updatedPayment);
+        } finally {
+            releaseImpUidLock(paymentRequestDto.getImpUid(), lockToken);
+        }
+    }
+
+    private void validateCompletionEligibility(
+            Payment payment,
+            PaymentRequestDto paymentRequestDto,
+            CustomUserDetails userDetails,
+            String expectedPublicTargetType
+    ) {
         if (expectedPublicTargetType == null) {
             Long paymentUserId = payment.getUser() != null ? payment.getUser().getUserId() : null;
             if (!Objects.equals(paymentUserId, userDetails.getUserId())) {
@@ -259,37 +328,28 @@ public class PaymentService {
         if (duplicateImpUid) {
             throw new IllegalStateException("이미 사용된 결제 ID입니다: " + paymentRequestDto.getImpUid());
         }
+    }
 
-        ReservationPaymentIntent reservationIntent = validateReservationCompletionRequest(
-                payment, paymentRequestDto, userDetails);
-        validatePaymentWithIamport(paymentRequestDto.getImpUid(), payment);
-
-        PaymentStatusCode completedStatus = paymentStatusCodeRepository.findByCode("COMPLETED")
-                .orElseThrow(() -> new IllegalStateException("COMPLETED 상태 코드를 찾을 수 없습니다."));
-
-        payment.setImpUid(paymentRequestDto.getImpUid());
-        payment.setPaymentStatusCode(completedStatus);
-        payment.setPaidAt(LocalDateTime.now());
-
-        Payment savedPayment = paymentRepository.save(payment);
-
-        System.out.println("🔵 [PaymentService] completePayment - 받은 scheduleId: " + paymentRequestDto.getScheduleId() + 
-                ", ticketId: " + paymentRequestDto.getTicketId());
-        Long completionScheduleId = reservationIntent != null ? reservationIntent.scheduleId() : paymentRequestDto.getScheduleId();
-        Long completionTicketId = reservationIntent != null ? reservationIntent.ticketId() : paymentRequestDto.getTicketId();
-        processPaymentCompletionActions(savedPayment, completionScheduleId, completionTicketId);
-
-        if (reservationIntent != null) {
-            reservationPaymentIntentStore.delete(payment.getMerchantUid(), reservationIntent.userId());
+    private String acquireImpUidLock(String impUid) {
+        String lockKey = impUidLockKey(impUid);
+        String lockToken = UUID.randomUUID().toString();
+        Boolean acquired = redisTemplate.opsForValue().setIfAbsent(lockKey, lockToken, IMP_UID_LOCK_TTL);
+        if (!Boolean.TRUE.equals(acquired)) {
+            throw new IllegalStateException("결제 ID 처리 중입니다: " + impUid);
         }
+        return lockToken;
+    }
 
-        Payment updatedPayment = paymentRepository.findById(savedPayment.getPaymentId())
-                .orElse(savedPayment);
-        
-        System.out.println("🟢 [PaymentService] completePayment 반환 - paymentId: " + updatedPayment.getPaymentId() +
-                ", targetId: " + updatedPayment.getTargetId());
-        
-        return PaymentResponseDto.fromEntity(updatedPayment);
+    private void releaseImpUidLock(String impUid, String lockToken) {
+        try {
+            redisTemplate.execute(RELEASE_IMP_UID_LOCK_SCRIPT, Collections.singletonList(impUidLockKey(impUid)), lockToken);
+        } catch (Exception e) {
+            System.err.println("결제 ID 락 해제 실패 - impUid: " + impUid + ", error: " + e.getMessage());
+        }
+    }
+
+    private String impUidLockKey(String impUid) {
+        return IMP_UID_LOCK_PREFIX + impUid;
     }
 
     private void validatePublicCompletionTargetType(Payment payment, String expectedTargetType) {
@@ -789,26 +849,39 @@ public class PaymentService {
      * 아임포트 API를 통한 결제 검증
      * PG사에서 실제로 결제가 완료되었는지 확인
      */
-    private void validatePaymentWithIamport(String impUid, Payment payment) {
+    private IamportPaymentInfo validatePaymentWithIamport(String impUid, Payment payment) {
         try {
             System.out.println("아임포트 결제 검증 시작 - impUid: " + impUid + ", 예상금액: " + payment.getAmount());
 
             IamportPaymentInfo paymentInfo = iamportPaymentVerifier.findPayment(impUid);
-            if (!Objects.equals(impUid, paymentInfo.impUid())) {
-                throw new IllegalStateException("아임포트 결제 ID가 일치하지 않습니다.");
-            }
-            if (!Objects.equals(payment.getMerchantUid(), paymentInfo.merchantUid())) {
-                throw new IllegalStateException("아임포트 주문번호가 일치하지 않습니다.");
-            }
-            if (!"paid".equals(paymentInfo.status())) {
-                throw new IllegalStateException("아임포트에서 결제가 완료되지 않았습니다. 상태: " + paymentInfo.status());
-            }
-            if (paymentInfo.amount() == null || paymentInfo.amount().compareTo(payment.getAmount()) != 0) {
-                throw new IllegalStateException("아임포트 결제 금액이 일치하지 않습니다.");
-            }
-
+            validatePaymentWithIamportInfo(impUid, payment, paymentInfo);
+            return paymentInfo;
         } catch (Exception e) {
             throw new IllegalStateException("아임포트 결제 검증 실패: " + e.getMessage(), e);
+        }
+    }
+
+    private void validatePaymentWithIamportInfo(String impUid, Payment payment, IamportPaymentInfo paymentInfo) {
+        if (!Objects.equals(impUid, paymentInfo.impUid())) {
+            throw new IllegalStateException("아임포트 결제 ID가 일치하지 않습니다.");
+        }
+        if (!Objects.equals(payment.getMerchantUid(), paymentInfo.merchantUid())) {
+            throw new IllegalStateException("아임포트 주문번호가 일치하지 않습니다.");
+        }
+        if (!"paid".equals(paymentInfo.status())) {
+            throw new IllegalStateException("아임포트에서 결제가 완료되지 않았습니다. 상태: " + paymentInfo.status());
+        }
+        if (paymentInfo.amount() == null || paymentInfo.amount().compareTo(payment.getAmount()) != 0) {
+            throw new IllegalStateException("아임포트 결제 금액이 일치하지 않습니다.");
+        }
+    }
+
+    private void validateReservationIntentUnchanged(
+            ReservationPaymentIntent expected,
+            ReservationPaymentIntent actual
+    ) {
+        if (!Objects.equals(expected, actual)) {
+            throw new IllegalStateException("예약 결제 intent가 결제 검증 중 변경되었습니다.");
         }
     }
 
@@ -942,7 +1015,11 @@ public class PaymentService {
     }
 
     private BigDecimal unitPriceFrom(ReservationPaymentIntent intent) {
-        return intent.amount().divide(BigDecimal.valueOf(intent.quantity()));
+        try {
+            return intent.amount().divide(BigDecimal.valueOf(intent.quantity()), RoundingMode.UNNECESSARY);
+        } catch (ArithmeticException e) {
+            throw new IllegalArgumentException("예약 결제 intent 금액은 수량으로 정확히 나누어져야 합니다.", e);
+        }
     }
 
     /**

--- a/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
+++ b/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
@@ -43,7 +43,9 @@ import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -62,7 +64,7 @@ import java.util.UUID;
 public class PaymentService {
 
     private static final String IMP_UID_LOCK_PREFIX = "payment:impUid:lock:";
-    private static final Duration IMP_UID_LOCK_TTL = Duration.ofSeconds(30);
+    private static final Duration IMP_UID_LOCK_TTL = Duration.ofSeconds(90);
     private static final DefaultRedisScript<Long> RELEASE_IMP_UID_LOCK_SCRIPT = new DefaultRedisScript<>(
             """
                     if redis.call('get', KEYS[1]) == ARGV[1] then
@@ -112,6 +114,7 @@ public class PaymentService {
     private final IamportPaymentVerifier iamportPaymentVerifier;
     private final ReservationPaymentIntentStore reservationPaymentIntentStore;
     private final StringRedisTemplate redisTemplate;
+    private final PlatformTransactionManager transactionManager;
 
     // 결제 요청 정보 저장 (예약/부스/광고 통합)
     @Transactional
@@ -221,18 +224,15 @@ public class PaymentService {
     }
 
     // 티켓 결제 완료 처리 (PG사 결제 후 호출)
-    @Transactional
     public PaymentResponseDto completePayment(PaymentRequestDto paymentRequestDto) {
         return completePaymentInternal(paymentRequestDto, null, null);
     }
 
     // 티켓 결제 완료 처리 (PG사 결제 후 호출)
-    @Transactional
     public PaymentResponseDto completePayment(PaymentRequestDto paymentRequestDto, CustomUserDetails userDetails) {
         return completePaymentInternal(paymentRequestDto, userDetails, null);
     }
 
-    @Transactional
     public PaymentResponseDto completePublicPayment(PaymentRequestDto paymentRequestDto, String expectedTargetType) {
         if (!"BOOTH_APPLICATION".equals(expectedTargetType) && !"BANNER_APPLICATION".equals(expectedTargetType)) {
             throw new IllegalArgumentException("공개 결제 완료는 부스 또는 배너 신청에만 사용 가능합니다.");
@@ -257,13 +257,38 @@ public class PaymentService {
 
         String lockToken = acquireImpUidLock(paymentRequestDto.getImpUid());
         try {
+            PaymentCompletionSnapshot snapshot = loadCompletionSnapshot(paymentRequestDto, userDetails, expectedPublicTargetType);
+            IamportPaymentInfo paymentInfo = validatePaymentWithIamportSnapshot(paymentRequestDto.getImpUid(), snapshot);
+            return completePaymentAfterPgVerification(
+                    paymentRequestDto, userDetails, expectedPublicTargetType, snapshot.reservationIntent(), paymentInfo);
+        } finally {
+            releaseImpUidLock(paymentRequestDto.getImpUid(), lockToken);
+        }
+    }
+
+    private PaymentCompletionSnapshot loadCompletionSnapshot(
+            PaymentRequestDto paymentRequestDto,
+            CustomUserDetails userDetails,
+            String expectedPublicTargetType
+    ) {
+        return readOnlyTransactionTemplate().execute(status -> {
             Payment paymentSnapshot = paymentRepository.findByMerchantUid(paymentRequestDto.getMerchantUid())
                     .orElseThrow(() -> new IllegalArgumentException("결제 정보가 없습니다: " + paymentRequestDto.getMerchantUid()));
             validateCompletionEligibility(paymentSnapshot, paymentRequestDto, userDetails, expectedPublicTargetType);
             ReservationPaymentIntent reservationIntentSnapshot = validateReservationCompletionRequest(
                     paymentSnapshot, paymentRequestDto, userDetails);
-            IamportPaymentInfo paymentInfo = validatePaymentWithIamport(paymentRequestDto.getImpUid(), paymentSnapshot);
+            return PaymentCompletionSnapshot.from(paymentSnapshot, reservationIntentSnapshot);
+        });
+    }
 
+    private PaymentResponseDto completePaymentAfterPgVerification(
+            PaymentRequestDto paymentRequestDto,
+            CustomUserDetails userDetails,
+            String expectedPublicTargetType,
+            ReservationPaymentIntent reservationIntentSnapshot,
+            IamportPaymentInfo paymentInfo
+    ) {
+        return writeTransactionTemplate().execute(status -> {
             Payment payment = paymentRepository.findByMerchantUidForUpdate(paymentRequestDto.getMerchantUid())
                     .orElseThrow(() -> new IllegalArgumentException("결제 정보가 없습니다: " + paymentRequestDto.getMerchantUid()));
             validateCompletionEligibility(payment, paymentRequestDto, userDetails, expectedPublicTargetType);
@@ -298,9 +323,17 @@ public class PaymentService {
                     ", targetId: " + updatedPayment.getTargetId());
 
             return PaymentResponseDto.fromEntity(updatedPayment);
-        } finally {
-            releaseImpUidLock(paymentRequestDto.getImpUid(), lockToken);
-        }
+        });
+    }
+
+    private TransactionTemplate readOnlyTransactionTemplate() {
+        TransactionTemplate template = new TransactionTemplate(transactionManager);
+        template.setReadOnly(true);
+        return template;
+    }
+
+    private TransactionTemplate writeTransactionTemplate() {
+        return new TransactionTemplate(transactionManager);
     }
 
     private void validateCompletionEligibility(
@@ -861,6 +894,18 @@ public class PaymentService {
         }
     }
 
+    private IamportPaymentInfo validatePaymentWithIamportSnapshot(String impUid, PaymentCompletionSnapshot payment) {
+        try {
+            System.out.println("아임포트 결제 검증 시작 - impUid: " + impUid + ", 예상금액: " + payment.amount());
+
+            IamportPaymentInfo paymentInfo = iamportPaymentVerifier.findPayment(impUid);
+            validatePaymentWithIamportSnapshotInfo(impUid, payment, paymentInfo);
+            return paymentInfo;
+        } catch (Exception e) {
+            throw new IllegalStateException("아임포트 결제 검증 실패: " + e.getMessage(), e);
+        }
+    }
+
     private void validatePaymentWithIamportInfo(String impUid, Payment payment, IamportPaymentInfo paymentInfo) {
         if (!Objects.equals(impUid, paymentInfo.impUid())) {
             throw new IllegalStateException("아임포트 결제 ID가 일치하지 않습니다.");
@@ -872,6 +917,25 @@ public class PaymentService {
             throw new IllegalStateException("아임포트에서 결제가 완료되지 않았습니다. 상태: " + paymentInfo.status());
         }
         if (paymentInfo.amount() == null || paymentInfo.amount().compareTo(payment.getAmount()) != 0) {
+            throw new IllegalStateException("아임포트 결제 금액이 일치하지 않습니다.");
+        }
+    }
+
+    private void validatePaymentWithIamportSnapshotInfo(
+            String impUid,
+            PaymentCompletionSnapshot payment,
+            IamportPaymentInfo paymentInfo
+    ) {
+        if (!Objects.equals(impUid, paymentInfo.impUid())) {
+            throw new IllegalStateException("아임포트 결제 ID가 일치하지 않습니다.");
+        }
+        if (!Objects.equals(payment.merchantUid(), paymentInfo.merchantUid())) {
+            throw new IllegalStateException("아임포트 주문번호가 일치하지 않습니다.");
+        }
+        if (!"paid".equals(paymentInfo.status())) {
+            throw new IllegalStateException("아임포트에서 결제가 완료되지 않았습니다. 상태: " + paymentInfo.status());
+        }
+        if (paymentInfo.amount() == null || paymentInfo.amount().compareTo(payment.amount()) != 0) {
             throw new IllegalStateException("아임포트 결제 금액이 일치하지 않습니다.");
         }
     }
@@ -1138,6 +1202,16 @@ public class PaymentService {
                 reservationId != null ? reservationId.toString() : "처리중",
                 payment.getMerchantUid()
         );
+    }
+
+    private record PaymentCompletionSnapshot(
+            String merchantUid,
+            BigDecimal amount,
+            ReservationPaymentIntent reservationIntent
+    ) {
+        private static PaymentCompletionSnapshot from(Payment payment, ReservationPaymentIntent reservationIntent) {
+            return new PaymentCompletionSnapshot(payment.getMerchantUid(), payment.getAmount(), reservationIntent);
+        }
     }
 
     // 이메일에서 부스 결제 요청 처리 (인증 없이)

--- a/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
+++ b/src/main/java/com/fairing/fairplay/payment/service/PaymentService.java
@@ -192,28 +192,48 @@ public class PaymentService {
     // 티켓 결제 완료 처리 (PG사 결제 후 호출)
     @Transactional
     public PaymentResponseDto completePayment(PaymentRequestDto paymentRequestDto) {
-        return completePayment(paymentRequestDto, null);
+        return completePaymentInternal(paymentRequestDto, null, null);
     }
 
     // 티켓 결제 완료 처리 (PG사 결제 후 호출)
     @Transactional
     public PaymentResponseDto completePayment(PaymentRequestDto paymentRequestDto, CustomUserDetails userDetails) {
+        return completePaymentInternal(paymentRequestDto, userDetails, null);
+    }
+
+    @Transactional
+    public PaymentResponseDto completePublicPayment(PaymentRequestDto paymentRequestDto, String expectedTargetType) {
+        if (!"BOOTH_APPLICATION".equals(expectedTargetType) && !"BANNER_APPLICATION".equals(expectedTargetType)) {
+            throw new IllegalArgumentException("공개 결제 완료는 부스 또는 배너 신청에만 사용 가능합니다.");
+        }
+        return completePaymentInternal(paymentRequestDto, null, expectedTargetType);
+    }
+
+    private PaymentResponseDto completePaymentInternal(
+            PaymentRequestDto paymentRequestDto,
+            CustomUserDetails userDetails,
+            String expectedPublicTargetType
+    ) {
         if (paymentRequestDto == null) {
             throw new IllegalArgumentException("결제 요청 데이터가 없습니다.");
         }
-        if (userDetails == null) {
+        if (userDetails == null && expectedPublicTargetType == null) {
             throw new AccessDeniedException("인증되지 않은 사용자입니다.");
         }
         if (paymentRequestDto.getImpUid() == null || paymentRequestDto.getImpUid().isBlank()) {
             throw new IllegalArgumentException("impUid는 필수입니다.");
         }
 
-        Payment payment = paymentRepository.findByMerchantUid(paymentRequestDto.getMerchantUid())
+        Payment payment = paymentRepository.findByMerchantUidForUpdate(paymentRequestDto.getMerchantUid())
                 .orElseThrow(() -> new IllegalArgumentException("결제 정보가 없습니다: " + paymentRequestDto.getMerchantUid()));
 
-        Long paymentUserId = payment.getUser() != null ? payment.getUser().getUserId() : null;
-        if (!Objects.equals(paymentUserId, userDetails.getUserId())) {
-            throw new AccessDeniedException("본인 결제만 완료할 수 있습니다.");
+        if (expectedPublicTargetType == null) {
+            Long paymentUserId = payment.getUser() != null ? payment.getUser().getUserId() : null;
+            if (!Objects.equals(paymentUserId, userDetails.getUserId())) {
+                throw new AccessDeniedException("본인 결제만 완료할 수 있습니다.");
+            }
+        } else {
+            validatePublicCompletionTargetType(payment, expectedPublicTargetType);
         }
 
         String currentStatus = payment.getPaymentStatusCode() != null ? payment.getPaymentStatusCode().getCode() : null;
@@ -250,6 +270,15 @@ public class PaymentService {
                 ", targetId: " + updatedPayment.getTargetId());
         
         return PaymentResponseDto.fromEntity(updatedPayment);
+    }
+
+    private void validatePublicCompletionTargetType(Payment payment, String expectedTargetType) {
+        String actualTargetType = payment.getPaymentTargetType() != null
+                ? payment.getPaymentTargetType().getPaymentTargetCode()
+                : null;
+        if (!Objects.equals(actualTargetType, expectedTargetType)) {
+            throw new AccessDeniedException("허용되지 않은 공개 결제 완료 대상입니다.");
+        }
     }
 
     // 티켓 결제 전체 조회 (전체 관리자, 행사 관리자)

--- a/src/main/java/com/fairing/fairplay/payment/service/ReservationPaymentIntent.java
+++ b/src/main/java/com/fairing/fairplay/payment/service/ReservationPaymentIntent.java
@@ -1,0 +1,15 @@
+package com.fairing.fairplay.payment.service;
+
+import java.math.BigDecimal;
+
+public record ReservationPaymentIntent(
+        Long eventId,
+        Long scheduleId,
+        Long ticketId,
+        Integer quantity,
+        BigDecimal amount,
+        String targetType,
+        Long userId,
+        String merchantUid
+) {
+}

--- a/src/main/java/com/fairing/fairplay/payment/service/ReservationPaymentIntentStore.java
+++ b/src/main/java/com/fairing/fairplay/payment/service/ReservationPaymentIntentStore.java
@@ -1,0 +1,51 @@
+package com.fairing.fairplay.payment.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationPaymentIntentStore {
+
+    private static final String KEY_PREFIX = "payment:intent:reservation:";
+    private static final Duration INTENT_TTL = Duration.ofMinutes(30);
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void save(ReservationPaymentIntent intent) {
+        try {
+            redisTemplate.opsForValue().set(key(intent.merchantUid(), intent.userId()),
+                    objectMapper.writeValueAsString(intent),
+                    INTENT_TTL);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("예약 결제 intent 저장에 실패했습니다.", e);
+        }
+    }
+
+    public Optional<ReservationPaymentIntent> find(String merchantUid, Long userId) {
+        String raw = redisTemplate.opsForValue().get(key(merchantUid, userId));
+        if (raw == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(objectMapper.readValue(raw, ReservationPaymentIntent.class));
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("예약 결제 intent를 읽을 수 없습니다.", e);
+        }
+    }
+
+    public void delete(String merchantUid, Long userId) {
+        redisTemplate.delete(key(merchantUid, userId));
+    }
+
+    private String key(String merchantUid, Long userId) {
+        return KEY_PREFIX + merchantUid + ":" + userId;
+    }
+}

--- a/src/test/java/com/fairing/fairplay/core/config/SecurityConfigPublicSurfaceTest.java
+++ b/src/test/java/com/fairing/fairplay/core/config/SecurityConfigPublicSurfaceTest.java
@@ -74,6 +74,15 @@ class SecurityConfigPublicSurfaceTest {
     }
 
     @Test
+    void bannerPaymentCompleteRemainsPublicWithoutSession() throws Exception {
+        mockMvc.perform(post("/api/banners/payment/complete")
+                        .contentType("application/json")
+                        .content("{}"))
+                .andExpect(result -> assertThat(result.getResponse().getStatus())
+                        .isNotIn(401, 403));
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     void sessionFilterDoesNotClassifyUploadApiAsPublicPath() {
         List<String> publicPaths = (List<String>) ReflectionTestUtils.getField(

--- a/src/test/java/com/fairing/fairplay/core/config/SecurityConfigPublicSurfaceTest.java
+++ b/src/test/java/com/fairing/fairplay/core/config/SecurityConfigPublicSurfaceTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = FileUploadController.class)
@@ -62,6 +63,14 @@ class SecurityConfigPublicSurfaceTest {
                 .andExpect(status().isUnauthorized());
 
         verifyNoInteractions(localFileService);
+    }
+
+    @Test
+    void paymentCompleteRequiresAuthenticationWithoutSession() throws Exception {
+        mockMvc.perform(post("/api/payments/complete")
+                        .contentType("application/json")
+                        .content("{}"))
+                .andExpect(status().isUnauthorized());
     }
 
     @Test

--- a/src/test/java/com/fairing/fairplay/payment/service/DefaultIamportPaymentVerifierTest.java
+++ b/src/test/java/com/fairing/fairplay/payment/service/DefaultIamportPaymentVerifierTest.java
@@ -1,0 +1,65 @@
+package com.fairing.fairplay.payment.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class DefaultIamportPaymentVerifierTest {
+
+    @Test
+    void iamportRestTemplateHasConnectAndReadTimeouts() {
+        RestTemplate restTemplate = DefaultIamportPaymentVerifier.createIamportRestTemplate();
+
+        assertThat(restTemplate.getRequestFactory()).isInstanceOf(SimpleClientHttpRequestFactory.class);
+        SimpleClientHttpRequestFactory requestFactory =
+                (SimpleClientHttpRequestFactory) restTemplate.getRequestFactory();
+
+        assertThat(ReflectionTestUtils.getField(requestFactory, "connectTimeout"))
+                .isEqualTo((int) DefaultIamportPaymentVerifier.IAMPORT_CONNECT_TIMEOUT.toMillis());
+        assertThat(ReflectionTestUtils.getField(requestFactory, "readTimeout"))
+                .isEqualTo((int) DefaultIamportPaymentVerifier.IAMPORT_READ_TIMEOUT.toMillis());
+    }
+
+    @Test
+    void findPaymentUsesTokenThenPaymentLookupAndParsesResponse() {
+        RestTemplate restTemplate = DefaultIamportPaymentVerifier.createIamportRestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(restTemplate).build();
+        DefaultIamportPaymentVerifier verifier = new DefaultIamportPaymentVerifier(restTemplate, new ObjectMapper());
+        ReflectionTestUtils.setField(verifier, "iamportApiKey", "api-key");
+        ReflectionTestUtils.setField(verifier, "iamportSecretKey", "secret-key");
+        ReflectionTestUtils.setField(verifier, "iamportBaseUrl", "https://api.iamport.kr");
+
+        server.expect(requestTo("https://api.iamport.kr/users/getToken"))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess("""
+                        {"code":0,"response":{"access_token":"access-token"}}
+                        """, MediaType.APPLICATION_JSON));
+        server.expect(requestTo("https://api.iamport.kr/payments/imp-valid"))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header("Authorization", "Bearer access-token"))
+                .andRespond(withSuccess("""
+                        {"code":0,"response":{"imp_uid":"imp-valid","merchant_uid":"merchant-1","status":"paid","amount":12000}}
+                        """, MediaType.APPLICATION_JSON));
+
+        IamportPaymentInfo paymentInfo = verifier.findPayment("imp-valid");
+
+        assertThat(paymentInfo.impUid()).isEqualTo("imp-valid");
+        assertThat(paymentInfo.merchantUid()).isEqualTo("merchant-1");
+        assertThat(paymentInfo.status()).isEqualTo("paid");
+        assertThat(paymentInfo.amount()).isEqualByComparingTo(BigDecimal.valueOf(12000));
+        server.verify();
+    }
+}

--- a/src/test/java/com/fairing/fairplay/payment/service/DefaultIamportPaymentVerifierTest.java
+++ b/src/test/java/com/fairing/fairplay/payment/service/DefaultIamportPaymentVerifierTest.java
@@ -62,4 +62,30 @@ class DefaultIamportPaymentVerifierTest {
         assertThat(paymentInfo.amount()).isEqualByComparingTo(BigDecimal.valueOf(12000));
         server.verify();
     }
+
+    @Test
+    void findPaymentParsesLargeJsonNumberWithoutDoubleConversion() {
+        RestTemplate restTemplate = DefaultIamportPaymentVerifier.createIamportRestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(restTemplate).build();
+        DefaultIamportPaymentVerifier verifier = new DefaultIamportPaymentVerifier(restTemplate, new ObjectMapper());
+        ReflectionTestUtils.setField(verifier, "iamportApiKey", "api-key");
+        ReflectionTestUtils.setField(verifier, "iamportSecretKey", "secret-key");
+        ReflectionTestUtils.setField(verifier, "iamportBaseUrl", "https://api.iamport.kr");
+
+        server.expect(requestTo("https://api.iamport.kr/users/getToken"))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess("""
+                        {"code":0,"response":{"access_token":"access-token"}}
+                        """, MediaType.APPLICATION_JSON));
+        server.expect(requestTo("https://api.iamport.kr/payments/imp-valid"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("""
+                        {"code":0,"response":{"imp_uid":"imp-valid","merchant_uid":"merchant-1","status":"paid","amount":9007199254740993}}
+                        """, MediaType.APPLICATION_JSON));
+
+        IamportPaymentInfo paymentInfo = verifier.findPayment("imp-valid");
+
+        assertThat(paymentInfo.amount()).isEqualByComparingTo(new BigDecimal("9007199254740993"));
+        server.verify();
+    }
 }

--- a/src/test/java/com/fairing/fairplay/payment/service/PaymentServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/payment/service/PaymentServiceAuthorizationTest.java
@@ -26,6 +26,10 @@ import com.fairing.fairplay.reservation.entity.Reservation;
 import com.fairing.fairplay.reservation.repository.ReservationRepository;
 import com.fairing.fairplay.reservation.repository.ReservationStatusCodeRepository;
 import com.fairing.fairplay.reservation.service.ReservationService;
+import com.fairing.fairplay.ticket.entity.EventSchedule;
+import com.fairing.fairplay.ticket.entity.ScheduleTicket;
+import com.fairing.fairplay.ticket.entity.ScheduleTicketId;
+import com.fairing.fairplay.ticket.entity.Ticket;
 import com.fairing.fairplay.ticket.repository.EventScheduleRepository;
 import com.fairing.fairplay.ticket.repository.ScheduleTicketRepository;
 import com.fairing.fairplay.ticket.repository.TicketRepository;
@@ -95,6 +99,8 @@ class PaymentServiceAuthorizationTest {
     private BannerApplicationRepository bannerApplicationRepository;
     @Mock
     private AttendeeFormAttendeeService attendeeFormAttendeeService;
+    @Mock
+    private IamportPaymentVerifier iamportPaymentVerifier;
 
     private PaymentService paymentService;
 
@@ -119,7 +125,8 @@ class PaymentServiceAuthorizationTest {
                 boothApplicationRepository,
                 boothRepository,
                 bannerApplicationRepository,
-                attendeeFormAttendeeService
+                attendeeFormAttendeeService,
+                iamportPaymentVerifier
         );
     }
 
@@ -411,6 +418,207 @@ class PaymentServiceAuthorizationTest {
         verify(paymentRepository, never()).findByEvent_EventId(any());
     }
 
+    @Test
+    void completePaymentRejectsNullPrincipal() {
+        assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), null))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(paymentRepository, never()).findByMerchantUid(any());
+    }
+
+    @Test
+    void completePaymentRejectsOtherUsersPayment() {
+        Payment payment = pendingPayment("merchant-complete", 301L, 10L, event(1L, 100L));
+        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+
+        assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), user(300L, "COMMON")))
+                .isInstanceOf(AccessDeniedException.class);
+
+        verify(iamportPaymentVerifier, never()).findPayment(any());
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void completePaymentRejectsNonPendingPayment() {
+        Payment payment = pendingPayment("merchant-complete", 300L, 10L, event(1L, 100L));
+        payment.setPaymentStatusCode(paymentStatusCode("CANCELED"));
+        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+
+        assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), user(300L, "COMMON")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("대기 상태");
+
+        verify(iamportPaymentVerifier, never()).findPayment(any());
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void completePaymentRejectsMissingImpUid() {
+        PaymentRequestDto request = completeRequest();
+        request.setImpUid(" ");
+
+        assertThatThrownBy(() -> paymentService.completePayment(request, user(300L, "COMMON")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("impUid");
+
+        verify(paymentRepository, never()).findByMerchantUid(any());
+    }
+
+    @Test
+    void completePaymentRejectsDuplicateCompletedImpUidForAnotherPayment() {
+        Payment payment = pendingPayment("merchant-complete", 300L, 10L, event(1L, 100L));
+        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        when(paymentRepository.existsByImpUidAndPaymentStatusCode_CodeAndMerchantUidNot(
+                "imp-valid", "COMPLETED", "merchant-complete")).thenReturn(true);
+
+        assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), user(300L, "COMMON")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("이미 사용");
+
+        verify(iamportPaymentVerifier, never()).findPayment(any());
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void completePaymentRejectsPgMerchantMismatch() {
+        Payment payment = pendingPayment("merchant-complete", 300L, 10L, event(1L, 100L));
+        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        when(iamportPaymentVerifier.findPayment("imp-valid"))
+                .thenReturn(new IamportPaymentInfo("imp-valid", "merchant-other", "paid", BigDecimal.valueOf(100)));
+
+        assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), user(300L, "COMMON")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("아임포트");
+
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void completePaymentRejectsPgAmountMismatch() {
+        Payment payment = pendingPayment("merchant-complete", 300L, 10L, event(1L, 100L));
+        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        when(iamportPaymentVerifier.findPayment("imp-valid"))
+                .thenReturn(new IamportPaymentInfo("imp-valid", "merchant-complete", "paid", BigDecimal.valueOf(101)));
+
+        assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), user(300L, "COMMON")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("아임포트");
+
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void completePaymentRejectsPgStatusNotPaid() {
+        Payment payment = pendingPayment("merchant-complete", 300L, 10L, event(1L, 100L));
+        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        when(iamportPaymentVerifier.findPayment("imp-valid"))
+                .thenReturn(new IamportPaymentInfo("imp-valid", "merchant-complete", "ready", BigDecimal.valueOf(100)));
+
+        assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), user(300L, "COMMON")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("아임포트");
+
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void completePaymentRejectsTicketPricePaymentAmountMismatch() {
+        Event event = event(1L, 100L);
+        Payment payment = pendingPayment("merchant-complete", 300L, 10L, event);
+        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        stubValidIamport();
+        stubReservationRelation(event, 1L, 10L, 50);
+
+        assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), user(300L, "COMMON")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("금액");
+
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void completePaymentRejectsScheduleOutsidePaymentEvent() {
+        Event paymentEvent = event(1L, 100L);
+        Event otherEvent = event(2L, 100L);
+        Payment payment = pendingPayment("merchant-complete", 300L, 10L, paymentEvent);
+        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        stubValidIamport();
+        when(eventScheduleRepository.findById(1L)).thenReturn(Optional.of(schedule(1L, otherEvent)));
+
+        assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), user(300L, "COMMON")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("스케줄");
+
+        verify(scheduleTicketRepository, never()).findById(any());
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void completePaymentRejectsMissingScheduleOrTicketForReservation() {
+        Payment payment = pendingPayment("merchant-complete", 300L, 10L, event(1L, 100L));
+        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        stubValidIamport();
+        PaymentRequestDto request = completeRequest();
+        request.setScheduleId(null);
+
+        assertThatThrownBy(() -> paymentService.completePayment(request, user(300L, "COMMON")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("scheduleId");
+
+        verify(eventScheduleRepository, never()).findById(any());
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void completePaymentRejectsMissingScheduleTicketRelation() {
+        Event event = event(1L, 100L);
+        Payment payment = pendingPayment("merchant-complete", 300L, 10L, event);
+        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        stubValidIamport();
+        when(eventScheduleRepository.findById(1L)).thenReturn(Optional.of(schedule(1L, event)));
+        when(scheduleTicketRepository.findById(new ScheduleTicketId(10L, 1L))).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), user(300L, "COMMON")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("스케줄");
+
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void completePaymentPropagatesReservationCompletionException() {
+        Event event = event(1L, 100L);
+        Payment payment = pendingPayment("merchant-complete", 300L, null, event);
+        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        when(paymentStatusCodeRepository.findByCode("COMPLETED")).thenReturn(Optional.of(paymentStatusCode("COMPLETED")));
+        when(paymentRepository.save(any(Payment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        stubValidIamport();
+        stubReservationRelation(event, 1L, 10L, 100);
+        when(reservationService.createReservation(any(), any(), any()))
+                .thenThrow(new IllegalStateException("stock failed"));
+
+        assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), user(300L, "COMMON")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("예매 생성에 실패");
+    }
+
+    @Test
+    void completePaymentAllowsValidReservationCompletion() {
+        Event event = event(1L, 100L);
+        Payment payment = pendingPayment("merchant-complete", 300L, 10L, event);
+        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
+        when(paymentStatusCodeRepository.findByCode("COMPLETED")).thenReturn(Optional.of(paymentStatusCode("COMPLETED")));
+        when(paymentRepository.save(any(Payment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        stubValidIamport();
+        stubReservationRelation(event, 1L, 10L, 100);
+
+        paymentService.completePayment(completeRequest(), user(300L, "COMMON"));
+
+        assertThat(payment.getPaymentStatusCode().getCode()).isEqualTo("COMPLETED");
+        assertThat(payment.getImpUid()).isEqualTo("imp-valid");
+    }
+
     private Payment payment(String merchantUid, Long userId, Long targetId, Event event) {
         return payment(merchantUid, userId, targetId, "RESERVATION", event);
     }
@@ -439,6 +647,52 @@ class PaymentServiceAuthorizationTest {
                         .code("COMPLETED")
                         .name("완료")
                         .build())
+                .build();
+    }
+
+    private Payment pendingPayment(String merchantUid, Long userId, Long targetId, Event event) {
+        Payment payment = payment(merchantUid, userId, targetId, "RESERVATION", event);
+        payment.setPaymentStatusCode(paymentStatusCode("PENDING"));
+        return payment;
+    }
+
+    private PaymentRequestDto completeRequest() {
+        return PaymentRequestDto.builder()
+                .merchantUid("merchant-complete")
+                .impUid("imp-valid")
+                .scheduleId(1L)
+                .ticketId(10L)
+                .build();
+    }
+
+    private void stubValidIamport() {
+        when(iamportPaymentVerifier.findPayment("imp-valid"))
+                .thenReturn(new IamportPaymentInfo("imp-valid", "merchant-complete", "paid", BigDecimal.valueOf(100)));
+    }
+
+    private void stubReservationRelation(Event event, Long scheduleId, Long ticketId, Integer ticketPrice) {
+        EventSchedule schedule = schedule(scheduleId, event);
+        Ticket ticket = Ticket.builder()
+                .ticketId(ticketId)
+                .name("ticket")
+                .price(ticketPrice)
+                .build();
+        ScheduleTicket scheduleTicket = ScheduleTicket.builder()
+                .id(new ScheduleTicketId(ticketId, scheduleId))
+                .eventSchedule(schedule)
+                .ticket(ticket)
+                .build();
+
+        when(eventScheduleRepository.findById(scheduleId)).thenReturn(Optional.of(schedule));
+        when(scheduleTicketRepository.findById(new ScheduleTicketId(ticketId, scheduleId)))
+                .thenReturn(Optional.of(scheduleTicket));
+        lenient().when(ticketRepository.findById(ticketId)).thenReturn(Optional.of(ticket));
+    }
+
+    private EventSchedule schedule(Long scheduleId, Event event) {
+        return EventSchedule.builder()
+                .scheduleId(scheduleId)
+                .event(event)
                 .build();
     }
 

--- a/src/test/java/com/fairing/fairplay/payment/service/PaymentServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/payment/service/PaymentServiceAuthorizationTest.java
@@ -43,9 +43,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.security.access.AccessDeniedException;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
@@ -53,11 +57,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doReturn;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentServiceAuthorizationTest {
@@ -104,11 +111,20 @@ class PaymentServiceAuthorizationTest {
     private IamportPaymentVerifier iamportPaymentVerifier;
     @Mock
     private ReservationPaymentIntentStore reservationPaymentIntentStore;
+    @Mock
+    private StringRedisTemplate redisTemplate;
+    @Mock
+    private ValueOperations<String, String> valueOperations;
 
     private PaymentService paymentService;
 
     @BeforeEach
     void setUp() {
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        lenient().when(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).thenReturn(true);
+        lenient().when(redisTemplate.execute(any(RedisScript.class), anyList(), anyString())).thenReturn(1L);
+        lenient().when(paymentRepository.findByMerchantUid(anyString()))
+                .thenAnswer(invocation -> paymentRepository.findByMerchantUidForUpdate(invocation.getArgument(0)));
         paymentService = new PaymentService(
                 paymentRepository,
                 refundRepository,
@@ -130,7 +146,8 @@ class PaymentServiceAuthorizationTest {
                 bannerApplicationRepository,
                 attendeeFormAttendeeService,
                 iamportPaymentVerifier,
-                reservationPaymentIntentStore
+                reservationPaymentIntentStore,
+                redisTemplate
         );
     }
 
@@ -614,6 +631,39 @@ class PaymentServiceAuthorizationTest {
     }
 
     @Test
+    void completePaymentRejectsConcurrentSameImpUidBeforePgLookup() {
+        when(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).thenReturn(false);
+
+        assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), user(300L, "COMMON")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("처리 중");
+
+        verify(paymentRepository, never()).findByMerchantUid(any());
+        verify(iamportPaymentVerifier, never()).findPayment(any());
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void completePaymentRevalidatesLockedStatusAfterPgLookup() {
+        Event event = event(1L, 100L);
+        Payment snapshot = pendingPayment("merchant-complete", 300L, 10L, event);
+        Payment locked = pendingPayment("merchant-complete", 300L, 10L, event);
+        locked.setPaymentStatusCode(paymentStatusCode("COMPLETED"));
+        doReturn(Optional.of(snapshot)).when(paymentRepository).findByMerchantUid("merchant-complete");
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(locked));
+        stubValidReservationIntent(event, 1L, 10L);
+        stubReservationRelation(event, 1L, 10L, 100);
+        stubValidIamport();
+
+        assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), user(300L, "COMMON")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("대기 상태");
+
+        verify(iamportPaymentVerifier).findPayment("imp-valid");
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
     void completePaymentRejectsPgMerchantMismatch() {
         Payment payment = pendingPayment("merchant-complete", 300L, 10L, event(1L, 100L));
         when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
@@ -864,6 +914,37 @@ class PaymentServiceAuthorizationTest {
     }
 
     @Test
+    void completePaymentRejectsNonExactReservationUnitPrice() {
+        Event event = event(1L, 100L);
+        Payment payment = pendingPayment("merchant-complete", 300L, 10L, event);
+        payment.setQuantity(3);
+        payment.setAmount(BigDecimal.valueOf(100));
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
+        when(reservationPaymentIntentStore.find("merchant-complete", 300L))
+                .thenReturn(Optional.of(new ReservationPaymentIntent(
+                        event.getEventId(),
+                        1L,
+                        10L,
+                        3,
+                        BigDecimal.valueOf(100),
+                        "RESERVATION",
+                        300L,
+                        "merchant-complete")));
+
+        PaymentRequestDto request = completeRequest();
+        request.setQuantity(3);
+        request.setAmount(BigDecimal.valueOf(100));
+        request.setPrice(new BigDecimal("33.33"));
+
+        assertThatThrownBy(() -> paymentService.completePayment(request, user(300L, "COMMON")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("정확히 나누어");
+
+        verify(iamportPaymentVerifier, never()).findPayment(any());
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
     void completePaymentPropagatesReservationCompletionException() {
         Event event = event(1L, 100L);
         Payment payment = pendingPayment("merchant-complete", 300L, null, event);
@@ -949,12 +1030,8 @@ class PaymentServiceAuthorizationTest {
     void completePaymentUsesLockedLookupSoSecondConfirmDoesNotRunCompletionAgain() {
         Event event = event(1L, 100L);
         Payment payment = pendingPayment("merchant-complete", 300L, 10L, event);
-        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete"))
-                .thenReturn(Optional.of(payment))
-                .thenAnswer(invocation -> {
-                    payment.setPaymentStatusCode(paymentStatusCode("COMPLETED"));
-                    return Optional.of(payment);
-                });
+        doReturn(Optional.of(payment)).when(paymentRepository).findByMerchantUid("merchant-complete");
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
         when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
         when(paymentStatusCodeRepository.findByCode("COMPLETED")).thenReturn(Optional.of(paymentStatusCode("COMPLETED")));
         when(paymentRepository.save(any(Payment.class))).thenAnswer(invocation -> invocation.getArgument(0));
@@ -968,7 +1045,7 @@ class PaymentServiceAuthorizationTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("대기 상태");
 
-        verify(paymentRepository, org.mockito.Mockito.times(2)).findByMerchantUidForUpdate("merchant-complete");
+        verify(paymentRepository, org.mockito.Mockito.atLeastOnce()).findByMerchantUidForUpdate("merchant-complete");
         verify(paymentRepository, org.mockito.Mockito.times(1)).save(any(Payment.class));
         verify(iamportPaymentVerifier, org.mockito.Mockito.times(1)).findPayment("imp-valid");
     }

--- a/src/test/java/com/fairing/fairplay/payment/service/PaymentServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/payment/service/PaymentServiceAuthorizationTest.java
@@ -423,13 +423,13 @@ class PaymentServiceAuthorizationTest {
         assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), null))
                 .isInstanceOf(AccessDeniedException.class);
 
-        verify(paymentRepository, never()).findByMerchantUid(any());
+        verify(paymentRepository, never()).findByMerchantUidForUpdate(any());
     }
 
     @Test
     void completePaymentRejectsOtherUsersPayment() {
         Payment payment = pendingPayment("merchant-complete", 301L, 10L, event(1L, 100L));
-        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
 
         assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), user(300L, "COMMON")))
                 .isInstanceOf(AccessDeniedException.class);
@@ -442,7 +442,7 @@ class PaymentServiceAuthorizationTest {
     void completePaymentRejectsNonPendingPayment() {
         Payment payment = pendingPayment("merchant-complete", 300L, 10L, event(1L, 100L));
         payment.setPaymentStatusCode(paymentStatusCode("CANCELED"));
-        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
 
         assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), user(300L, "COMMON")))
                 .isInstanceOf(IllegalStateException.class)
@@ -461,13 +461,13 @@ class PaymentServiceAuthorizationTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("impUid");
 
-        verify(paymentRepository, never()).findByMerchantUid(any());
+        verify(paymentRepository, never()).findByMerchantUidForUpdate(any());
     }
 
     @Test
     void completePaymentRejectsDuplicateCompletedImpUidForAnotherPayment() {
         Payment payment = pendingPayment("merchant-complete", 300L, 10L, event(1L, 100L));
-        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
         when(paymentRepository.existsByImpUidAndPaymentStatusCode_CodeAndMerchantUidNot(
                 "imp-valid", "COMPLETED", "merchant-complete")).thenReturn(true);
 
@@ -482,7 +482,7 @@ class PaymentServiceAuthorizationTest {
     @Test
     void completePaymentRejectsPgMerchantMismatch() {
         Payment payment = pendingPayment("merchant-complete", 300L, 10L, event(1L, 100L));
-        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
         when(iamportPaymentVerifier.findPayment("imp-valid"))
                 .thenReturn(new IamportPaymentInfo("imp-valid", "merchant-other", "paid", BigDecimal.valueOf(100)));
 
@@ -496,7 +496,7 @@ class PaymentServiceAuthorizationTest {
     @Test
     void completePaymentRejectsPgAmountMismatch() {
         Payment payment = pendingPayment("merchant-complete", 300L, 10L, event(1L, 100L));
-        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
         when(iamportPaymentVerifier.findPayment("imp-valid"))
                 .thenReturn(new IamportPaymentInfo("imp-valid", "merchant-complete", "paid", BigDecimal.valueOf(101)));
 
@@ -510,7 +510,7 @@ class PaymentServiceAuthorizationTest {
     @Test
     void completePaymentRejectsPgStatusNotPaid() {
         Payment payment = pendingPayment("merchant-complete", 300L, 10L, event(1L, 100L));
-        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
         when(iamportPaymentVerifier.findPayment("imp-valid"))
                 .thenReturn(new IamportPaymentInfo("imp-valid", "merchant-complete", "ready", BigDecimal.valueOf(100)));
 
@@ -525,7 +525,7 @@ class PaymentServiceAuthorizationTest {
     void completePaymentRejectsTicketPricePaymentAmountMismatch() {
         Event event = event(1L, 100L);
         Payment payment = pendingPayment("merchant-complete", 300L, 10L, event);
-        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
         stubValidIamport();
         stubReservationRelation(event, 1L, 10L, 50);
 
@@ -541,7 +541,7 @@ class PaymentServiceAuthorizationTest {
         Event paymentEvent = event(1L, 100L);
         Event otherEvent = event(2L, 100L);
         Payment payment = pendingPayment("merchant-complete", 300L, 10L, paymentEvent);
-        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
         stubValidIamport();
         when(eventScheduleRepository.findById(1L)).thenReturn(Optional.of(schedule(1L, otherEvent)));
 
@@ -556,7 +556,7 @@ class PaymentServiceAuthorizationTest {
     @Test
     void completePaymentRejectsMissingScheduleOrTicketForReservation() {
         Payment payment = pendingPayment("merchant-complete", 300L, 10L, event(1L, 100L));
-        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
         stubValidIamport();
         PaymentRequestDto request = completeRequest();
         request.setScheduleId(null);
@@ -573,7 +573,7 @@ class PaymentServiceAuthorizationTest {
     void completePaymentRejectsMissingScheduleTicketRelation() {
         Event event = event(1L, 100L);
         Payment payment = pendingPayment("merchant-complete", 300L, 10L, event);
-        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
         stubValidIamport();
         when(eventScheduleRepository.findById(1L)).thenReturn(Optional.of(schedule(1L, event)));
         when(scheduleTicketRepository.findById(new ScheduleTicketId(10L, 1L))).thenReturn(Optional.empty());
@@ -589,7 +589,7 @@ class PaymentServiceAuthorizationTest {
     void completePaymentPropagatesReservationCompletionException() {
         Event event = event(1L, 100L);
         Payment payment = pendingPayment("merchant-complete", 300L, null, event);
-        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
         when(paymentStatusCodeRepository.findByCode("COMPLETED")).thenReturn(Optional.of(paymentStatusCode("COMPLETED")));
         when(paymentRepository.save(any(Payment.class))).thenAnswer(invocation -> invocation.getArgument(0));
         stubValidIamport();
@@ -606,7 +606,7 @@ class PaymentServiceAuthorizationTest {
     void completePaymentAllowsValidReservationCompletion() {
         Event event = event(1L, 100L);
         Payment payment = pendingPayment("merchant-complete", 300L, 10L, event);
-        when(paymentRepository.findByMerchantUid("merchant-complete")).thenReturn(Optional.of(payment));
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
         when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
         when(paymentStatusCodeRepository.findByCode("COMPLETED")).thenReturn(Optional.of(paymentStatusCode("COMPLETED")));
         when(paymentRepository.save(any(Payment.class))).thenAnswer(invocation -> invocation.getArgument(0));
@@ -617,6 +617,62 @@ class PaymentServiceAuthorizationTest {
 
         assertThat(payment.getPaymentStatusCode().getCode()).isEqualTo("COMPLETED");
         assertThat(payment.getImpUid()).isEqualTo("imp-valid");
+    }
+
+    @Test
+    void completePublicPaymentAllowsBoothApplicationWithoutPrincipal() {
+        Payment payment = pendingPayment("merchant-public", 300L, 10L, "BOOTH_APPLICATION", null);
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-public")).thenReturn(Optional.of(payment));
+        when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
+        when(paymentStatusCodeRepository.findByCode("COMPLETED")).thenReturn(Optional.of(paymentStatusCode("COMPLETED")));
+        when(paymentRepository.save(any(Payment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(iamportPaymentVerifier.findPayment("imp-public"))
+                .thenReturn(new IamportPaymentInfo("imp-public", "merchant-public", "paid", BigDecimal.valueOf(100)));
+
+        paymentService.completePublicPayment(publicCompleteRequest(), "BOOTH_APPLICATION");
+
+        assertThat(payment.getPaymentStatusCode().getCode()).isEqualTo("COMPLETED");
+        assertThat(payment.getImpUid()).isEqualTo("imp-public");
+    }
+
+    @Test
+    void completePublicPaymentRejectsWrongTargetType() {
+        Payment payment = pendingPayment("merchant-public", 300L, 10L, "RESERVATION", event(1L, 100L));
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-public")).thenReturn(Optional.of(payment));
+
+        assertThatThrownBy(() -> paymentService.completePublicPayment(publicCompleteRequest(), "BOOTH_APPLICATION"))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("공개 결제 완료 대상");
+
+        verify(iamportPaymentVerifier, never()).findPayment(any());
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void completePaymentUsesLockedLookupSoSecondConfirmDoesNotRunCompletionAgain() {
+        Event event = event(1L, 100L);
+        Payment payment = pendingPayment("merchant-complete", 300L, 10L, event);
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete"))
+                .thenReturn(Optional.of(payment))
+                .thenAnswer(invocation -> {
+                    payment.setPaymentStatusCode(paymentStatusCode("COMPLETED"));
+                    return Optional.of(payment);
+                });
+        when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
+        when(paymentStatusCodeRepository.findByCode("COMPLETED")).thenReturn(Optional.of(paymentStatusCode("COMPLETED")));
+        when(paymentRepository.save(any(Payment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        stubValidIamport();
+        stubReservationRelation(event, 1L, 10L, 100);
+
+        paymentService.completePayment(completeRequest(), user(300L, "COMMON"));
+
+        assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), user(300L, "COMMON")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("대기 상태");
+
+        verify(paymentRepository, org.mockito.Mockito.times(2)).findByMerchantUidForUpdate("merchant-complete");
+        verify(paymentRepository, org.mockito.Mockito.times(1)).save(any(Payment.class));
+        verify(iamportPaymentVerifier, org.mockito.Mockito.times(1)).findPayment("imp-valid");
     }
 
     private Payment payment(String merchantUid, Long userId, Long targetId, Event event) {
@@ -656,12 +712,25 @@ class PaymentServiceAuthorizationTest {
         return payment;
     }
 
+    private Payment pendingPayment(String merchantUid, Long userId, Long targetId, String targetCode, Event event) {
+        Payment payment = payment(merchantUid, userId, targetId, targetCode, event);
+        payment.setPaymentStatusCode(paymentStatusCode("PENDING"));
+        return payment;
+    }
+
     private PaymentRequestDto completeRequest() {
         return PaymentRequestDto.builder()
                 .merchantUid("merchant-complete")
                 .impUid("imp-valid")
                 .scheduleId(1L)
                 .ticketId(10L)
+                .build();
+    }
+
+    private PaymentRequestDto publicCompleteRequest() {
+        return PaymentRequestDto.builder()
+                .merchantUid("merchant-public")
+                .impUid("imp-public")
                 .build();
     }
 

--- a/src/test/java/com/fairing/fairplay/payment/service/PaymentServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/payment/service/PaymentServiceAuthorizationTest.java
@@ -1,5 +1,6 @@
 package com.fairing.fairplay.payment.service;
 
+import com.fairing.fairplay.attendeeform.dto.AttendeeFormSaveResponseDto;
 import com.fairing.fairplay.attendeeform.service.AttendeeFormAttendeeService;
 import com.fairing.fairplay.banner.entity.BannerApplication;
 import com.fairing.fairplay.banner.repository.BannerApplicationRepository;
@@ -367,6 +368,90 @@ class PaymentServiceAuthorizationTest {
     }
 
     @Test
+    void savePaymentRejectsReservationClientAmountMismatch() {
+        Event event = event(1L, 100L);
+        Users currentUser = userEntity(300L, "owner@example.com", "COMMON");
+        when(userRepository.findById(300L)).thenReturn(Optional.of(currentUser));
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
+        when(paymentTargetTypeRepository.findByPaymentTargetCode("RESERVATION"))
+                .thenReturn(Optional.of(targetType("RESERVATION")));
+        stubReservationRelation(event, 1L, 10L, 100);
+
+        PaymentRequestDto request = reservationCreateRequest();
+        request.setAmount(BigDecimal.valueOf(101));
+
+        assertThatThrownBy(() -> paymentService.savePayment(request, 300L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("총액");
+
+        verify(paymentRepository, never()).save(any());
+        verify(reservationPaymentIntentStore, never()).save(any());
+    }
+
+    @Test
+    void savePaymentRejectsReservationQuantityAboveMaxPurchase() {
+        Event event = event(1L, 100L);
+        Users currentUser = userEntity(300L, "owner@example.com", "COMMON");
+        when(userRepository.findById(300L)).thenReturn(Optional.of(currentUser));
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
+        when(paymentTargetTypeRepository.findByPaymentTargetCode("RESERVATION"))
+                .thenReturn(Optional.of(targetType("RESERVATION")));
+        stubReservationRelation(event, 1L, 10L, 100, 1);
+
+        PaymentRequestDto request = reservationCreateRequest();
+        request.setQuantity(2);
+        request.setAmount(BigDecimal.valueOf(200));
+
+        assertThatThrownBy(() -> paymentService.savePayment(request, 300L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("최대 구매 수량");
+
+        verify(paymentRepository, never()).save(any());
+        verify(reservationPaymentIntentStore, never()).save(any());
+    }
+
+    @Test
+    void processFreeTicketDeletesReservationIntentAfterSuccessfulCompletion() {
+        Event event = event(1L, 100L);
+        Users currentUser = userEntity(300L, "owner@example.com", "COMMON");
+        when(userRepository.findById(300L)).thenReturn(Optional.of(currentUser));
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
+        when(paymentTargetTypeRepository.findByPaymentTargetCode("RESERVATION"))
+                .thenReturn(Optional.of(targetType("RESERVATION")));
+        when(paymentTypeCodeRepository.getReferenceByCode("CARD")).thenReturn(paymentTypeCode());
+        when(paymentStatusCodeRepository.getReferenceByCode("PENDING")).thenReturn(paymentStatusCode("PENDING"));
+        when(paymentStatusCodeRepository.findByCode("COMPLETED")).thenReturn(Optional.of(paymentStatusCode("COMPLETED")));
+        stubReservationRelation(event, 1L, 10L, 0);
+        Payment[] savedPayment = new Payment[1];
+        when(paymentRepository.save(any(Payment.class))).thenAnswer(invocation -> {
+            Payment payment = invocation.getArgument(0);
+            payment.setPaymentId(1L);
+            savedPayment[0] = payment;
+            return payment;
+        });
+        when(paymentRepository.findByMerchantUid("merchant-free"))
+                .thenAnswer(invocation -> Optional.ofNullable(savedPayment[0]));
+        when(reservationService.createReservation(any(), any(), any()))
+                .thenReturn(reservation(77L, 300L));
+        when(attendeeFormAttendeeService.saveAttendeeFormAndAttendee(any(), any()))
+                .thenReturn(AttendeeFormSaveResponseDto.builder()
+                        .reservationId(77L)
+                        .token("token")
+                        .build());
+
+        PaymentRequestDto request = reservationCreateRequest();
+        request.setMerchantUid("merchant-free");
+        request.setPrice(BigDecimal.ZERO);
+        request.setAmount(BigDecimal.ZERO);
+
+        paymentService.processFreeTicket(request, 300L);
+
+        verify(reservationPaymentIntentStore).save(new ReservationPaymentIntent(
+                1L, 1L, 10L, 1, BigDecimal.ZERO, "RESERVATION", 300L, "merchant-free"));
+        verify(reservationPaymentIntentStore).delete("merchant-free", 300L);
+    }
+
+    @Test
     void savePaymentRejectsUnsupportedTargetCodeWithTargetIdBeforeSave() {
         Users currentUser = userEntity(300L, "owner@example.com", "COMMON");
         when(userRepository.findById(300L)).thenReturn(Optional.of(currentUser));
@@ -725,6 +810,60 @@ class PaymentServiceAuthorizationTest {
     }
 
     @Test
+    void completePaymentRejectsRequestQuantityMismatchWithStoredIntent() {
+        Event event = event(1L, 100L);
+        Payment payment = pendingPayment("merchant-complete", 300L, 10L, event);
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
+        stubValidReservationIntent(event, 1L, 10L);
+
+        PaymentRequestDto request = completeRequest();
+        request.setQuantity(2);
+
+        assertThatThrownBy(() -> paymentService.completePayment(request, user(300L, "COMMON")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("수량");
+
+        verify(iamportPaymentVerifier, never()).findPayment(any());
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void completePaymentRejectsRequestAmountMismatchWithStoredIntent() {
+        Event event = event(1L, 100L);
+        Payment payment = pendingPayment("merchant-complete", 300L, 10L, event);
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
+        stubValidReservationIntent(event, 1L, 10L);
+
+        PaymentRequestDto request = completeRequest();
+        request.setAmount(BigDecimal.valueOf(101));
+
+        assertThatThrownBy(() -> paymentService.completePayment(request, user(300L, "COMMON")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("금액");
+
+        verify(iamportPaymentVerifier, never()).findPayment(any());
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void completePaymentRejectsRequestPriceMismatchWithStoredIntent() {
+        Event event = event(1L, 100L);
+        Payment payment = pendingPayment("merchant-complete", 300L, 10L, event);
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
+        stubValidReservationIntent(event, 1L, 10L);
+
+        PaymentRequestDto request = completeRequest();
+        request.setPrice(BigDecimal.valueOf(101));
+
+        assertThatThrownBy(() -> paymentService.completePayment(request, user(300L, "COMMON")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("가격");
+
+        verify(iamportPaymentVerifier, never()).findPayment(any());
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
     void completePaymentPropagatesReservationCompletionException() {
         Event event = event(1L, 100L);
         Payment payment = pendingPayment("merchant-complete", 300L, null, event);
@@ -772,6 +911,22 @@ class PaymentServiceAuthorizationTest {
                 .thenReturn(new IamportPaymentInfo("imp-public", "merchant-public", "paid", BigDecimal.valueOf(100)));
 
         paymentService.completePublicPayment(publicCompleteRequest(), "BOOTH_APPLICATION");
+
+        assertThat(payment.getPaymentStatusCode().getCode()).isEqualTo("COMPLETED");
+        assertThat(payment.getImpUid()).isEqualTo("imp-public");
+    }
+
+    @Test
+    void completePublicPaymentAllowsBannerApplicationWithoutPrincipal() {
+        Payment payment = pendingPayment("merchant-public", 300L, 10L, "BANNER_APPLICATION", null);
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-public")).thenReturn(Optional.of(payment));
+        when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
+        when(paymentStatusCodeRepository.findByCode("COMPLETED")).thenReturn(Optional.of(paymentStatusCode("COMPLETED")));
+        when(paymentRepository.save(any(Payment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(iamportPaymentVerifier.findPayment("imp-public"))
+                .thenReturn(new IamportPaymentInfo("imp-public", "merchant-public", "paid", BigDecimal.valueOf(100)));
+
+        paymentService.completePublicPayment(publicCompleteRequest(), "BANNER_APPLICATION");
 
         assertThat(payment.getPaymentStatusCode().getCode()).isEqualTo("COMPLETED");
         assertThat(payment.getImpUid()).isEqualTo("imp-public");
@@ -896,11 +1051,16 @@ class PaymentServiceAuthorizationTest {
     }
 
     private void stubReservationRelation(Event event, Long scheduleId, Long ticketId, Integer ticketPrice) {
+        stubReservationRelation(event, scheduleId, ticketId, ticketPrice, null);
+    }
+
+    private void stubReservationRelation(Event event, Long scheduleId, Long ticketId, Integer ticketPrice, Integer maxPurchase) {
         EventSchedule schedule = schedule(scheduleId, event);
         Ticket ticket = Ticket.builder()
                 .ticketId(ticketId)
                 .name("ticket")
                 .price(ticketPrice)
+                .maxPurchase(maxPurchase)
                 .build();
         ScheduleTicket scheduleTicket = ScheduleTicket.builder()
                 .id(new ScheduleTicketId(ticketId, scheduleId))

--- a/src/test/java/com/fairing/fairplay/payment/service/PaymentServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/payment/service/PaymentServiceAuthorizationTest.java
@@ -47,6 +47,8 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.SimpleTransactionStatus;
 
 import java.math.BigDecimal;
 import java.time.Duration;
@@ -59,12 +61,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentServiceAuthorizationTest {
@@ -115,6 +119,8 @@ class PaymentServiceAuthorizationTest {
     private StringRedisTemplate redisTemplate;
     @Mock
     private ValueOperations<String, String> valueOperations;
+    @Mock
+    private PlatformTransactionManager transactionManager;
 
     private PaymentService paymentService;
 
@@ -123,6 +129,7 @@ class PaymentServiceAuthorizationTest {
         lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
         lenient().when(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class))).thenReturn(true);
         lenient().when(redisTemplate.execute(any(RedisScript.class), anyList(), anyString())).thenReturn(1L);
+        lenient().when(transactionManager.getTransaction(any())).thenReturn(new SimpleTransactionStatus());
         lenient().when(paymentRepository.findByMerchantUid(anyString()))
                 .thenAnswer(invocation -> paymentRepository.findByMerchantUidForUpdate(invocation.getArgument(0)));
         paymentService = new PaymentService(
@@ -147,7 +154,8 @@ class PaymentServiceAuthorizationTest {
                 attendeeFormAttendeeService,
                 iamportPaymentVerifier,
                 reservationPaymentIntentStore,
-                redisTemplate
+                redisTemplate,
+                transactionManager
         );
     }
 
@@ -661,6 +669,33 @@ class PaymentServiceAuthorizationTest {
 
         verify(iamportPaymentVerifier).findPayment("imp-valid");
         verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void completePaymentLoadsSnapshotAndLockedPaymentInSeparateTransactionBoundaries() {
+        Event event = event(1L, 100L);
+        Payment snapshot = pendingPayment("merchant-complete", 300L, 10L, event);
+        Payment locked = pendingPayment("merchant-complete", 300L, 10L, event);
+        doReturn(Optional.of(snapshot)).when(paymentRepository).findByMerchantUid("merchant-complete");
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(locked));
+        when(paymentRepository.findById(1L)).thenReturn(Optional.of(locked));
+        when(paymentStatusCodeRepository.findByCode("COMPLETED")).thenReturn(Optional.of(paymentStatusCode("COMPLETED")));
+        when(paymentRepository.save(any(Payment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        stubValidReservationIntent(event, 1L, 10L);
+        stubValidIamport();
+        stubReservationRelation(event, 1L, 10L, 100);
+
+        paymentService.completePayment(completeRequest(), user(300L, "COMMON"));
+
+        var ordered = inOrder(transactionManager, paymentRepository, iamportPaymentVerifier, redisTemplate);
+        ordered.verify(transactionManager).getTransaction(argThat(definition -> definition.isReadOnly()));
+        ordered.verify(paymentRepository).findByMerchantUid("merchant-complete");
+        ordered.verify(transactionManager).commit(any());
+        ordered.verify(iamportPaymentVerifier).findPayment("imp-valid");
+        ordered.verify(transactionManager).getTransaction(argThat(definition -> !definition.isReadOnly()));
+        ordered.verify(paymentRepository).findByMerchantUidForUpdate("merchant-complete");
+        ordered.verify(transactionManager).commit(any());
+        ordered.verify(redisTemplate).execute(any(RedisScript.class), anyList(), anyString());
     }
 
     @Test

--- a/src/test/java/com/fairing/fairplay/payment/service/PaymentServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/payment/service/PaymentServiceAuthorizationTest.java
@@ -101,6 +101,8 @@ class PaymentServiceAuthorizationTest {
     private AttendeeFormAttendeeService attendeeFormAttendeeService;
     @Mock
     private IamportPaymentVerifier iamportPaymentVerifier;
+    @Mock
+    private ReservationPaymentIntentStore reservationPaymentIntentStore;
 
     private PaymentService paymentService;
 
@@ -126,7 +128,8 @@ class PaymentServiceAuthorizationTest {
                 boothRepository,
                 bannerApplicationRepository,
                 attendeeFormAttendeeService,
-                iamportPaymentVerifier
+                iamportPaymentVerifier,
+                reservationPaymentIntentStore
         );
     }
 
@@ -318,6 +321,52 @@ class PaymentServiceAuthorizationTest {
     }
 
     @Test
+    void savePaymentStoresReservationIntentAfterServerSideValidation() {
+        Event event = event(1L, 100L);
+        Users currentUser = userEntity(300L, "owner@example.com", "COMMON");
+        when(userRepository.findById(300L)).thenReturn(Optional.of(currentUser));
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
+        when(paymentTargetTypeRepository.findByPaymentTargetCode("RESERVATION"))
+                .thenReturn(Optional.of(targetType("RESERVATION")));
+        when(paymentTypeCodeRepository.getReferenceByCode("CARD")).thenReturn(paymentTypeCode());
+        when(paymentStatusCodeRepository.getReferenceByCode("PENDING")).thenReturn(paymentStatusCode("PENDING"));
+        stubReservationRelation(event, 1L, 10L, 100);
+        when(paymentRepository.save(any(Payment.class))).thenAnswer(invocation -> {
+            Payment payment = invocation.getArgument(0);
+            payment.setPaymentId(1L);
+            return payment;
+        });
+
+        PaymentRequestDto request = reservationCreateRequest();
+
+        paymentService.savePayment(request, 300L);
+
+        verify(reservationPaymentIntentStore).save(new ReservationPaymentIntent(
+                1L, 1L, 10L, 1, BigDecimal.valueOf(100), "RESERVATION", 300L, "merchant-create"));
+    }
+
+    @Test
+    void savePaymentRejectsReservationClientPriceMismatch() {
+        Event event = event(1L, 100L);
+        Users currentUser = userEntity(300L, "owner@example.com", "COMMON");
+        when(userRepository.findById(300L)).thenReturn(Optional.of(currentUser));
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(event));
+        when(paymentTargetTypeRepository.findByPaymentTargetCode("RESERVATION"))
+                .thenReturn(Optional.of(targetType("RESERVATION")));
+        stubReservationRelation(event, 1L, 10L, 100);
+
+        PaymentRequestDto request = reservationCreateRequest();
+        request.setPrice(BigDecimal.valueOf(99));
+
+        assertThatThrownBy(() -> paymentService.savePayment(request, 300L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("가격");
+
+        verify(paymentRepository, never()).save(any());
+        verify(reservationPaymentIntentStore, never()).save(any());
+    }
+
+    @Test
     void savePaymentRejectsUnsupportedTargetCodeWithTargetIdBeforeSave() {
         Users currentUser = userEntity(300L, "owner@example.com", "COMMON");
         when(userRepository.findById(300L)).thenReturn(Optional.of(currentUser));
@@ -483,6 +532,8 @@ class PaymentServiceAuthorizationTest {
     void completePaymentRejectsPgMerchantMismatch() {
         Payment payment = pendingPayment("merchant-complete", 300L, 10L, event(1L, 100L));
         when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
+        stubValidReservationIntent(payment.getEvent(), 1L, 10L);
+        stubReservationRelation(payment.getEvent(), 1L, 10L, 100);
         when(iamportPaymentVerifier.findPayment("imp-valid"))
                 .thenReturn(new IamportPaymentInfo("imp-valid", "merchant-other", "paid", BigDecimal.valueOf(100)));
 
@@ -497,6 +548,8 @@ class PaymentServiceAuthorizationTest {
     void completePaymentRejectsPgAmountMismatch() {
         Payment payment = pendingPayment("merchant-complete", 300L, 10L, event(1L, 100L));
         when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
+        stubValidReservationIntent(payment.getEvent(), 1L, 10L);
+        stubReservationRelation(payment.getEvent(), 1L, 10L, 100);
         when(iamportPaymentVerifier.findPayment("imp-valid"))
                 .thenReturn(new IamportPaymentInfo("imp-valid", "merchant-complete", "paid", BigDecimal.valueOf(101)));
 
@@ -511,6 +564,8 @@ class PaymentServiceAuthorizationTest {
     void completePaymentRejectsPgStatusNotPaid() {
         Payment payment = pendingPayment("merchant-complete", 300L, 10L, event(1L, 100L));
         when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
+        stubValidReservationIntent(payment.getEvent(), 1L, 10L);
+        stubReservationRelation(payment.getEvent(), 1L, 10L, 100);
         when(iamportPaymentVerifier.findPayment("imp-valid"))
                 .thenReturn(new IamportPaymentInfo("imp-valid", "merchant-complete", "ready", BigDecimal.valueOf(100)));
 
@@ -526,7 +581,7 @@ class PaymentServiceAuthorizationTest {
         Event event = event(1L, 100L);
         Payment payment = pendingPayment("merchant-complete", 300L, 10L, event);
         when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
-        stubValidIamport();
+        stubValidReservationIntent(event, 1L, 10L);
         stubReservationRelation(event, 1L, 10L, 50);
 
         assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), user(300L, "COMMON")))
@@ -542,7 +597,7 @@ class PaymentServiceAuthorizationTest {
         Event otherEvent = event(2L, 100L);
         Payment payment = pendingPayment("merchant-complete", 300L, 10L, paymentEvent);
         when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
-        stubValidIamport();
+        stubValidReservationIntent(paymentEvent, 1L, 10L);
         when(eventScheduleRepository.findById(1L)).thenReturn(Optional.of(schedule(1L, otherEvent)));
 
         assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), user(300L, "COMMON")))
@@ -557,7 +612,6 @@ class PaymentServiceAuthorizationTest {
     void completePaymentRejectsMissingScheduleOrTicketForReservation() {
         Payment payment = pendingPayment("merchant-complete", 300L, 10L, event(1L, 100L));
         when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
-        stubValidIamport();
         PaymentRequestDto request = completeRequest();
         request.setScheduleId(null);
 
@@ -574,7 +628,7 @@ class PaymentServiceAuthorizationTest {
         Event event = event(1L, 100L);
         Payment payment = pendingPayment("merchant-complete", 300L, 10L, event);
         when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
-        stubValidIamport();
+        stubValidReservationIntent(event, 1L, 10L);
         when(eventScheduleRepository.findById(1L)).thenReturn(Optional.of(schedule(1L, event)));
         when(scheduleTicketRepository.findById(new ScheduleTicketId(10L, 1L))).thenReturn(Optional.empty());
 
@@ -586,12 +640,98 @@ class PaymentServiceAuthorizationTest {
     }
 
     @Test
+    void completePaymentRejectsDifferentTicketFromStoredIntentEvenWithSameEventAndPrice() {
+        Event event = event(1L, 100L);
+        Payment payment = pendingPayment("merchant-complete", 300L, 10L, event);
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
+        stubValidReservationIntent(event, 1L, 10L);
+
+        PaymentRequestDto request = completeRequest();
+        request.setTicketId(11L);
+
+        assertThatThrownBy(() -> paymentService.completePayment(request, user(300L, "COMMON")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("intent");
+
+        verify(iamportPaymentVerifier, never()).findPayment(any());
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void completePaymentRejectsDifferentScheduleFromStoredIntentEvenWithSameEventAndPrice() {
+        Event event = event(1L, 100L);
+        Payment payment = pendingPayment("merchant-complete", 300L, 10L, event);
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
+        stubValidReservationIntent(event, 1L, 10L);
+
+        PaymentRequestDto request = completeRequest();
+        request.setScheduleId(2L);
+
+        assertThatThrownBy(() -> paymentService.completePayment(request, user(300L, "COMMON")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("intent");
+
+        verify(iamportPaymentVerifier, never()).findPayment(any());
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void completePaymentRejectsMissingReservationIntent() {
+        Event event = event(1L, 100L);
+        Payment payment = pendingPayment("merchant-complete", 300L, 10L, event);
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
+        when(reservationPaymentIntentStore.find("merchant-complete", 300L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), user(300L, "COMMON")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("intent");
+
+        verify(iamportPaymentVerifier, never()).findPayment(any());
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void completePaymentRejectsReservationIntentWithDifferentMerchantUid() {
+        Event event = event(1L, 100L);
+        Payment payment = pendingPayment("merchant-complete", 300L, 10L, event);
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
+        when(reservationPaymentIntentStore.find("merchant-complete", 300L))
+                .thenReturn(Optional.of(new ReservationPaymentIntent(
+                        1L, 1L, 10L, 1, BigDecimal.valueOf(100), "RESERVATION", 300L, "merchant-other")));
+
+        assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), user(300L, "COMMON")))
+                .isInstanceOf(AccessDeniedException.class)
+                .hasMessageContaining("intent");
+
+        verify(iamportPaymentVerifier, never()).findPayment(any());
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
+    void completePaymentRejectsReservationAmountOrQuantityMismatch() {
+        Event event = event(1L, 100L);
+        Payment payment = pendingPayment("merchant-complete", 300L, 10L, event);
+        payment.setQuantity(2);
+        payment.setAmount(BigDecimal.valueOf(200));
+        when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
+        stubValidReservationIntent(event, 1L, 10L);
+
+        assertThatThrownBy(() -> paymentService.completePayment(completeRequest(), user(300L, "COMMON")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("금액 또는 수량");
+
+        verify(iamportPaymentVerifier, never()).findPayment(any());
+        verify(paymentRepository, never()).save(any());
+    }
+
+    @Test
     void completePaymentPropagatesReservationCompletionException() {
         Event event = event(1L, 100L);
         Payment payment = pendingPayment("merchant-complete", 300L, null, event);
         when(paymentRepository.findByMerchantUidForUpdate("merchant-complete")).thenReturn(Optional.of(payment));
         when(paymentStatusCodeRepository.findByCode("COMPLETED")).thenReturn(Optional.of(paymentStatusCode("COMPLETED")));
         when(paymentRepository.save(any(Payment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        stubValidReservationIntent(event, 1L, 10L);
         stubValidIamport();
         stubReservationRelation(event, 1L, 10L, 100);
         when(reservationService.createReservation(any(), any(), any()))
@@ -610,6 +750,7 @@ class PaymentServiceAuthorizationTest {
         when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
         when(paymentStatusCodeRepository.findByCode("COMPLETED")).thenReturn(Optional.of(paymentStatusCode("COMPLETED")));
         when(paymentRepository.save(any(Payment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        stubValidReservationIntent(event, 1L, 10L);
         stubValidIamport();
         stubReservationRelation(event, 1L, 10L, 100);
 
@@ -617,6 +758,7 @@ class PaymentServiceAuthorizationTest {
 
         assertThat(payment.getPaymentStatusCode().getCode()).isEqualTo("COMPLETED");
         assertThat(payment.getImpUid()).isEqualTo("imp-valid");
+        verify(reservationPaymentIntentStore).delete("merchant-complete", 300L);
     }
 
     @Test
@@ -661,6 +803,7 @@ class PaymentServiceAuthorizationTest {
         when(paymentRepository.findById(1L)).thenReturn(Optional.of(payment));
         when(paymentStatusCodeRepository.findByCode("COMPLETED")).thenReturn(Optional.of(paymentStatusCode("COMPLETED")));
         when(paymentRepository.save(any(Payment.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        stubValidReservationIntent(event, 1L, 10L);
         stubValidIamport();
         stubReservationRelation(event, 1L, 10L, 100);
 
@@ -739,6 +882,19 @@ class PaymentServiceAuthorizationTest {
                 .thenReturn(new IamportPaymentInfo("imp-valid", "merchant-complete", "paid", BigDecimal.valueOf(100)));
     }
 
+    private void stubValidReservationIntent(Event event, Long scheduleId, Long ticketId) {
+        when(reservationPaymentIntentStore.find("merchant-complete", 300L))
+                .thenReturn(Optional.of(new ReservationPaymentIntent(
+                        event.getEventId(),
+                        scheduleId,
+                        ticketId,
+                        1,
+                        BigDecimal.valueOf(100),
+                        "RESERVATION",
+                        300L,
+                        "merchant-complete")));
+    }
+
     private void stubReservationRelation(Event event, Long scheduleId, Long ticketId, Integer ticketPrice) {
         EventSchedule schedule = schedule(scheduleId, event);
         Ticket ticket = Ticket.builder()
@@ -771,6 +927,20 @@ class PaymentServiceAuthorizationTest {
                 .targetId(targetId)
                 .quantity(1)
                 .price(BigDecimal.valueOf(100))
+                .pgProvider("html5_inicis")
+                .merchantUid("merchant-create")
+                .build();
+    }
+
+    private PaymentRequestDto reservationCreateRequest() {
+        return PaymentRequestDto.builder()
+                .paymentTargetType("RESERVATION")
+                .eventId(1L)
+                .scheduleId(1L)
+                .ticketId(10L)
+                .quantity(1)
+                .price(BigDecimal.valueOf(100))
+                .amount(BigDecimal.valueOf(100))
                 .pgProvider("html5_inicis")
                 .merchantUid("merchant-create")
                 .build();


### PR DESCRIPTION
## 요약
- 결제 완료 경로에서 인증된 소유자와 최초 예약 intent를 기준으로 merchantUid, event/schedule/ticket/quantity/amount 정합성을 검증합니다.
- public booth/banner 완료 경로는 명시적 public 완료 메서드로 제한하고, 결제 row PESSIMISTIC_WRITE 잠금으로 PENDING 완료를 직렬화합니다.
- 무료 티켓 완료 후 reservation intent replay gap을 닫고 관련 서비스/보안 테스트를 보강했습니다.

## 검증 evidence
- `./gradlew test --tests com.fairing.fairplay.payment.service.PaymentServiceAuthorizationTest`
- `./gradlew test --tests com.fairing.fairplay.core.config.SecurityConfigPublicSurfaceTest`
- `./gradlew test --tests "*PaymentService*" --tests "*SecurityConfig*"`
- `./gradlew test --rerun-tasks`
- `./gradlew clean && ./gradlew test --rerun-tasks`
- `git diff --check`

## 남은 gap
- live PortOne/Redis/PG smoke 미실행
- P0-01 live mini-server stack not running
- CodeRabbit rate-limit은 non-blocking policy로 취급

## main 보호
- 이 PR은 `epic/security-payment-intent-confirm` -> `develop` 대상입니다.
- `main`은 건드리지 않습니다. develop/main merge는 수행하지 않습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **보안**
  * 결제 완료 API의 인증 요구사항이 강화되었습니다.
  * 채팅 및 업로드 기능이 인증 없이 접근 가능하도록 변경되었습니다.

* **개선**
  * 결제 검증 프로세스가 개선되었습니다.
  * 예약 결제 처리가 더욱 견고해졌습니다.

* **테스트**
  * 결제 인증 및 보안 관련 테스트 범위가 확대되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rktclgh/FairPlay_BE/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->