### PR TITLE
Prevent invalid mini-server nginx config from reaching deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,12 @@ jobs:
           psql -h 127.0.0.1 -U fairplay -d fairplay -v ON_ERROR_STOP=1 -f src/main/resources/db/postgres/001_pgvector_rag.sql
           psql -h 127.0.0.1 -U fairplay -d fairplay -v ON_ERROR_STOP=1 -f src/main/resources/db/postgres/002_runtime_constraints.sql
 
+      - name: Validate mini-server nginx config
+        run: |
+          docker run --rm \
+            -v "${PWD}/deploy/nginx.miniserver.conf:/etc/nginx/conf.d/default.conf:ro" \
+            nginx:1.27-alpine nginx -t
+
       - name: Grant execute for gradlew
         run: chmod +x gradlew
 

--- a/deploy/nginx.miniserver.conf
+++ b/deploy/nginx.miniserver.conf
@@ -32,7 +32,7 @@ server {
         return 404;
     }
 
-    location ~ ^/uploads/tmp[0-9]{4}-[0-9]{2}-[0-9]{2}(/|$) {
+    location ~ "^/uploads/tmp[0-9]{4}-[0-9]{2}-[0-9]{2}(/|$)" {
         return 404;
     }
 
@@ -52,7 +52,7 @@ server {
         return 404;
     }
 
-    location ~ ^/uploads/uploads/tmp[0-9]{4}-[0-9]{2}-[0-9]{2}(/|$) {
+    location ~ "^/uploads/uploads/tmp[0-9]{4}-[0-9]{2}-[0-9]{2}(/|$)" {
         return 404;
     }
 

--- a/src/test/java/com/fairing/fairplay/core/config/NginxMiniserverUploadDenyOrderTest.java
+++ b/src/test/java/com/fairing/fairplay/core/config/NginxMiniserverUploadDenyOrderTest.java
@@ -40,17 +40,17 @@ class NginxMiniserverUploadDenyOrderTest {
                 "location ^~ /uploads/temp/",
                 "location = /uploads/tmp",
                 "location ^~ /uploads/tmp/",
-                "location ~ ^/uploads/tmp[0-9]{4}-[0-9]{2}-[0-9]{2}(/|$)",
+                "location ~ \"^/uploads/tmp[0-9]{4}-[0-9]{2}-[0-9]{2}(/|$)\"",
                 "location = /uploads/uploads/temp",
                 "location ^~ /uploads/uploads/temp/",
                 "location = /uploads/uploads/tmp",
                 "location ^~ /uploads/uploads/tmp/",
-                "location ~ ^/uploads/uploads/tmp[0-9]{4}-[0-9]{2}-[0-9]{2}(/|$)"
+                "location ~ \"^/uploads/uploads/tmp[0-9]{4}-[0-9]{2}-[0-9]{2}(/|$)\""
         );
 
         assertThat(config).containsPattern("(?s)location = /uploads/private \\{\\s*return 404;\\s*}");
         assertThat(config).containsPattern("(?s)location \\^~ /uploads/uploads/temp/ \\{\\s*return 404;\\s*}");
-        assertThat(config).containsPattern("(?s)location ~ \\^/uploads/uploads/tmp\\[0-9\\]\\{4}-\\[0-9\\]\\{2}-\\[0-9\\]\\{2}\\(/\\|\\$\\) \\{\\s*return 404;\\s*}");
+        assertThat(config).containsPattern("(?s)location ~ \"\\^/uploads/uploads/tmp\\[0-9\\]\\{4}-\\[0-9\\]\\{2}-\\[0-9\\]\\{2}\\(/\\|\\$\\)\" \\{\\s*return 404;\\s*}");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Quote nginx regex `location` patterns that were crashing `nginx:1.27-alpine` on the mini server.
- Add backend CI validation for `deploy/nginx.miniserver.conf` using the same nginx image used by the mini-server compose stack.
- Update the existing nginx deny-order regression test to accept the required quoted regex syntax.

## Verification
- `git diff --check`
- `./gradlew test --no-daemon`
- `docker run --rm -v "$PWD/nginx.miniserver.conf:/etc/nginx/conf.d/default.conf:ro" nginx:1.27-alpine nginx -t` on the mini server
- Mini-server smoke after synced config: `/actuator/health` UP, `/` 200, `/api/events` 200, SSE 401 unauthenticated, SockJS info 200, `/uploads/temp/x` 404

## Notes
- Local Docker daemon is not running on the Mac, so nginx validation was executed on the mini server.
- Historical failed GitHub Actions runs remain in GitHub history, but latest BE/FE `develop` and deploy/notify workflows were green before this PR; this PR fixes the nginx parser regression found while turning the server back on.