### PR TITLE
Keep QR and waiting realtime behind authenticated SSE

### DIFF
--- a/src/main/java/com/fairing/fairplay/booth/controller/BoothWaitingRealtimeController.java
+++ b/src/main/java/com/fairing/fairplay/booth/controller/BoothWaitingRealtimeController.java
@@ -1,0 +1,29 @@
+package com.fairing.fairplay.booth.controller;
+
+import com.fairing.fairplay.core.security.CustomUserDetails;
+import com.fairing.fairplay.realtime.service.RealtimeSseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/booth-experiences")
+public class BoothWaitingRealtimeController {
+
+    private final RealtimeSseService realtimeSseService;
+
+    @GetMapping(value = "/waiting/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public ResponseEntity<SseEmitter> streamWaitingStatus(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        if (userDetails == null) {
+            return ResponseEntity.status(401).build();
+        }
+        return ResponseEntity.ok(realtimeSseService.openWaitingStream(userDetails.getUserId()));
+    }
+}

--- a/src/main/java/com/fairing/fairplay/booth/service/BoothExperienceService.java
+++ b/src/main/java/com/fairing/fairplay/booth/service/BoothExperienceService.java
@@ -12,6 +12,7 @@ import com.fairing.fairplay.booth.repository.BoothRepository;
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.core.security.CustomUserDetails;
 import com.fairing.fairplay.event.entity.Event;
+import com.fairing.fairplay.realtime.service.RealtimeSseService;
 import com.fairing.fairplay.user.entity.Users;
 import com.fairing.fairplay.user.repository.UserRepository;
 import java.util.Optional;
@@ -22,7 +23,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,7 +46,7 @@ public class BoothExperienceService {
   private final BoothExperienceStatusCodeRepository statusCodeRepository;
   private final BoothRepository boothRepository;
   private final UserRepository userRepository;
-  private final SimpMessagingTemplate messagingTemplate;
+  private final RealtimeSseService realtimeSseService;
 
   // 1. 부스 체험 등록 (부스 담당자)
   @Transactional
@@ -949,6 +949,6 @@ public class BoothExperienceService {
 
   public void waitingNotification(Long userId, Integer waitingCount, String statusMessage) {
     WaitingMessage msg = new WaitingMessage(waitingCount, statusMessage);
-    messagingTemplate.convertAndSend("/topic/waiting/" + userId, msg);
+    realtimeSseService.sendWaitingEvent(userId, msg);
   }
 }

--- a/src/main/java/com/fairing/fairplay/booth/service/BoothQrService.java
+++ b/src/main/java/com/fairing/fairplay/booth/service/BoothQrService.java
@@ -11,12 +11,12 @@ import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.qr.dto.scan.CheckResponseDto;
 import com.fairing.fairplay.qr.entity.QrTicket;
 import com.fairing.fairplay.qr.service.QrTicketEntryService;
+import com.fairing.fairplay.realtime.service.RealtimeSseService;
 import com.fairing.fairplay.user.entity.Users;
 import com.fairing.fairplay.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,7 +29,7 @@ public class BoothQrService {
   private final BoothExperienceStatusCodeRepository boothExperienceStatusCodeRepository;
   private final BoothExperienceService boothExperienceService;
   private final QrTicketEntryService qrTicketEntryService;
-  private final SimpMessagingTemplate messagingTemplate;
+  private final RealtimeSseService realtimeSseService;
 
   // QR 티켓을 통한 부스 입장 처리
   @Transactional
@@ -79,6 +79,6 @@ public class BoothQrService {
   }
 
   private void checkInBooth(Long qrTicketId) {
-    messagingTemplate.convertAndSend("/topic/booth/qr/"+qrTicketId, "부스 입장 완료");
+    realtimeSseService.sendQrTicketEvent(qrTicketId, "부스 입장 완료");
   }
 }

--- a/src/main/java/com/fairing/fairplay/chat/websocket/SessionStompChannelInterceptor.java
+++ b/src/main/java/com/fairing/fairplay/chat/websocket/SessionStompChannelInterceptor.java
@@ -15,18 +15,11 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Component;
 
 import java.security.Principal;
-import java.util.Set;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class SessionStompChannelInterceptor implements ChannelInterceptor {
-
-    private static final Set<String> PUBLIC_SUBSCRIBE_PREFIXES = Set.of(
-            "/topic/check-in/",
-            "/topic/check-out/",
-            "/topic/booth/qr/",
-            "/topic/waiting/");
 
     private final SessionService sessionService;
     private final ChatRoomRepository chatRoomRepository;
@@ -79,14 +72,10 @@ public class SessionStompChannelInterceptor implements ChannelInterceptor {
             return;
         }
 
-        if (StompCommand.SUBSCRIBE.equals(command) && destination != null && !isPublicSubscribeDestination(destination)) {
+        if (StompCommand.SUBSCRIBE.equals(command) && destination != null) {
             Long userId = requireAuthenticated(accessor, command, destination);
             requirePrivateSubscribeAccess(userId, destination);
         }
-    }
-
-    private boolean isPublicSubscribeDestination(String destination) {
-        return PUBLIC_SUBSCRIBE_PREFIXES.stream().anyMatch(destination::startsWith);
     }
 
     private Long requireAuthenticated(StompHeaderAccessor accessor, StompCommand command, String destination) {

--- a/src/main/java/com/fairing/fairplay/chat/websocket/WebSocketConfig.java
+++ b/src/main/java/com/fairing/fairplay/chat/websocket/WebSocketConfig.java
@@ -52,32 +52,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 .setHeartbeatTime(25000)
                 .setDisconnectDelay(30000);
 
-        // 체크인/체크아웃 전용 SockJS fallback 엔드포인트
-        registry.addEndpoint("/ws/qr-sockjs")
-                .setAllowedOriginPatterns("*")
-                .withSockJS()
-                .setSessionCookieNeeded(false)
-                .setHeartbeatTime(25000)
-                .setDisconnectDelay(30000)
-                .setSuppressCors(false);
-
-        // 부스 체크인 전용 SockJS fallback 엔드포인트
-        registry.addEndpoint("/ws/booth-sockjs")
-                .setAllowedOriginPatterns("*")
-                .withSockJS()
-                .setSessionCookieNeeded(false)
-                .setHeartbeatTime(25000)
-                .setDisconnectDelay(30000)
-                .setSuppressCors(false);
-
-        // 부스 실시간 웨이팅 전용 SockJS fallback 엔드포인트
-        registry.addEndpoint("/ws/waiting-sockjs")
-                .setAllowedOriginPatterns("*")
-                .withSockJS()
-                .setSessionCookieNeeded(false)
-                .setHeartbeatTime(25000)
-                .setDisconnectDelay(30000)
-                .setSuppressCors(false);
     }
 
     @Override

--- a/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
+++ b/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
@@ -106,8 +106,6 @@ public class SecurityConfig {
                                 "/api/users/event-admin/*/public",
                                 "/api/qr-tickets/*",
                                 "/api/qr-tickets/reissue",
-                                "/ws/**", // ★ 반드시 필요
-                                "/ws/*/info", // SockJS info 엔드포인트
                                 "/api/chat/rooms/**", // 채팅방 목록 조회만 허용
                                 "/api/chat/presence/status/**", // 사용자 온라인 상태 조회 허용
                                 "/uploads/**", // 로컬 파일 시스템의 정적 파일 서빙

--- a/src/main/java/com/fairing/fairplay/core/security/SessionAuthenticationFilter.java
+++ b/src/main/java/com/fairing/fairplay/core/security/SessionAuthenticationFilter.java
@@ -49,7 +49,6 @@ public class SessionAuthenticationFilter extends OncePerRequestFilter {
         "/api/users/signup",
         "/api/users/check-",
         "/api/email/",
-        "/ws/",
         "/api/qr-tickets/",
         "/uploads/"
     );

--- a/src/main/java/com/fairing/fairplay/qr/controller/QrTicketRealtimeController.java
+++ b/src/main/java/com/fairing/fairplay/qr/controller/QrTicketRealtimeController.java
@@ -1,0 +1,31 @@
+package com.fairing.fairplay.qr.controller;
+
+import com.fairing.fairplay.core.security.CustomUserDetails;
+import com.fairing.fairplay.realtime.service.RealtimeSseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/qr-tickets")
+public class QrTicketRealtimeController {
+
+    private final RealtimeSseService realtimeSseService;
+
+    @GetMapping(value = "/{qrTicketId}/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public ResponseEntity<SseEmitter> streamQrTicketStatus(
+            @PathVariable Long qrTicketId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        if (userDetails == null) {
+            return ResponseEntity.status(401).build();
+        }
+        return ResponseEntity.ok(realtimeSseService.openQrTicketStream(qrTicketId, userDetails.getUserId()));
+    }
+}

--- a/src/main/java/com/fairing/fairplay/qr/repository/QrTicketRepository.java
+++ b/src/main/java/com/fairing/fairplay/qr/repository/QrTicketRepository.java
@@ -71,4 +71,18 @@ public interface QrTicketRepository extends JpaRepository<QrTicket, Long> {
   boolean existsByQrCode(String qrCode);
 
   boolean existsByManualCode(String manualCode);
+
+  @Query("""
+      SELECT COUNT(q) > 0
+      FROM QrTicket q
+      JOIN q.attendee a
+      JOIN a.reservation r
+      JOIN r.user u
+      WHERE q.id = :qrTicketId
+        AND u.userId = :userId
+      """)
+  boolean existsByIdAndReservationUserId(
+      @Param("qrTicketId") Long qrTicketId,
+      @Param("userId") Long userId
+  );
 }

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketEntryService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketEntryService.java
@@ -17,6 +17,7 @@ import com.fairing.fairplay.qr.entity.QrTicket;
 import com.fairing.fairplay.qr.repository.QrActionCodeRepository;
 import com.fairing.fairplay.qr.repository.QrTicketRepository;
 import com.fairing.fairplay.qr.util.CodeValidator;
+import com.fairing.fairplay.realtime.service.RealtimeSseService;
 import com.fairing.fairplay.reservation.entity.Reservation;
 import com.fairing.fairplay.user.entity.Users;
 import java.time.LocalDateTime;
@@ -24,7 +25,6 @@ import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -37,7 +37,7 @@ public class QrTicketEntryService {
   private final QrLogService qrLogService;
   private final QrTicketAttendeeService qrTicketAttendeeService;
   private final QrEntryValidateService qrEntryValidateService;
-  private final SimpMessagingTemplate messagingTemplate;
+  private final RealtimeSseService realtimeSseService;
 
   private static final String QR = "QR";
   private static final String MANUAL = "MANUAL";
@@ -247,11 +247,11 @@ public class QrTicketEntryService {
   }
 
   public void checkInQrTicket(QrTicket qrTicket) {
-    messagingTemplate.convertAndSend("/topic/check-in/" + qrTicket.getId(), "체크인 처리가 완료되었습니다.");
+    realtimeSseService.sendQrTicketEvent(qrTicket.getId(), "체크인 처리가 완료되었습니다.");
   }
 
   public void boothCheckIn(QrTicket qrTicket) {
-    messagingTemplate.convertAndSend("/topic/booth/qr/" + qrTicket.getId(), "체크인 처리가 완료되었습니다.");
+    realtimeSseService.sendQrTicketEvent(qrTicket.getId(), "체크인 처리가 완료되었습니다.");
   }
 
   private CheckResponseDto processBoothCheck(QrTicket qrTicket) {

--- a/src/main/java/com/fairing/fairplay/qr/service/QrTicketExitService.java
+++ b/src/main/java/com/fairing/fairplay/qr/service/QrTicketExitService.java
@@ -13,12 +13,12 @@ import com.fairing.fairplay.qr.entity.QrCheckStatusCode;
 import com.fairing.fairplay.qr.entity.QrTicket;
 import com.fairing.fairplay.qr.repository.QrTicketRepository;
 import com.fairing.fairplay.qr.util.CodeValidator;
+import com.fairing.fairplay.realtime.service.RealtimeSseService;
 import com.fairing.fairplay.user.entity.Users;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -32,7 +32,7 @@ public class QrTicketExitService {
   private final QrTicketAttendeeService qrTicketAttendeeService;
   private final QrEntryValidateService qrEntryValidateService;
   private final CodeValidator codeValidator;
-  private final SimpMessagingTemplate messagingTemplate;
+  private final RealtimeSseService realtimeSseService;
 
   private static final String QR = "QR";
   private static final String MANUAL = "MANUAL";
@@ -162,6 +162,6 @@ public class QrTicketExitService {
     return qrLogService.exitQrLog(qrTicket, qrCheckStatusCode);
   }
   public void checkOutQrTicket(QrTicket qrTicket){
-    messagingTemplate.convertAndSend("/topic/check-out/"+qrTicket.getId(),"체크아웃 처리가 완료되었습니다.");
+    realtimeSseService.sendQrTicketEvent(qrTicket.getId(), "체크아웃 처리가 완료되었습니다.");
   }
 }

--- a/src/main/java/com/fairing/fairplay/realtime/service/RealtimeSseService.java
+++ b/src/main/java/com/fairing/fairplay/realtime/service/RealtimeSseService.java
@@ -6,6 +6,7 @@ import com.fairing.fairplay.qr.repository.QrTicketRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -19,6 +20,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class RealtimeSseService {
 
     private static final long TIMEOUT = 60L * 60L * 1000L;
+    private static final long HEARTBEAT_DELAY = 25_000L;
 
     private final QrTicketRepository qrTicketRepository;
     private final ConcurrentHashMap<Long, Set<SseEmitter>> qrTicketEmitters = new ConcurrentHashMap<>();
@@ -39,18 +41,36 @@ public class RealtimeSseService {
     }
 
     public void sendQrTicketEvent(Long qrTicketId, String message) {
+        if (qrTicketId == null) {
+            return;
+        }
         send(qrTicketEmitters, qrTicketId, "qr-ticket-status", message);
     }
 
     public void sendWaitingEvent(Long userId, WaitingMessage message) {
+        if (userId == null) {
+            return;
+        }
         send(waitingEmitters, userId, "waiting-status", message);
+    }
+
+    @Scheduled(fixedDelay = HEARTBEAT_DELAY)
+    public void sendHeartbeat() {
+        sendHeartbeat(qrTicketEmitters);
+        sendHeartbeat(waitingEmitters);
     }
 
     private SseEmitter register(ConcurrentHashMap<Long, Set<SseEmitter>> registry, Long key,
                                 String eventName, String message) {
         SseEmitter emitter = new SseEmitter(TIMEOUT);
-        Set<SseEmitter> emitters = registry.computeIfAbsent(key, ignored -> ConcurrentHashMap.newKeySet());
-        emitters.add(emitter);
+        registry.compute(key, (ignored, emitters) -> {
+            Set<SseEmitter> activeEmitters = emitters;
+            if (activeEmitters == null) {
+                activeEmitters = ConcurrentHashMap.newKeySet();
+            }
+            activeEmitters.add(emitter);
+            return activeEmitters;
+        });
 
         Runnable cleanup = () -> remove(registry, key, emitter);
         emitter.onCompletion(cleanup);
@@ -64,7 +84,7 @@ public class RealtimeSseService {
         });
 
         try {
-            emitter.send(SseEmitter.event().name(eventName).data(message));
+            sendEmitter(emitter, SseEmitter.event().name(eventName).data(message));
         } catch (IOException e) {
             cleanup.run();
             emitter.completeWithError(e);
@@ -81,7 +101,7 @@ public class RealtimeSseService {
 
         for (SseEmitter emitter : emitters) {
             try {
-                emitter.send(SseEmitter.event().name(eventName).data(payload));
+                sendEmitter(emitter, SseEmitter.event().name(eventName).data(payload));
             } catch (IOException | IllegalStateException e) {
                 remove(registry, key, emitter);
                 emitter.completeWithError(e);
@@ -89,14 +109,30 @@ public class RealtimeSseService {
         }
     }
 
+    private void sendHeartbeat(ConcurrentHashMap<Long, Set<SseEmitter>> registry) {
+        registry.forEach((key, emitters) -> {
+            for (SseEmitter emitter : emitters) {
+                try {
+                    sendEmitter(emitter, SseEmitter.event().comment("heartbeat"));
+                } catch (IOException | IllegalStateException e) {
+                    remove(registry, key, emitter);
+                    emitter.completeWithError(e);
+                }
+            }
+        });
+    }
+
+    private void sendEmitter(SseEmitter emitter, SseEmitter.SseEventBuilder event)
+            throws IOException {
+        synchronized (emitter) {
+            emitter.send(event);
+        }
+    }
+
     private void remove(ConcurrentHashMap<Long, Set<SseEmitter>> registry, Long key, SseEmitter emitter) {
-        Set<SseEmitter> emitters = registry.get(key);
-        if (emitters == null) {
-            return;
-        }
-        emitters.remove(emitter);
-        if (emitters.isEmpty()) {
-            registry.remove(key, emitters);
-        }
+        registry.computeIfPresent(key, (ignored, emitters) -> {
+            emitters.remove(emitter);
+            return emitters.isEmpty() ? null : emitters;
+        });
     }
 }

--- a/src/main/java/com/fairing/fairplay/realtime/service/RealtimeSseService.java
+++ b/src/main/java/com/fairing/fairplay/realtime/service/RealtimeSseService.java
@@ -1,0 +1,102 @@
+package com.fairing.fairplay.realtime.service;
+
+import com.fairing.fairplay.booth.dto.WaitingMessage;
+import com.fairing.fairplay.common.exception.CustomException;
+import com.fairing.fairplay.qr.repository.QrTicketRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RealtimeSseService {
+
+    private static final long TIMEOUT = 60L * 60L * 1000L;
+
+    private final QrTicketRepository qrTicketRepository;
+    private final ConcurrentHashMap<Long, Set<SseEmitter>> qrTicketEmitters = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Long, Set<SseEmitter>> waitingEmitters = new ConcurrentHashMap<>();
+
+    public SseEmitter openQrTicketStream(Long qrTicketId, Long userId) {
+        if (!qrTicketRepository.existsById(qrTicketId)) {
+            throw new CustomException(HttpStatus.NOT_FOUND, "QR 티켓을 찾을 수 없습니다.");
+        }
+        if (!qrTicketRepository.existsByIdAndReservationUserId(qrTicketId, userId)) {
+            throw new CustomException(HttpStatus.FORBIDDEN, "QR 티켓 실시간 상태를 구독할 권한이 없습니다.");
+        }
+        return register(qrTicketEmitters, qrTicketId, "qr-ticket-connected", "QR 티켓 실시간 연결 성공");
+    }
+
+    public SseEmitter openWaitingStream(Long userId) {
+        return register(waitingEmitters, userId, "waiting-connected", "웨이팅 실시간 연결 성공");
+    }
+
+    public void sendQrTicketEvent(Long qrTicketId, String message) {
+        send(qrTicketEmitters, qrTicketId, "qr-ticket-status", message);
+    }
+
+    public void sendWaitingEvent(Long userId, WaitingMessage message) {
+        send(waitingEmitters, userId, "waiting-status", message);
+    }
+
+    private SseEmitter register(ConcurrentHashMap<Long, Set<SseEmitter>> registry, Long key,
+                                String eventName, String message) {
+        SseEmitter emitter = new SseEmitter(TIMEOUT);
+        Set<SseEmitter> emitters = registry.computeIfAbsent(key, ignored -> ConcurrentHashMap.newKeySet());
+        emitters.add(emitter);
+
+        Runnable cleanup = () -> remove(registry, key, emitter);
+        emitter.onCompletion(cleanup);
+        emitter.onTimeout(() -> {
+            cleanup.run();
+            emitter.complete();
+        });
+        emitter.onError(error -> {
+            cleanup.run();
+            log.debug("SSE stream closed with error. key={}, event={}", key, eventName, error);
+        });
+
+        try {
+            emitter.send(SseEmitter.event().name(eventName).data(message));
+        } catch (IOException e) {
+            cleanup.run();
+            emitter.completeWithError(e);
+        }
+        return emitter;
+    }
+
+    private void send(ConcurrentHashMap<Long, Set<SseEmitter>> registry, Long key, String eventName,
+                      Object payload) {
+        Set<SseEmitter> emitters = registry.get(key);
+        if (emitters == null || emitters.isEmpty()) {
+            return;
+        }
+
+        for (SseEmitter emitter : emitters) {
+            try {
+                emitter.send(SseEmitter.event().name(eventName).data(payload));
+            } catch (IOException | IllegalStateException e) {
+                remove(registry, key, emitter);
+                emitter.completeWithError(e);
+            }
+        }
+    }
+
+    private void remove(ConcurrentHashMap<Long, Set<SseEmitter>> registry, Long key, SseEmitter emitter) {
+        Set<SseEmitter> emitters = registry.get(key);
+        if (emitters == null) {
+            return;
+        }
+        emitters.remove(emitter);
+        if (emitters.isEmpty()) {
+            registry.remove(key, emitters);
+        }
+    }
+}

--- a/src/test/java/com/fairing/fairplay/booth/service/BoothExperienceServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/booth/service/BoothExperienceServiceAuthorizationTest.java
@@ -14,6 +14,7 @@ import com.fairing.fairplay.booth.repository.BoothRepository;
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.core.security.CustomUserDetails;
 import com.fairing.fairplay.event.entity.Event;
+import com.fairing.fairplay.realtime.service.RealtimeSseService;
 import com.fairing.fairplay.user.entity.BoothAdmin;
 import com.fairing.fairplay.user.entity.EventAdmin;
 import com.fairing.fairplay.user.entity.Users;
@@ -29,7 +30,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.access.AccessDeniedException;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,7 +60,7 @@ class BoothExperienceServiceAuthorizationTest {
   private UserRepository userRepository;
 
   @Mock
-  private SimpMessagingTemplate messagingTemplate;
+  private RealtimeSseService realtimeSseService;
 
   private BoothExperienceService service;
 
@@ -72,7 +72,7 @@ class BoothExperienceServiceAuthorizationTest {
         statusCodeRepository,
         boothRepository,
         userRepository,
-        messagingTemplate
+        realtimeSseService
     );
   }
 

--- a/src/test/java/com/fairing/fairplay/booth/service/BoothQrServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/booth/service/BoothQrServiceAuthorizationTest.java
@@ -15,6 +15,7 @@ import com.fairing.fairplay.event.entity.Event;
 import com.fairing.fairplay.qr.dto.scan.CheckResponseDto;
 import com.fairing.fairplay.qr.entity.QrTicket;
 import com.fairing.fairplay.qr.service.QrTicketEntryService;
+import com.fairing.fairplay.realtime.service.RealtimeSseService;
 import com.fairing.fairplay.reservation.entity.Reservation;
 import com.fairing.fairplay.user.entity.BoothAdmin;
 import com.fairing.fairplay.user.entity.EventAdmin;
@@ -31,7 +32,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -63,7 +63,7 @@ class BoothQrServiceAuthorizationTest {
   private QrTicketEntryService qrTicketEntryService;
 
   @Mock
-  private SimpMessagingTemplate messagingTemplate;
+  private RealtimeSseService realtimeSseService;
 
   private BoothQrService boothQrService;
 
@@ -75,14 +75,14 @@ class BoothQrServiceAuthorizationTest {
         statusCodeRepository,
         boothRepository,
         userRepository,
-        messagingTemplate
+        realtimeSseService
     );
     boothQrService = new BoothQrService(
         userRepository,
         statusCodeRepository,
         boothExperienceService,
         qrTicketEntryService,
-        messagingTemplate
+        realtimeSseService
     );
   }
 

--- a/src/test/java/com/fairing/fairplay/chat/websocket/SessionStompChannelInterceptorTest.java
+++ b/src/test/java/com/fairing/fairplay/chat/websocket/SessionStompChannelInterceptorTest.java
@@ -39,11 +39,11 @@ class SessionStompChannelInterceptorTest {
     }
 
     @Test
-    void allowsPublicQrSubscribeWithoutAuthentication() {
+    void rejectsUnauthenticatedQrSubscribe() {
         Message<byte[]> message = stompMessage(StompCommand.SUBSCRIBE, "/topic/check-in/123", null);
 
-        assertThatCode(() -> interceptor.preSend(message, null))
-                .doesNotThrowAnyException();
+        assertThatThrownBy(() -> interceptor.preSend(message, null))
+                .isInstanceOf(AccessDeniedException.class);
     }
 
     @Test

--- a/src/test/java/com/fairing/fairplay/core/config/SecurityConfigPublicSurfaceTest.java
+++ b/src/test/java/com/fairing/fairplay/core/config/SecurityConfigPublicSurfaceTest.java
@@ -74,6 +74,27 @@ class SecurityConfigPublicSurfaceTest {
     }
 
     @Test
+    void realtimeQrAndWaitingStreamsRequireAuthenticationWithoutSession() throws Exception {
+        mockMvc.perform(get("/api/qr-tickets/1/stream"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/api/booth-experiences/waiting/stream"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void legacyPublicSockJsSurfacesRequireAuthenticationWithoutSession() throws Exception {
+        mockMvc.perform(get("/ws/qr-sockjs/info"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/ws/waiting-sockjs/info"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/ws/booth-sockjs/info"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
     void bannerPaymentCompleteRemainsPublicWithoutSession() throws Exception {
         mockMvc.perform(post("/api/banners/payment/complete")
                         .contentType("application/json")
@@ -90,5 +111,6 @@ class SecurityConfigPublicSurfaceTest {
                 "PUBLIC_PATHS");
 
         assertThat(publicPaths).doesNotContain("/api/uploads/");
+        assertThat(publicPaths).doesNotContain("/ws/");
     }
 }

--- a/src/test/java/com/fairing/fairplay/realtime/service/RealtimeSseServiceTest.java
+++ b/src/test/java/com/fairing/fairplay/realtime/service/RealtimeSseServiceTest.java
@@ -53,4 +53,12 @@ class RealtimeSseServiceTest {
         assertThatCode(() -> service.sendQrTicketEvent(1L, "체크인 완료"))
                 .doesNotThrowAnyException();
     }
+
+    @Test
+    void sendingWithNullKeysIsNoop() {
+        assertThatCode(() -> {
+            service.sendQrTicketEvent(null, "체크인 완료");
+            service.sendWaitingEvent(null, null);
+        }).doesNotThrowAnyException();
+    }
 }

--- a/src/test/java/com/fairing/fairplay/realtime/service/RealtimeSseServiceTest.java
+++ b/src/test/java/com/fairing/fairplay/realtime/service/RealtimeSseServiceTest.java
@@ -1,0 +1,56 @@
+package com.fairing.fairplay.realtime.service;
+
+import com.fairing.fairplay.common.exception.CustomException;
+import com.fairing.fairplay.qr.repository.QrTicketRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RealtimeSseServiceTest {
+
+    private final QrTicketRepository qrTicketRepository = mock(QrTicketRepository.class);
+    private final RealtimeSseService service = new RealtimeSseService(qrTicketRepository);
+
+    @Test
+    void openQrTicketStreamRejectsMissingTicket() {
+        when(qrTicketRepository.existsById(1L)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.openQrTicketStream(1L, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting("status")
+                .isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void openQrTicketStreamRejectsTicketOwnedByAnotherUser() {
+        when(qrTicketRepository.existsById(1L)).thenReturn(true);
+        when(qrTicketRepository.existsByIdAndReservationUserId(1L, 10L)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.openQrTicketStream(1L, 10L))
+                .isInstanceOf(CustomException.class)
+                .extracting("status")
+                .isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void openQrTicketStreamAllowsTicketOwner() {
+        when(qrTicketRepository.existsById(1L)).thenReturn(true);
+        when(qrTicketRepository.existsByIdAndReservationUserId(1L, 10L)).thenReturn(true);
+
+        SseEmitter emitter = service.openQrTicketStream(1L, 10L);
+
+        assertThat(emitter).isNotNull();
+    }
+
+    @Test
+    void sendingWithoutSubscribersIsNoop() {
+        assertThatCode(() -> service.sendQrTicketEvent(1L, "체크인 완료"))
+                .doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## Summary
- Replace public QR/booth/waiting SockJS topics with authenticated SSE streams.
- Require QR ticket ownership before opening the QR stream and use the authenticated user for waiting updates.
- Remove the legacy public SockJS endpoints and public STOMP subscribe bypasses.

## Verification
- `./gradlew test --no-daemon`

## Notes
- Mini-server idle check before this change showed backend around 572 MiB / 1 GiB and ~0.75% CPU, so realtime was kept via SSE instead of removed.
- CodeRabbit rate-limit/stale notices are non-blocking per project policy unless they include concrete Critical/High/Important findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * QR 티켓 상태에 대한 실시간 스트리밍 기능 추가
  * 부스 대기열 상태에 대한 실시간 스트리밍 기능 추가

* **보안**
  * 실시간 상태 스트리밍 엔드포인트에 인증 필수 요구사항 추가

* **변경사항**
  * 일부 레거시 WebSocket/SockJS 엔드포인트 제거

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rktclgh/FairPlay_BE/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->