### PR TITLE
Fix admin inquiry chat access

### DIFF
--- a/src/main/java/com/fairing/fairplay/chat/controller/ChatRestController.java
+++ b/src/main/java/com/fairing/fairplay/chat/controller/ChatRestController.java
@@ -11,6 +11,7 @@ import com.fairing.fairplay.chat.service.ChatMessageService;
 import com.fairing.fairplay.chat.service.ChatRoomService;
 import com.fairing.fairplay.user.repository.UserRepository;
 import com.fairing.fairplay.core.security.CustomUserDetails;
+import com.fairing.fairplay.user.entity.Users;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.access.AccessDeniedException;
@@ -92,18 +93,24 @@ public class ChatRestController {
         Set<Long> existingRoomIds = allRooms.stream()
                 .map(ChatRoomResponseDto::getChatRoomId)
                 .collect(Collectors.toSet());
+        List<ChatRoom> roomsToAdd = managerRooms.stream()
+                .filter(room -> !existingRoomIds.contains(room.getChatRoomId()))
+                .toList();
+        Map<Long, String> userNamesById = userRepository.findAllById(roomsToAdd.stream()
+                        .map(ChatRoom::getUserId)
+                        .collect(Collectors.toSet()))
+                .stream()
+                .collect(Collectors.toMap(
+                        Users::getUserId,
+                        Users::getName,
+                        (left, right) -> left));
         
-        for (ChatRoom room : managerRooms) {
-            if (!existingRoomIds.contains(room.getChatRoomId())) {
-                // 관리자로서 읽지 않은 메시지 수 계산
-                Long unreadCount = chatMessageService.countUnreadMessages(room, userId, roleCode);
-                
-                // 사용자 이름 가져오기
-                String userName = userRepository.findById(room.getUserId())
-                    .map(user -> user.getName())
-                    .orElse("알 수 없는 사용자");
-                
-                allRooms.add(ChatRoomResponseDto.builder()
+        for (ChatRoom room : roomsToAdd) {
+            // 관리자로서 읽지 않은 메시지 수 계산
+            Long unreadCount = chatMessageService.countUnreadMessages(room, userId, roleCode);
+            String userName = userNamesById.getOrDefault(room.getUserId(), "알 수 없는 사용자");
+
+            allRooms.add(ChatRoomResponseDto.builder()
                     .chatRoomId(room.getChatRoomId())
                     .eventId(room.getEventId())
                     .userId(room.getUserId())
@@ -117,7 +124,6 @@ public class ChatRestController {
                     .userName(userName)
                     .unreadCount(unreadCount)
                     .build());
-            }
         }
     }
 

--- a/src/main/java/com/fairing/fairplay/chat/controller/ChatRestController.java
+++ b/src/main/java/com/fairing/fairplay/chat/controller/ChatRestController.java
@@ -48,7 +48,7 @@ public class ChatRestController {
         
         // 사용자가 참여한 채팅방 추가
         for (ChatRoom room : userRooms) {
-            Long unreadCount = chatMessageService.countUnreadMessages(room.getChatRoomId(), userId);
+            Long unreadCount = chatMessageService.countUnreadMessages(room, userId, userRole);
             allRooms.add(ChatRoomResponseDto.builder()
                     .chatRoomId(room.getChatRoomId())
                     .eventId(room.getEventId())
@@ -68,17 +68,17 @@ public class ChatRestController {
         if ("ADMIN".equals(userRole)) {
             // 전체 관리자: 모든 ADMIN 타입 채팅방 (1:N 구조)
             List<ChatRoom> adminRooms = chatRoomService.getAllAdminRooms();
-            addManagerRooms(allRooms, adminRooms, userId);
+            addManagerRooms(allRooms, adminRooms, userId, userRole);
             
         } else if ("EVENT_MANAGER".equals(userRole)) {
             // 행사 담당자: 자신이 담당하는 EVENT_MANAGER 타입 채팅방
             List<ChatRoom> eventManagerRooms = chatRoomService.getRoomsByManager(TargetType.EVENT_MANAGER, userId);
-            addManagerRooms(allRooms, eventManagerRooms, userId);
+            addManagerRooms(allRooms, eventManagerRooms, userId, userRole);
             
         } else if ("BOOTH_MANAGER".equals(userRole)) {
             // 부스 담당자: 자신이 담당하는 BOOTH_MANAGER 타입 채팅방
             List<ChatRoom> boothManagerRooms = chatRoomService.getRoomsByManager(TargetType.BOOTH_MANAGER, userId);
-            addManagerRooms(allRooms, boothManagerRooms, userId);
+            addManagerRooms(allRooms, boothManagerRooms, userId, userRole);
         }
         
         return allRooms.stream()
@@ -88,7 +88,7 @@ public class ChatRestController {
     }
     
     // 관리자 채팅방을 추가하는 헬퍼 메소드
-    private void addManagerRooms(List<ChatRoomResponseDto> allRooms, List<ChatRoom> managerRooms, Long userId) {
+    private void addManagerRooms(List<ChatRoomResponseDto> allRooms, List<ChatRoom> managerRooms, Long userId, String roleCode) {
         Set<Long> existingRoomIds = allRooms.stream()
                 .map(ChatRoomResponseDto::getChatRoomId)
                 .collect(Collectors.toSet());
@@ -96,7 +96,7 @@ public class ChatRestController {
         for (ChatRoom room : managerRooms) {
             if (!existingRoomIds.contains(room.getChatRoomId())) {
                 // 관리자로서 읽지 않은 메시지 수 계산
-                Long unreadCount = chatMessageService.countUnreadMessages(room.getChatRoomId(), userId);
+                Long unreadCount = chatMessageService.countUnreadMessages(room, userId, roleCode);
                 
                 // 사용자 이름 가져오기
                 String userName = userRepository.findById(room.getUserId())
@@ -156,7 +156,7 @@ public class ChatRestController {
                         .orElse("알 수 없는 사용자");
                     
                     // 읽지 않은 메시지 수 계산
-                    Long unreadCount = chatMessageService.countUnreadMessages(room.getChatRoomId(), targetId);
+                    Long unreadCount = chatMessageService.countUnreadMessages(room, targetId, userDetails.getRoleCode());
                     
                     return ChatRoomResponseDto.builder()
                         .chatRoomId(room.getChatRoomId())
@@ -207,7 +207,7 @@ public class ChatRestController {
             @RequestParam Long chatRoomId,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        return chatMessageService.getMessages(chatRoomId, userDetails.getUserId());
+        return chatMessageService.getMessages(chatRoomId, userDetails.getUserId(), userDetails.getRoleCode());
     }
 
     // 페이징된 메시지 조회 (페이지 기반)
@@ -218,7 +218,7 @@ public class ChatRestController {
             @RequestParam(defaultValue = "20") int size,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        return chatMessageService.getMessagesPaged(chatRoomId, userDetails.getUserId(), page, size);
+        return chatMessageService.getMessagesPaged(chatRoomId, userDetails.getUserId(), userDetails.getRoleCode(), page, size);
     }
 
     // 커서 기반 무한스크롤 메시지 조회
@@ -229,7 +229,7 @@ public class ChatRestController {
             @RequestParam(defaultValue = "20") int size,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        return chatMessageService.getMessagesWithCursor(chatRoomId, userDetails.getUserId(), lastMessageId, size);
+        return chatMessageService.getMessagesWithCursor(chatRoomId, userDetails.getUserId(), userDetails.getRoleCode(), lastMessageId, size);
     }
 
     // 메시지 전송
@@ -239,7 +239,7 @@ public class ChatRestController {
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long senderId = userDetails.getUserId();
-        return chatMessageService.sendMessage(dto.getChatRoomId(), senderId, dto.getContent());
+        return chatMessageService.sendMessage(dto.getChatRoomId(), senderId, userDetails.getRoleCode(), dto.getContent());
     }
 
     // 안읽은 메시지 개수
@@ -249,7 +249,7 @@ public class ChatRestController {
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long myUserId = userDetails.getUserId();
-        return chatMessageService.countUnreadMessages(chatRoomId, myUserId);
+        return chatMessageService.countUnreadMessages(chatRoomId, myUserId, userDetails.getRoleCode());
     }
 
     // 채팅방의 모든 메시지를 읽음으로 처리
@@ -259,7 +259,7 @@ public class ChatRestController {
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long myUserId = userDetails.getUserId();
-        chatMessageService.markRoomMessagesAsRead(chatRoomId, myUserId);
+        chatMessageService.markRoomMessagesAsRead(chatRoomId, myUserId, userDetails.getRoleCode());
     }
 
     // 👉 이벤트 담당자 문의용 API

--- a/src/main/java/com/fairing/fairplay/chat/service/ChatMessageService.java
+++ b/src/main/java/com/fairing/fairplay/chat/service/ChatMessageService.java
@@ -13,7 +13,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -34,26 +33,34 @@ public class ChatMessageService {
     private final ApplicationEventPublisher eventPublisher;
     private final ChatCacheService chatCacheService;
     private final Executor chatCacheExecutor;
+    private final ChatRoomAccessService chatRoomAccessService;
 
     public ChatMessageService(
             ChatMessageRepository chatMessageRepository,
             ChatRoomRepository chatRoomRepository,
             ApplicationEventPublisher eventPublisher,
             ChatCacheService chatCacheService,
-            @Qualifier("chatCacheTaskExecutor") Executor chatCacheExecutor
+            @Qualifier("chatCacheTaskExecutor") Executor chatCacheExecutor,
+            ChatRoomAccessService chatRoomAccessService
     ) {
         this.chatMessageRepository = chatMessageRepository;
         this.chatRoomRepository = chatRoomRepository;
         this.eventPublisher = eventPublisher;
         this.chatCacheService = chatCacheService;
         this.chatCacheExecutor = chatCacheExecutor;
+        this.chatRoomAccessService = chatRoomAccessService;
     }
 
     @Transactional
     public ChatMessageResponseDto sendMessage(Long chatRoomId, Long senderId, String content) {
+        return sendMessage(chatRoomId, senderId, null, content);
+    }
+
+    @Transactional
+    public ChatMessageResponseDto sendMessage(Long chatRoomId, Long senderId, String roleCode, String content) {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
-        assertRoomParticipant(chatRoom, senderId, "채팅방에 참여하지 않은 사용자는 메시지를 보낼 수 없습니다.");
+        chatRoomAccessService.assertCanAccess(chatRoom, senderId, roleCode, "채팅방에 참여하지 않은 사용자는 메시지를 보낼 수 없습니다.");
 
         ChatMessage message = ChatMessage.builder()
                 .chatRoom(chatRoom)
@@ -88,22 +95,16 @@ public class ChatMessageService {
         return responseDto;
     }
 
-    private void assertRoomParticipant(ChatRoom chatRoom, Long userId, String message) {
-        if (userId == null) {
-            throw new AccessDeniedException("인증된 사용자만 채팅방에 접근할 수 있습니다.");
-        }
-        if (userId.equals(chatRoom.getUserId()) || userId.equals(chatRoom.getTargetId())) {
-            return;
-        }
-        throw new AccessDeniedException(message);
+    public List<ChatMessageResponseDto> getMessages(Long chatRoomId, Long viewerId) {
+        return getMessages(chatRoomId, viewerId, null);
     }
 
-    public List<ChatMessageResponseDto> getMessages(Long chatRoomId, Long viewerId) {
+    public List<ChatMessageResponseDto> getMessages(Long chatRoomId, Long viewerId, String roleCode) {
         // 먼저 Redis 캐시에서 확인
         List<ChatMessageResponseDto> cachedMessages = chatCacheService.getCachedMessages(chatRoomId);
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
-        assertRoomParticipant(chatRoom, viewerId, "채팅방에 참여하지 않은 사용자는 메시지를 읽을 수 없습니다.");
+        chatRoomAccessService.assertCanAccess(chatRoom, viewerId, roleCode, "채팅방에 참여하지 않은 사용자는 메시지를 읽을 수 없습니다.");
 
         if (!cachedMessages.isEmpty()) {
             System.out.println("Redis 캐시에서 메시지 조회: roomId=" + chatRoomId + ", count=" + cachedMessages.size());
@@ -141,9 +142,13 @@ public class ChatMessageService {
      * @return 페이징된 메시지 응답
      */
     public ChatMessagePageResponseDto getMessagesPaged(Long chatRoomId, Long viewerId, int page, int size) {
+        return getMessagesPaged(chatRoomId, viewerId, null, page, size);
+    }
+
+    public ChatMessagePageResponseDto getMessagesPaged(Long chatRoomId, Long viewerId, String roleCode, int page, int size) {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
-        assertRoomParticipant(chatRoom, viewerId, "채팅방에 참여하지 않은 사용자는 메시지를 읽을 수 없습니다.");
+        chatRoomAccessService.assertCanAccess(chatRoom, viewerId, roleCode, "채팅방에 참여하지 않은 사용자는 메시지를 읽을 수 없습니다.");
         
         Pageable pageable = PageRequest.of(page, size);
         Page<ChatMessage> messagePage = chatMessageRepository.findByChatRoomOrderBySentAtDesc(chatRoom, pageable);
@@ -185,9 +190,13 @@ public class ChatMessageService {
      * @return 페이징된 메시지 응답
      */
     public ChatMessagePageResponseDto getMessagesWithCursor(Long chatRoomId, Long viewerId, Long lastMessageId, int size) {
+        return getMessagesWithCursor(chatRoomId, viewerId, null, lastMessageId, size);
+    }
+
+    public ChatMessagePageResponseDto getMessagesWithCursor(Long chatRoomId, Long viewerId, String roleCode, Long lastMessageId, int size) {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
-        assertRoomParticipant(chatRoom, viewerId, "채팅방에 참여하지 않은 사용자는 메시지를 읽을 수 없습니다.");
+        chatRoomAccessService.assertCanAccess(chatRoom, viewerId, roleCode, "채팅방에 참여하지 않은 사용자는 메시지를 읽을 수 없습니다.");
         
         Pageable pageable = PageRequest.of(0, size);
         Page<ChatMessage> messagePage;
@@ -242,16 +251,25 @@ public class ChatMessageService {
     }
 
     public Long countUnreadMessages(Long chatRoomId, Long myUserId) {
+        return countUnreadMessages(chatRoomId, myUserId, null);
+    }
+
+    public Long countUnreadMessages(Long chatRoomId, Long myUserId, String roleCode) {
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+        return countUnreadMessages(chatRoom, myUserId, roleCode);
+    }
+
+    public Long countUnreadMessages(ChatRoom chatRoom, Long myUserId, String roleCode) {
+        chatRoomAccessService.assertCanAccess(chatRoom, myUserId, roleCode, "채팅방에 참여하지 않은 사용자는 읽지 않은 메시지 수를 볼 수 없습니다.");
+        Long chatRoomId = chatRoom.getChatRoomId();
+
         // 먼저 Redis 캐시에서 확인
         Long cachedCount = chatCacheService.getCachedUnreadCount(chatRoomId, myUserId);
         if (cachedCount != null) {
             return cachedCount;
         }
-        
-        // 캐시가 없으면 DB에서 조회하고 캐싱
-        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
-                .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
-        assertRoomParticipant(chatRoom, myUserId, "채팅방에 참여하지 않은 사용자는 읽지 않은 메시지 수를 볼 수 없습니다.");
+
         Long count = chatMessageRepository.countByChatRoomAndIsReadFalseAndSenderIdNot(chatRoom, myUserId);
         
         // 결과를 Redis에 캐싱
@@ -262,9 +280,14 @@ public class ChatMessageService {
 
     @Transactional
     public void markRoomMessagesAsRead(Long chatRoomId, Long myUserId) {
+        markRoomMessagesAsRead(chatRoomId, myUserId, null);
+    }
+
+    @Transactional
+    public void markRoomMessagesAsRead(Long chatRoomId, Long myUserId, String roleCode) {
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
-        assertRoomParticipant(chatRoom, myUserId, "채팅방에 참여하지 않은 사용자는 메시지를 읽음 처리할 수 없습니다.");
+        chatRoomAccessService.assertCanAccess(chatRoom, myUserId, roleCode, "채팅방에 참여하지 않은 사용자는 메시지를 읽음 처리할 수 없습니다.");
         
         // 내가 보낸 메시지가 아닌 읽지 않은 메시지들을 읽음으로 처리
         List<ChatMessage> unreadMessages = chatMessageRepository.findByChatRoomAndIsReadFalseAndSenderIdNot(chatRoom, myUserId);

--- a/src/main/java/com/fairing/fairplay/chat/service/ChatRoomAccessService.java
+++ b/src/main/java/com/fairing/fairplay/chat/service/ChatRoomAccessService.java
@@ -1,0 +1,50 @@
+package com.fairing.fairplay.chat.service;
+
+import com.fairing.fairplay.chat.entity.ChatRoom;
+import com.fairing.fairplay.chat.entity.TargetType;
+import com.fairing.fairplay.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomAccessService {
+
+    private static final String ADMIN_ROLE = "ADMIN";
+
+    private final UserRepository userRepository;
+
+    public void assertCanAccess(ChatRoom chatRoom, Long userId, String roleCode, String message) {
+        if (!canAccess(chatRoom, userId, roleCode)) {
+            throw new AccessDeniedException(userId == null
+                    ? "인증된 사용자만 채팅방에 접근할 수 있습니다."
+                    : message);
+        }
+    }
+
+    public boolean canAccess(ChatRoom chatRoom, Long userId) {
+        return canAccess(chatRoom, userId, null);
+    }
+
+    public boolean canAccess(ChatRoom chatRoom, Long userId, String roleCode) {
+        if (chatRoom == null || userId == null) {
+            return false;
+        }
+
+        if (userId.equals(chatRoom.getUserId()) || userId.equals(chatRoom.getTargetId())) {
+            return true;
+        }
+
+        return TargetType.ADMIN.equals(chatRoom.getTargetType()) && isAdmin(userId, roleCode);
+    }
+
+    private boolean isAdmin(Long userId, String roleCode) {
+        if (ADMIN_ROLE.equals(roleCode)) {
+            return true;
+        }
+        return !userRepository.findByUserIdInAndRoleCode_Code(Set.of(userId), ADMIN_ROLE).isEmpty();
+    }
+}

--- a/src/main/java/com/fairing/fairplay/chat/service/ChatRoomAccessService.java
+++ b/src/main/java/com/fairing/fairplay/chat/service/ChatRoomAccessService.java
@@ -42,8 +42,8 @@ public class ChatRoomAccessService {
     }
 
     private boolean isAdmin(Long userId, String roleCode) {
-        if (ADMIN_ROLE.equals(roleCode)) {
-            return true;
+        if (roleCode != null) {
+            return ADMIN_ROLE.equals(roleCode);
         }
         return !userRepository.findByUserIdInAndRoleCode_Code(Set.of(userId), ADMIN_ROLE).isEmpty();
     }

--- a/src/main/java/com/fairing/fairplay/chat/websocket/SessionStompChannelInterceptor.java
+++ b/src/main/java/com/fairing/fairplay/chat/websocket/SessionStompChannelInterceptor.java
@@ -2,6 +2,7 @@ package com.fairing.fairplay.chat.websocket;
 
 import com.fairing.fairplay.chat.entity.ChatRoom;
 import com.fairing.fairplay.chat.repository.ChatRoomRepository;
+import com.fairing.fairplay.chat.service.ChatRoomAccessService;
 import com.fairing.fairplay.core.service.SessionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +31,7 @@ public class SessionStompChannelInterceptor implements ChannelInterceptor {
 
     private final SessionService sessionService;
     private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomAccessService chatRoomAccessService;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -123,7 +125,7 @@ public class SessionStompChannelInterceptor implements ChannelInterceptor {
 
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new AccessDeniedException("Chat room not found."));
-        if (userId.equals(chatRoom.getUserId()) || userId.equals(chatRoom.getTargetId())) {
+        if (chatRoomAccessService.canAccess(chatRoom, userId)) {
             return;
         }
         log.warn("STOMP SUBSCRIBE denied. userId={}, destination={}", userId, destination);

--- a/src/main/java/com/fairing/fairplay/user/repository/UserRepository.java
+++ b/src/main/java/com/fairing/fairplay/user/repository/UserRepository.java
@@ -1,13 +1,8 @@
 package com.fairing.fairplay.user.repository;
 
-import java.util.List;
-import java.util.Optional;
-
+import com.fairing.fairplay.user.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.stereotype.Repository;
-
-import com.fairing.fairplay.user.entity.Users;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
@@ -29,7 +24,7 @@ public interface UserRepository extends JpaRepository<Users, Long> {
 
     @Query("SELECT u FROM Users u WHERE u.roleCode.id <= 2")
     List<Users> findAdmin();
-    
+
     // ADMIN 권한을 가진 사용자들을 조회하여 첫 번째 사용자 반환
     @Query("SELECT u FROM Users u WHERE u.roleCode.code = :roleCode ORDER BY u.userId ASC")
     List<Users> findByRoleCodeCodeOrderByUserIdAsc(@Param("roleCode") String roleCode);

--- a/src/test/java/com/fairing/fairplay/chat/controller/ChatRestControllerTest.java
+++ b/src/test/java/com/fairing/fairplay/chat/controller/ChatRestControllerTest.java
@@ -13,10 +13,10 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -46,7 +46,7 @@ class ChatRestControllerTest {
         when(chatRoomService.getRoomsByUser(10L)).thenReturn(List.of());
         when(chatRoomService.getAllAdminRooms()).thenReturn(List.of(adminInquiryRoom));
         when(chatMessageService.countUnreadMessages(adminInquiryRoom, 10L, "ADMIN")).thenReturn(3L);
-        when(userRepository.findById(1092L)).thenReturn(Optional.of(Users.builder()
+        when(userRepository.findAllById(java.util.Set.of(1092L))).thenReturn(List.of(Users.builder()
                 .userId(1092L)
                 .name("문의자")
                 .build()));
@@ -61,5 +61,6 @@ class ChatRestControllerTest {
         assertThat(room.getUserName()).isEqualTo("문의자");
         assertThat(room.getUnreadCount()).isEqualTo(3L);
         verify(chatMessageService).countUnreadMessages(adminInquiryRoom, 10L, "ADMIN");
+        verify(userRepository, never()).findById(1092L);
     }
 }

--- a/src/test/java/com/fairing/fairplay/chat/controller/ChatRestControllerTest.java
+++ b/src/test/java/com/fairing/fairplay/chat/controller/ChatRestControllerTest.java
@@ -1,0 +1,65 @@
+package com.fairing.fairplay.chat.controller;
+
+import com.fairing.fairplay.chat.dto.ChatRoomResponseDto;
+import com.fairing.fairplay.chat.entity.ChatRoom;
+import com.fairing.fairplay.chat.entity.TargetType;
+import com.fairing.fairplay.chat.service.ChatEventHelperService;
+import com.fairing.fairplay.chat.service.ChatMessageService;
+import com.fairing.fairplay.chat.service.ChatRoomService;
+import com.fairing.fairplay.core.security.CustomUserDetails;
+import com.fairing.fairplay.user.entity.Users;
+import com.fairing.fairplay.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ChatRestControllerTest {
+
+    private final ChatRoomService chatRoomService = mock(ChatRoomService.class);
+    private final ChatMessageService chatMessageService = mock(ChatMessageService.class);
+    private final ChatEventHelperService chatEventHelperService = mock(ChatEventHelperService.class);
+    private final UserRepository userRepository = mock(UserRepository.class);
+    private final ChatRestController controller = new ChatRestController(
+            chatRoomService,
+            chatMessageService,
+            chatEventHelperService,
+            userRepository);
+
+    @Test
+    void adminRoomListIncludesAdminInquiryWhenAdminIsNotStoredTargetUser() {
+        CustomUserDetails admin = CustomUserDetails.fromSession(10L, "admin@example.com", "ADMIN", 1);
+        ChatRoom adminInquiryRoom = ChatRoom.builder()
+                .chatRoomId(45L)
+                .userId(1092L)
+                .targetType(TargetType.ADMIN)
+                .targetId(1L)
+                .createdAt(LocalDateTime.of(2026, 5, 27, 16, 37))
+                .build();
+
+        when(chatRoomService.getRoomsByUser(10L)).thenReturn(List.of());
+        when(chatRoomService.getAllAdminRooms()).thenReturn(List.of(adminInquiryRoom));
+        when(chatMessageService.countUnreadMessages(adminInquiryRoom, 10L, "ADMIN")).thenReturn(3L);
+        when(userRepository.findById(1092L)).thenReturn(Optional.of(Users.builder()
+                .userId(1092L)
+                .name("문의자")
+                .build()));
+
+        List<ChatRoomResponseDto> rooms = controller.getMyChatRooms(admin);
+
+        assertThat(rooms).hasSize(1);
+        ChatRoomResponseDto room = rooms.get(0);
+        assertThat(room.getChatRoomId()).isEqualTo(45L);
+        assertThat(room.getTargetType()).isEqualTo("ADMIN");
+        assertThat(room.getTargetId()).isEqualTo(1L);
+        assertThat(room.getUserName()).isEqualTo("문의자");
+        assertThat(room.getUnreadCount()).isEqualTo(3L);
+        verify(chatMessageService).countUnreadMessages(adminInquiryRoom, 10L, "ADMIN");
+    }
+}

--- a/src/test/java/com/fairing/fairplay/chat/service/ChatMessageServiceEventContractTest.java
+++ b/src/test/java/com/fairing/fairplay/chat/service/ChatMessageServiceEventContractTest.java
@@ -6,10 +6,11 @@ import com.fairing.fairplay.chat.entity.TargetType;
 import com.fairing.fairplay.chat.event.ChatMessageCreatedEvent;
 import com.fairing.fairplay.chat.repository.ChatMessageRepository;
 import com.fairing.fairplay.chat.repository.ChatRoomRepository;
+import com.fairing.fairplay.user.repository.UserRepository;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
@@ -46,8 +47,24 @@ class ChatMessageServiceEventContractTest {
     @Mock
     Executor chatCacheExecutor;
 
-    @InjectMocks
+    @Mock
+    UserRepository userRepository;
+
+    ChatRoomAccessService chatRoomAccessService;
+
     ChatMessageService chatMessageService;
+
+    @BeforeEach
+    void setUp() {
+        chatRoomAccessService = new ChatRoomAccessService(userRepository);
+        chatMessageService = new ChatMessageService(
+                chatMessageRepository,
+                chatRoomRepository,
+                eventPublisher,
+                chatCacheService,
+                chatCacheExecutor,
+                chatRoomAccessService);
+    }
 
     @Test
     void publishesSavedUserMessageIdentityAndContentInCreatedEvent() {

--- a/src/test/java/com/fairing/fairplay/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/fairing/fairplay/chat/service/ChatMessageServiceTest.java
@@ -5,13 +5,17 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.fairing.fairplay.chat.entity.ChatRoom;
+import com.fairing.fairplay.chat.entity.TargetType;
 import com.fairing.fairplay.chat.repository.ChatMessageRepository;
 import com.fairing.fairplay.chat.repository.ChatRoomRepository;
+import com.fairing.fairplay.user.repository.UserRepository;
 import java.util.Collections;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.access.AccessDeniedException;
+
+import static org.mockito.ArgumentMatchers.any;
 
 class ChatMessageServiceTest {
 
@@ -19,12 +23,15 @@ class ChatMessageServiceTest {
     private final ChatRoomRepository chatRoomRepository = mock(ChatRoomRepository.class);
     private final ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
     private final ChatCacheService chatCacheService = mock(ChatCacheService.class);
+    private final UserRepository userRepository = mock(UserRepository.class);
+    private final ChatRoomAccessService chatRoomAccessService = new ChatRoomAccessService(userRepository);
     private final ChatMessageService chatMessageService = new ChatMessageService(
             chatMessageRepository,
             chatRoomRepository,
             eventPublisher,
             chatCacheService,
-            Runnable::run);
+            Runnable::run,
+            chatRoomAccessService);
 
     @Test
     void rejectsMessageReadForNonParticipant() {
@@ -43,11 +50,44 @@ class ChatMessageServiceTest {
                 .isInstanceOf(AccessDeniedException.class);
     }
 
+    @Test
+    void allowsAdminRoleToReadAdminInquiryWhenNotStoredTarget() {
+        when(chatRoomRepository.findById(123L)).thenReturn(Optional.of(chatRoom(1092L, 1L, TargetType.ADMIN)));
+        when(chatCacheService.getCachedMessages(123L)).thenReturn(Collections.emptyList());
+        when(chatMessageRepository.findByChatRoomOrderBySentAtAsc(any(ChatRoom.class)))
+                .thenReturn(Collections.emptyList());
+
+        chatMessageService.getMessages(123L, 10L, "ADMIN");
+    }
+
+    @Test
+    void rejectsNonAdminRoleForAdminInquiryWhenNotParticipant() {
+        when(chatRoomRepository.findById(123L)).thenReturn(Optional.of(chatRoom(1092L, 1L, TargetType.ADMIN)));
+        when(chatCacheService.getCachedMessages(123L)).thenReturn(Collections.emptyList());
+
+        assertThatThrownBy(() -> chatMessageService.getMessages(123L, 10L, "COMMON"))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void rejectsUnreadCountForNonParticipantEvenWhenCached() {
+        when(chatRoomRepository.findById(123L)).thenReturn(Optional.of(chatRoom(10L, 20L)));
+        when(chatCacheService.getCachedUnreadCount(123L, 30L)).thenReturn(7L);
+
+        assertThatThrownBy(() -> chatMessageService.countUnreadMessages(123L, 30L))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
     private ChatRoom chatRoom(Long userId, Long targetId) {
+        return chatRoom(userId, targetId, TargetType.AI);
+    }
+
+    private ChatRoom chatRoom(Long userId, Long targetId, TargetType targetType) {
         return ChatRoom.builder()
                 .chatRoomId(123L)
                 .userId(userId)
                 .targetId(targetId)
+                .targetType(targetType)
                 .build();
     }
 }

--- a/src/test/java/com/fairing/fairplay/chat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/fairing/fairplay/chat/service/ChatMessageServiceTest.java
@@ -2,6 +2,8 @@ package com.fairing.fairplay.chat.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fairing.fairplay.chat.entity.ChatRoom;
@@ -67,6 +69,7 @@ class ChatMessageServiceTest {
 
         assertThatThrownBy(() -> chatMessageService.getMessages(123L, 10L, "COMMON"))
                 .isInstanceOf(AccessDeniedException.class);
+        verify(userRepository, never()).findByUserIdInAndRoleCode_Code(java.util.Set.of(10L), "ADMIN");
     }
 
     @Test

--- a/src/test/java/com/fairing/fairplay/chat/websocket/SessionStompChannelInterceptorTest.java
+++ b/src/test/java/com/fairing/fairplay/chat/websocket/SessionStompChannelInterceptorTest.java
@@ -6,8 +6,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.fairing.fairplay.chat.entity.ChatRoom;
+import com.fairing.fairplay.chat.entity.TargetType;
 import com.fairing.fairplay.chat.repository.ChatRoomRepository;
+import com.fairing.fairplay.chat.service.ChatRoomAccessService;
 import com.fairing.fairplay.core.service.SessionService;
+import com.fairing.fairplay.user.repository.UserRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.messaging.Message;
@@ -19,8 +22,10 @@ import org.springframework.security.access.AccessDeniedException;
 class SessionStompChannelInterceptorTest {
 
     private final ChatRoomRepository chatRoomRepository = mock(ChatRoomRepository.class);
+    private final UserRepository userRepository = mock(UserRepository.class);
+    private final ChatRoomAccessService chatRoomAccessService = new ChatRoomAccessService(userRepository);
     private final SessionStompChannelInterceptor interceptor =
-            new SessionStompChannelInterceptor(mock(SessionService.class), chatRoomRepository);
+            new SessionStompChannelInterceptor(mock(SessionService.class), chatRoomRepository, chatRoomAccessService);
 
     @Test
     void rejectsUnauthenticatedAppSend() {
@@ -72,6 +77,17 @@ class SessionStompChannelInterceptorTest {
                 .doesNotThrowAnyException();
     }
 
+    @Test
+    void allowsAdminSubscribeToAdminInquiryWhenNotStoredTarget() {
+        when(chatRoomRepository.findById(123L)).thenReturn(Optional.of(adminInquiryRoom(1092L, 1L)));
+        when(userRepository.findByUserIdInAndRoleCode_Code(java.util.Set.of(10L), "ADMIN"))
+                .thenReturn(java.util.List.of(mock(com.fairing.fairplay.user.entity.Users.class)));
+        Message<byte[]> message = stompMessage(StompCommand.SUBSCRIBE, "/topic/chat.123", new StompPrincipal("10"));
+
+        assertThatCode(() -> interceptor.preSend(message, null))
+                .doesNotThrowAnyException();
+    }
+
     private Message<byte[]> stompMessage(StompCommand command, String destination, StompPrincipal principal) {
         StompHeaderAccessor accessor = StompHeaderAccessor.create(command);
         accessor.setDestination(destination);
@@ -83,6 +99,15 @@ class SessionStompChannelInterceptorTest {
         return ChatRoom.builder()
                 .chatRoomId(123L)
                 .userId(userId)
+                .targetId(targetId)
+                .build();
+    }
+
+    private ChatRoom adminInquiryRoom(Long userId, Long targetId) {
+        return ChatRoom.builder()
+                .chatRoomId(123L)
+                .userId(userId)
+                .targetType(TargetType.ADMIN)
                 .targetId(targetId)
                 .build();
     }


### PR DESCRIPTION
## Summary
- centralize chat room access checks in ChatRoomAccessService
- allow ADMIN users to access ADMIN inquiry rooms even when they are not the stored target user
- check unread-count authorization before cache hits and cover the /api/chat/rooms list path

## Root cause
ADMIN inquiry rooms are stored with a representative target user, but the room list intentionally loads all ADMIN inquiry rooms for every ADMIN account. Existing message/unread/STOMP checks only accepted room.userId or room.targetId, so admins other than the stored target could receive 403s when unread counts were recalculated.

## Verification
- ./gradlew test --tests com.fairing.fairplay.chat.controller.ChatRestControllerTest --tests com.fairing.fairplay.chat.service.ChatMessageServiceTest --tests com.fairing.fairplay.chat.websocket.SessionStompChannelInterceptorTest --tests com.fairing.fairplay.chat.service.ChatMessageServiceEventContractTest
- ./gradlew clean test --no-daemon
- git diff --check

## Review
- code-reviewer found one Important gap: the actual /api/chat/rooms list path lacked direct coverage
- added ChatRestControllerTest to cover that path

## Not tested
- live authenticated browser/API smoke after deployment