### PR TITLE
Fix login role lookup session authentication

### DIFF
--- a/src/main/java/com/fairing/fairplay/core/security/SessionAuthenticationFilter.java
+++ b/src/main/java/com/fairing/fairplay/core/security/SessionAuthenticationFilter.java
@@ -32,7 +32,6 @@ public class SessionAuthenticationFilter extends OncePerRequestFilter {
 
     private static final List<String> PUBLIC_PATHS = Arrays.asList(
         "/api/creators",
-        "/api/events",
         "/api/banners",
         "/api/reviews",
         "/api/calendar",
@@ -127,7 +126,22 @@ public class SessionAuthenticationFilter extends OncePerRequestFilter {
      */
     private boolean shouldSkipAuthentication(String method, String requestURI) {
         return "GET".equalsIgnoreCase(method)
-                && PUBLIC_PATHS.stream().anyMatch(requestURI::startsWith);
+                && (PUBLIC_PATHS.stream().anyMatch(requestURI::startsWith)
+                || isPublicEventGetPath(requestURI));
+    }
+
+    private boolean isPublicEventGetPath(String requestURI) {
+        if ("/api/events".equals(requestURI)
+                || "/api/events/hot-picks".equals(requestURI)
+                || "/api/events/apply/check".equals(requestURI)) {
+            return true;
+        }
+
+        return requestURI.matches("^/api/events/[^/]+/details$")
+                || requestURI.matches("^/api/events/[^/]+/booths(?:/.*)?$")
+                || requestURI.matches("^/api/events/[^/]+/schedule$")
+                || requestURI.matches("^/api/events/[^/]+/tickets$")
+                || requestURI.matches("^/api/events/schedule/[^/]+/tickets$");
     }
 
     private String stringValue(Object value) {

--- a/src/test/java/com/fairing/fairplay/core/security/SessionAuthenticationFilterTest.java
+++ b/src/test/java/com/fairing/fairplay/core/security/SessionAuthenticationFilterTest.java
@@ -116,4 +116,39 @@ class SessionAuthenticationFilterTest {
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
         verify(sessionService, never()).getSessionData("session-1");
     }
+
+    @Test
+    void authenticatesProtectedEventRoleLookupEvenThoughItIsAGetRequest() throws Exception {
+        when(sessionService.getSessionData("session-1")).thenReturn(Map.of(
+                "userId", 10,
+                "email", "admin@example.com",
+                "role", "ADMIN",
+                "roleId", 1
+        ));
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/events/user/role");
+        request.setCookies(new Cookie("FAIRPLAY_SESSION", "session-1"));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        new SessionAuthenticationFilter(sessionService)
+                .doFilter(request, response, new MockFilterChain());
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication).isNotNull();
+        assertThat(((CustomUserDetails) authentication.getPrincipal()).getUserId()).isEqualTo(10L);
+        verify(sessionService).getSessionData("session-1");
+    }
+
+    @Test
+    void skipsRedisSessionLookupOnlyForKnownPublicEventGetPathsWhenCookieExists() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/events/32/details");
+        request.setCookies(new Cookie("FAIRPLAY_SESSION", "session-1"));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        new SessionAuthenticationFilter(sessionService)
+                .doFilter(request, response, new MockFilterChain());
+
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(sessionService, never()).getSessionData("session-1");
+    }
 }


### PR DESCRIPTION
## Summary
- Narrow SessionAuthenticationFilter public GET skips so /api/events/user/role still authenticates from FAIRPLAY_SESSION
- Keep Redis lookup skip for known anonymous event reads such as event list/details/hot-picks
- Add regression tests for protected event role lookup and public event details

## Root cause
Login succeeded and wrote login_history, but the frontend immediately calls GET /api/events/user/role. The filter treated every GET path starting with /api/events as public and skipped Redis session lookup, leaving @AuthenticationPrincipal null.

## Verification
- ./gradlew test --tests com.fairing.fairplay.core.security.SessionAuthenticationFilterTest --tests com.fairing.fairplay.core.config.SecurityConfigPublicSurfaceTest --no-daemon

Not-tested: production browser login smoke before this PR is deployed.