### PR TITLE
Promote SPA ticket route fallback to main

### DIFF
--- a/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
+++ b/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
@@ -82,6 +82,7 @@ public class SecurityConfig {
                                 "/booth-admin/**",
                                 "/events/**",
                                 "/eventdetail/**",
+                                "/ticket-reservation/**",
                                 "/qr-ticket/**",
                                 "/banner/payment",
                                 "/auth/**",

--- a/src/main/java/com/fairing/fairplay/core/controller/SpaForwardController.java
+++ b/src/main/java/com/fairing/fairplay/core/controller/SpaForwardController.java
@@ -16,7 +16,8 @@ public class SpaForwardController {
         "/login",
         "/register",
         "/eventoverview",
-        "/event-registration-intro"
+        "/event-registration-intro",
+        "/ticket-reservation/**"
     }, produces = "text/html")
     public String forward() {
         return "forward:/index.html";

--- a/src/test/java/com/fairing/fairplay/core/controller/SpaForwardControllerTest.java
+++ b/src/test/java/com/fairing/fairplay/core/controller/SpaForwardControllerTest.java
@@ -1,0 +1,47 @@
+package com.fairing.fairplay.core.controller;
+
+import com.fairing.fairplay.core.config.SecurityConfig;
+import com.fairing.fairplay.core.service.SessionService;
+import com.fairing.fairplay.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = SpaForwardController.class)
+@Import(SecurityConfig.class)
+class SpaForwardControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SessionService sessionService;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @Test
+    void ticketReservationFrontendRouteForwardsToSpaWithoutSession() throws Exception {
+        mockMvc.perform(get("/ticket-reservation/52").accept(MediaType.TEXT_HTML))
+                .andExpect(status().isOk())
+                .andExpect(forwardedUrl("/index.html"));
+    }
+
+    @Test
+    void ticketReservationApiLikeRequestStillRequiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/reservations/mypage").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## Summary
- Promote the verified SPA ticket-reservation route fallback from develop to main.
- Keeps `/ticket-reservation/**` document requests on the React app while preserving `/api/...` authentication.

## Verification
- PR #53 backend-ci run `26531317517` passed.
- Local targeted tests passed on this promotion branch:
  - `./gradlew test --tests com.fairing.fairplay.core.controller.SpaForwardControllerTest --tests com.fairing.fairplay.core.config.SecurityConfigPublicSurfaceTest --no-daemon`

## Deploy
- Merging to main triggers `deploy-on-main`.

Co-authored-by: OmX <omx@oh-my-codex.dev>
