### PR TITLE
Fix admin banner PostgreSQL smoke failures

### DIFF
--- a/src/main/java/com/fairing/fairplay/banner/entity/BannerApplication.java
+++ b/src/main/java/com/fairing/fairplay/banner/entity/BannerApplication.java
@@ -57,7 +57,6 @@ public class BannerApplication {
     @JoinColumn(name = "status_code_id", nullable = false)
     private ApplyStatusCode statusCode;     // PENDING/APPROVED/REJECTED
 
-    @Lob
     @Column(name = "admin_comment", columnDefinition = "TEXT")
     private String adminComment;
 

--- a/src/main/java/com/fairing/fairplay/banner/repository/BannerRepository.java
+++ b/src/main/java/com/fairing/fairplay/banner/repository/BannerRepository.java
@@ -86,7 +86,7 @@ public interface BannerRepository extends JpaRepository<Banner, Long> {
             String typeCode, Long eventId, String statusCode
     );
 
-    // (NEW) VIP 검색용: 타입/상태/기간 필터 (이름 검색은 배너→이벤트 연관 없으면 생략)
+    // (NEW) VIP 검색용: 타입/상태/기간 필터
     @Query("""
 SELECT b
 FROM Banner b
@@ -95,18 +95,32 @@ WHERE (:type   IS NULL OR bt.code = :type)
   AND (:status IS NULL OR b.bannerStatusCode.code = :status)
   AND (:from   IS NULL OR b.endDate   >= :from)
   AND (:to     IS NULL OR b.startDate <= :to)
-  AND (
-        :q IS NULL
-        OR b.eventId IN (
-            SELECT e.eventId
-            FROM Event e
-            WHERE e.titleKr  LIKE CONCAT('%', :q, '%')
-               OR e.titleEng LIKE CONCAT('%', :q, '%')
-        )
-      )
 ORDER BY b.startDate DESC, b.priority ASC
 """)
     List<Banner> search(
+            @Param("type") String type,
+            @Param("status") String status,
+            @Param("from") LocalDateTime from,
+            @Param("to") LocalDateTime to
+    );
+
+    @Query("""
+SELECT b
+FROM Banner b
+JOIN b.bannerType bt
+WHERE (:type   IS NULL OR bt.code = :type)
+  AND (:status IS NULL OR b.bannerStatusCode.code = :status)
+  AND (:from   IS NULL OR b.endDate   >= :from)
+  AND (:to     IS NULL OR b.startDate <= :to)
+  AND b.eventId IN (
+      SELECT e.eventId
+      FROM Event e
+      WHERE e.titleKr  LIKE CONCAT('%', :q, '%')
+         OR e.titleEng LIKE CONCAT('%', :q, '%')
+  )
+ORDER BY b.startDate DESC, b.priority ASC
+""")
+    List<Banner> searchByEventTitle(
             @Param("type") String type,
             @Param("status") String status,
             @Param("from") LocalDateTime from,

--- a/src/main/java/com/fairing/fairplay/banner/service/BannerService.java
+++ b/src/main/java/com/fairing/fairplay/banner/service/BannerService.java
@@ -503,7 +503,11 @@ public class BannerService {
             to = tmp;
         }
 
-        return bannerRepository.search(type, status, from, to, qNorm)
+        List<Banner> banners = (qNorm == null)
+                ? bannerRepository.search(type, status, from, to)
+                : bannerRepository.searchByEventTitle(type, status, from, to, qNorm);
+
+        return banners
                 .stream()
                 .map(this::toDto)
                 .toList();

--- a/src/test/java/com/fairing/fairplay/banner/entity/BannerApplicationMappingTest.java
+++ b/src/test/java/com/fairing/fairplay/banner/entity/BannerApplicationMappingTest.java
@@ -1,0 +1,15 @@
+package com.fairing.fairplay.banner.entity;
+
+import jakarta.persistence.Lob;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BannerApplicationMappingTest {
+
+    @Test
+    void adminCommentIsPlainTextNotPostgresOidLob() throws NoSuchFieldException {
+        assertThat(BannerApplication.class.getDeclaredField("adminComment").isAnnotationPresent(Lob.class))
+                .isFalse();
+    }
+}

--- a/src/test/java/com/fairing/fairplay/banner/service/BannerServicePostgresQueryTest.java
+++ b/src/test/java/com/fairing/fairplay/banner/service/BannerServicePostgresQueryTest.java
@@ -1,0 +1,73 @@
+package com.fairing.fairplay.banner.service;
+
+import com.fairing.fairplay.banner.repository.BannerActionCodeRepository;
+import com.fairing.fairplay.banner.repository.BannerLogRepository;
+import com.fairing.fairplay.banner.repository.BannerRepository;
+import com.fairing.fairplay.banner.repository.BannerSlotRepository;
+import com.fairing.fairplay.banner.repository.BannerStatusCodeRepository;
+import com.fairing.fairplay.banner.repository.BannerTypeRepository;
+import com.fairing.fairplay.core.service.LocalFileService;
+import com.fairing.fairplay.event.repository.EventRepository;
+import com.fairing.fairplay.file.service.FileService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class BannerServicePostgresQueryTest {
+
+    @Mock
+    private BannerRepository bannerRepository;
+    @Mock
+    private BannerStatusCodeRepository bannerStatusCodeRepository;
+    @Mock
+    private BannerActionCodeRepository bannerActionCodeRepository;
+    @Mock
+    private BannerLogRepository bannerLogRepository;
+    @Mock
+    private BannerSlotRepository bannerSlotRepository;
+    @Mock
+    private FileService fileService;
+    @Mock
+    private LocalFileService localFileService;
+    @Mock
+    private BannerTypeRepository bannerTypeRepository;
+    @Mock
+    private EventRepository eventRepository;
+
+    @InjectMocks
+    private BannerService bannerService;
+
+    @Test
+    void vipSearchWithoutKeywordUsesQueryWithoutLikePredicate() {
+        LocalDateTime from = LocalDateTime.now().minusDays(1);
+        LocalDateTime to = LocalDateTime.now().plusDays(1);
+        when(bannerRepository.search("HERO", null, from, to)).thenReturn(List.of());
+
+        bannerService.searchVip("HERO", null, "   ", from, to);
+
+        verify(bannerRepository).search("HERO", null, from, to);
+        verify(bannerRepository, never()).searchByEventTitle("HERO", null, from, to, "   ");
+    }
+
+    @Test
+    void vipSearchWithKeywordUsesTitleSearchQuery() {
+        LocalDateTime from = LocalDateTime.now().minusDays(1);
+        LocalDateTime to = LocalDateTime.now().plusDays(1);
+        when(bannerRepository.searchByEventTitle("HERO", "ACTIVE", from, to, "GD")).thenReturn(List.of());
+
+        bannerService.searchVip("HERO", "ACTIVE", "GD", from, to);
+
+        verify(bannerRepository).searchByEventTitle("HERO", "ACTIVE", from, to, "GD");
+        verify(bannerRepository, never()).search("HERO", "ACTIVE", from, to);
+    }
+}


### PR DESCRIPTION
## Summary
- Split VIP banner search so blank searches avoid nullable LIKE predicates on PostgreSQL
- Map banner application admin comments as TEXT instead of Hibernate LOB/OID
- Add regression tests for both PostgreSQL-specific failure modes

## Verification
- ./gradlew test --tests com.fairing.fairplay.banner.service.BannerServicePostgresQueryTest --tests com.fairing.fairplay.banner.entity.BannerApplicationMappingTest --no-daemon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 배너 검색 기능 최적화: 이벤트 제목 검색과 기본 필터 검색을 분리하여 검색 정확도 개선

* **Tests**
  * 배너 데이터 매핑 검증 테스트 추가
  * VIP 배너 검색 쿼리 동작 검증 테스트 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rktclgh/FairPlay_BE/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->