### PR TITLE
Deploy admin banner PostgreSQL follow-up

### DIFF
--- a/src/main/java/com/fairing/fairplay/banner/repository/BannerRepository.java
+++ b/src/main/java/com/fairing/fairplay/banner/repository/BannerRepository.java
@@ -93,8 +93,8 @@ FROM Banner b
 JOIN b.bannerType bt
 WHERE (:type   IS NULL OR bt.code = :type)
   AND (:status IS NULL OR b.bannerStatusCode.code = :status)
-  AND (:from   IS NULL OR b.endDate   >= :from)
-  AND (:to     IS NULL OR b.startDate <= :to)
+  AND b.endDate   >= :from
+  AND b.startDate <= :to
 ORDER BY b.startDate DESC, b.priority ASC
 """)
     List<Banner> search(
@@ -110,8 +110,8 @@ FROM Banner b
 JOIN b.bannerType bt
 WHERE (:type   IS NULL OR bt.code = :type)
   AND (:status IS NULL OR b.bannerStatusCode.code = :status)
-  AND (:from   IS NULL OR b.endDate   >= :from)
-  AND (:to     IS NULL OR b.startDate <= :to)
+  AND b.endDate   >= :from
+  AND b.startDate <= :to
   AND b.eventId IN (
       SELECT e.eventId
       FROM Event e

--- a/src/main/java/com/fairing/fairplay/banner/service/BannerApplicationService.java
+++ b/src/main/java/com/fairing/fairplay/banner/service/BannerApplicationService.java
@@ -537,6 +537,7 @@ public class BannerApplicationService {
 
         }
     /* ===== 관리자 조회용: 목록 ===== */
+    @Transactional(readOnly = true)
     public List<AdminApplicationListItemDto> listAdminApplications(String status, String type, Pageable pageable) {
         List<BannerApplication> bannerApplications = bannerApplicationRepository.findAllWithHostInfoOrderByCreatedAtDesc();
 

--- a/src/main/java/com/fairing/fairplay/banner/service/BannerService.java
+++ b/src/main/java/com/fairing/fairplay/banner/service/BannerService.java
@@ -479,6 +479,8 @@ public class BannerService {
     }
 
     private static final String TYPE_HERO = "HERO";
+    private static final LocalDateTime VIP_SEARCH_MIN_DATE = LocalDateTime.of(1970, 1, 1, 0, 0);
+    private static final LocalDateTime VIP_SEARCH_MAX_DATE = LocalDateTime.of(9999, 12, 31, 23, 59, 59);
 
     @Transactional(readOnly = true)
     public BigDecimal sumBannerSales() {
@@ -502,10 +504,12 @@ public class BannerService {
             from = to;
             to = tmp;
         }
+        LocalDateTime fromBound = (from == null) ? VIP_SEARCH_MIN_DATE : from;
+        LocalDateTime toBound = (to == null) ? VIP_SEARCH_MAX_DATE : to;
 
         List<Banner> banners = (qNorm == null)
-                ? bannerRepository.search(type, status, from, to)
-                : bannerRepository.searchByEventTitle(type, status, from, to, qNorm);
+                ? bannerRepository.search(type, status, fromBound, toBound)
+                : bannerRepository.searchByEventTitle(type, status, fromBound, toBound, qNorm);
 
         return banners
                 .stream()

--- a/src/test/java/com/fairing/fairplay/banner/service/BannerApplicationServiceTransactionTest.java
+++ b/src/test/java/com/fairing/fairplay/banner/service/BannerApplicationServiceTransactionTest.java
@@ -1,0 +1,20 @@
+package com.fairing.fairplay.banner.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BannerApplicationServiceTransactionTest {
+
+    @Test
+    void adminApplicationListKeepsSlotMappingInsideReadOnlyTransaction() throws NoSuchMethodException {
+        Transactional transactional = BannerApplicationService.class
+                .getDeclaredMethod("listAdminApplications", String.class, String.class, Pageable.class)
+                .getAnnotation(Transactional.class);
+
+        assertThat(transactional).isNotNull();
+        assertThat(transactional.readOnly()).isTrue();
+    }
+}

--- a/src/test/java/com/fairing/fairplay/banner/service/BannerServicePostgresQueryTest.java
+++ b/src/test/java/com/fairing/fairplay/banner/service/BannerServicePostgresQueryTest.java
@@ -25,6 +25,9 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class BannerServicePostgresQueryTest {
 
+    private static final LocalDateTime VIP_SEARCH_MIN_DATE = LocalDateTime.of(1970, 1, 1, 0, 0);
+    private static final LocalDateTime VIP_SEARCH_MAX_DATE = LocalDateTime.of(9999, 12, 31, 23, 59, 59);
+
     @Mock
     private BannerRepository bannerRepository;
     @Mock
@@ -69,5 +72,14 @@ class BannerServicePostgresQueryTest {
 
         verify(bannerRepository).searchByEventTitle("HERO", "ACTIVE", from, to, "GD");
         verify(bannerRepository, never()).search("HERO", "ACTIVE", from, to);
+    }
+
+    @Test
+    void vipSearchWithoutDateFiltersUsesTypedBoundsForPostgres() {
+        when(bannerRepository.search("HERO", null, VIP_SEARCH_MIN_DATE, VIP_SEARCH_MAX_DATE)).thenReturn(List.of());
+
+        bannerService.searchVip("HERO", null, null, null, null);
+
+        verify(bannerRepository).search("HERO", null, VIP_SEARCH_MIN_DATE, VIP_SEARCH_MAX_DATE);
     }
 }


### PR DESCRIPTION
## Summary
- Apply the admin banner PostgreSQL follow-up directly on main
- Avoid nullable timestamp query parameters in VIP banner search
- Keep banner application slot DTO mapping inside a read-only transaction

## Verification
- ./gradlew test --tests com.fairing.fairplay.banner.service.BannerServicePostgresQueryTest --tests com.fairing.fairplay.banner.service.BannerApplicationServiceTransactionTest --tests com.fairing.fairplay.banner.entity.BannerApplicationMappingTest --no-daemon
- develop backend-ci 26534440266 passed