### PR TITLE
Deploy public SPA route fallback cleanup

### DIFF
--- a/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
+++ b/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
@@ -85,6 +85,8 @@ public class SecurityConfig {
                                 "/ticket-reservation/**",
                                 "/qr-ticket/**",
                                 "/banner/payment",
+                                "/support/**",
+                                "/legal/**",
                                 "/auth/**",
                                 "/api/users/signup",
                                 "/api/auth/login",
@@ -136,6 +138,8 @@ public class SecurityConfig {
                                 "/api/host/reservation/**",
                                 "/participant-form",
                                 "/participant-form/**",
+                                "/booth/payment",
+                                "/booth/payment/**",
                                 "/booth/cancel",
                                 "/booth/cancel/**",
                                 // 제작자 페이지 - 공개 접근 허용

--- a/src/main/java/com/fairing/fairplay/core/controller/SpaForwardController.java
+++ b/src/main/java/com/fairing/fairplay/core/controller/SpaForwardController.java
@@ -17,7 +17,9 @@ public class SpaForwardController {
         "/register",
         "/eventoverview",
         "/event-registration-intro",
-        "/ticket-reservation/**"
+        "/ticket-reservation/**",
+        "/support/**",
+        "/legal/**"
     }, produces = "text/html")
     public String forward() {
         return "forward:/index.html";

--- a/src/test/java/com/fairing/fairplay/core/controller/SpaForwardControllerTest.java
+++ b/src/test/java/com/fairing/fairplay/core/controller/SpaForwardControllerTest.java
@@ -40,6 +40,31 @@ class SpaForwardControllerTest {
     }
 
     @Test
+    void supportFrontendRoutesForwardToSpaWithoutSession() throws Exception {
+        mockMvc.perform(get("/support/notices").accept(MediaType.TEXT_HTML))
+                .andExpect(status().isOk())
+                .andExpect(forwardedUrl("/index.html"));
+
+        mockMvc.perform(get("/support/faq").accept(MediaType.TEXT_HTML))
+                .andExpect(status().isOk())
+                .andExpect(forwardedUrl("/index.html"));
+    }
+
+    @Test
+    void legalFrontendRoutesForwardToSpaWithoutSession() throws Exception {
+        mockMvc.perform(get("/legal/privacy").accept(MediaType.TEXT_HTML))
+                .andExpect(status().isOk())
+                .andExpect(forwardedUrl("/index.html"));
+    }
+
+    @Test
+    void boothPaymentFrontendRouteForwardsToSpaWithoutSession() throws Exception {
+        mockMvc.perform(get("/booth/payment").accept(MediaType.TEXT_HTML))
+                .andExpect(status().isOk())
+                .andExpect(forwardedUrl("/index.html"));
+    }
+
+    @Test
     void ticketReservationApiLikeRequestStillRequiresAuthentication() throws Exception {
         mockMvc.perform(get("/api/reservations/mypage").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isUnauthorized());


### PR DESCRIPTION
## Summary
- Promote the support/legal/booth payment SPA fallback fix from develop to main
- Keeps direct browser route entry from returning backend JSON 401

## Verification
- ./gradlew test --tests com.fairing.fairplay.core.controller.SpaForwardControllerTest --no-daemon
- develop PR #60 backend-ci/test pass
- develop PR #60 CodeRabbit pass