### PR TITLE
Promote auth session probe cleanup to main

### DIFF
--- a/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
+++ b/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
@@ -92,6 +92,7 @@ public class SecurityConfig {
                                 "/api/auth/login",
                                 "/api/auth/logout",
                                 "/api/auth/refresh",
+                                "/api/auth/session",
                                 "/api/events", // GET 행사 목록 조회
                                 "/api/events/*/details", // GET 행사 상세 조회 (*/details 패턴)
                                 "/api/events/hot-picks", // GET 핫픽 조회

--- a/src/main/java/com/fairing/fairplay/core/controller/AuthController.java
+++ b/src/main/java/com/fairing/fairplay/core/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.fairing.fairplay.core.controller;
 
+import com.fairing.fairplay.core.dto.AuthSessionResponse;
 import com.fairing.fairplay.core.dto.KakaoLoginRequest;
 import com.fairing.fairplay.core.dto.LoginRequest;
 import com.fairing.fairplay.core.dto.LoginResponse;
@@ -8,6 +9,8 @@ import com.fairing.fairplay.core.security.CustomUserDetails;
 import com.fairing.fairplay.core.service.AuthService;
 import com.fairing.fairplay.core.service.RefreshTokenService;
 import com.fairing.fairplay.core.service.SessionService;
+import com.fairing.fairplay.user.dto.UserResponseDto;
+import com.fairing.fairplay.user.service.UserService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -30,6 +33,7 @@ public class AuthController {
     private final AuthService authService;
     private final RefreshTokenService refreshTokenService;
     private final SessionService sessionService;
+    private final UserService userService;
 
     @Value("${app.environment:dev}")
     private String environment;
@@ -112,6 +116,22 @@ public class AuthController {
     public ResponseEntity<LoginResponse> refresh(@RequestBody @Valid RefreshTokenRequest request) {
         LoginResponse response = authService.refreshToken(request.getRefreshToken());
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/session")
+    public ResponseEntity<AuthSessionResponse> session(HttpServletRequest request) {
+        String sessionId = getSessionIdFromCookie(request);
+        if (sessionId == null) {
+            return ResponseEntity.ok(AuthSessionResponse.anonymous());
+        }
+
+        Long userId = sessionService.getUserIdFromSession(sessionId);
+        if (userId == null) {
+            return ResponseEntity.ok(AuthSessionResponse.anonymous());
+        }
+
+        UserResponseDto user = userService.getMyInfo(userId);
+        return ResponseEntity.ok(AuthSessionResponse.authenticated(user));
     }
 
     @PostMapping("/kakao")

--- a/src/main/java/com/fairing/fairplay/core/dto/AuthSessionResponse.java
+++ b/src/main/java/com/fairing/fairplay/core/dto/AuthSessionResponse.java
@@ -1,0 +1,16 @@
+package com.fairing.fairplay.core.dto;
+
+import com.fairing.fairplay.user.dto.UserResponseDto;
+
+public record AuthSessionResponse(
+        boolean authenticated,
+        UserResponseDto user
+) {
+    public static AuthSessionResponse anonymous() {
+        return new AuthSessionResponse(false, null);
+    }
+
+    public static AuthSessionResponse authenticated(UserResponseDto user) {
+        return new AuthSessionResponse(true, user);
+    }
+}

--- a/src/test/java/com/fairing/fairplay/core/controller/AuthControllerSessionTest.java
+++ b/src/test/java/com/fairing/fairplay/core/controller/AuthControllerSessionTest.java
@@ -1,0 +1,93 @@
+package com.fairing.fairplay.core.controller;
+
+import com.fairing.fairplay.core.config.SecurityConfig;
+import com.fairing.fairplay.core.service.AuthService;
+import com.fairing.fairplay.core.service.RefreshTokenService;
+import com.fairing.fairplay.core.service.SessionService;
+import com.fairing.fairplay.user.dto.UserResponseDto;
+import com.fairing.fairplay.user.repository.UserRepository;
+import com.fairing.fairplay.user.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.mock.web.MockCookie;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = AuthController.class)
+@Import(SecurityConfig.class)
+class AuthControllerSessionTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private RefreshTokenService refreshTokenService;
+
+    @MockBean
+    private SessionService sessionService;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @Test
+    void sessionReturnsAnonymousWithoutCookie() throws Exception {
+        mockMvc.perform(get("/api/auth/session"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.authenticated").value(false))
+                .andExpect(jsonPath("$.user").doesNotExist());
+
+        verify(sessionService, never()).getUserIdFromSession("missing");
+    }
+
+    @Test
+    void sessionReturnsAnonymousForExpiredCookie() throws Exception {
+        when(sessionService.getUserIdFromSession("expired")).thenReturn(null);
+
+        mockMvc.perform(get("/api/auth/session")
+                        .cookie(new MockCookie("FAIRPLAY_SESSION", "expired")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.authenticated").value(false))
+                .andExpect(jsonPath("$.user").doesNotExist());
+    }
+
+    @Test
+    void sessionReturnsCurrentUserForValidCookie() throws Exception {
+        UserResponseDto user = UserResponseDto.builder()
+                .userId(10L)
+                .email("admin@example.test")
+                .name("Admin")
+                .role("ADMIN")
+                .build();
+
+        when(sessionService.getUserIdFromSession("session-10")).thenReturn(10L);
+        when(userService.getMyInfo(10L)).thenReturn(user);
+
+        mockMvc.perform(get("/api/auth/session")
+                        .cookie(new MockCookie("FAIRPLAY_SESSION", "session-10")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.authenticated").value(true))
+                .andExpect(jsonPath("$.user.userId").value(10))
+                .andExpect(jsonPath("$.user.email").value("admin@example.test"))
+                .andExpect(jsonPath("$.user.name").value("Admin"))
+                .andExpect(jsonPath("$.user.role").value("ADMIN"));
+    }
+}


### PR DESCRIPTION
## Summary
- promote /api/auth/session and silent-auth cleanup support from develop

## Verification
- ./gradlew test --tests com.fairing.fairplay.core.controller.AuthControllerSessionTest --no-daemon
- develop PR #62 backend-ci/test passed