### PR TITLE
Keep public booth experience lists readable without auth

### DIFF
--- a/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
+++ b/src/main/java/com/fairing/fairplay/core/config/SecurityConfig.java
@@ -150,6 +150,7 @@ public class SecurityConfig {
                         // 제작자 API - GET 요청은 공개, 관리 기능은 ADMIN만
                         .requestMatchers(HttpMethod.GET, "/api/creators/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/banners/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/booth-experiences/available").permitAll()
 
                                                 .requestMatchers(HttpMethod.GET, "/api/reviews/*").permitAll()
                                                 .requestMatchers(HttpMethod.GET, "/api/form").permitAll()

--- a/src/test/java/com/fairing/fairplay/core/config/SecurityConfigPublicSurfaceTest.java
+++ b/src/test/java/com/fairing/fairplay/core/config/SecurityConfigPublicSurfaceTest.java
@@ -104,6 +104,13 @@ class SecurityConfigPublicSurfaceTest {
     }
 
     @Test
+    void availableBoothExperienceListRemainsPublicWithoutSession() throws Exception {
+        mockMvc.perform(get("/api/booth-experiences/available"))
+                .andExpect(result -> assertThat(result.getResponse().getStatus())
+                        .isNotIn(401, 403));
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     void sessionFilterDoesNotClassifyUploadApiAsPublicPath() {
         List<String> publicPaths = (List<String>) ReflectionTestUtils.getField(


### PR DESCRIPTION
## Summary
- permit the public read-only booth-experience availability list without a session
- keep user-specific reservation and realtime surfaces protected

## Verification
- ./gradlew test --tests com.fairing.fairplay.core.config.SecurityConfigPublicSurfaceTest --no-daemon