### PR TITLE
Keep AI chat auth and RAG indexing aligned

### DIFF
--- a/src/main/java/com/fairing/fairplay/ai/controller/AiChatWebSocketController.java
+++ b/src/main/java/com/fairing/fairplay/ai/controller/AiChatWebSocketController.java
@@ -3,11 +3,13 @@ package com.fairing.fairplay.ai.controller;
 import com.fairing.fairplay.ai.dto.AiChatMessageDto;
 import com.fairing.fairplay.chat.dto.ChatMessageResponseDto;
 import com.fairing.fairplay.chat.service.ChatMessageService;
+import com.fairing.fairplay.core.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 
 import java.security.Principal;
@@ -67,13 +69,20 @@ public class AiChatWebSocketController {
     }
 
     private Long authenticatedSenderId(Principal principal) {
-        if (principal == null || principal.getName() == null) {
+        if (principal == null) {
+            return null;
+        }
+        if (principal instanceof Authentication authentication
+                && authentication.getPrincipal() instanceof CustomUserDetails userDetails) {
+            return userDetails.getUserId();
+        }
+        if (principal.getName() == null) {
             return null;
         }
         try {
             return Long.parseLong(principal.getName());
         } catch (NumberFormatException e) {
-            log.warn("AI WebSocket principal user id parsing failed: {}", principal.getName());
+            log.warn("AI WebSocket principal did not expose a user id: {}", principal.getName());
             return null;
         }
     }

--- a/src/main/java/com/fairing/fairplay/ai/rag/event/RagDocumentType.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/event/RagDocumentType.java
@@ -1,0 +1,7 @@
+package com.fairing.fairplay.ai.rag.event;
+
+public enum RagDocumentType {
+    EVENT,
+    BOOTH,
+    BOOTH_EXPERIENCE
+}

--- a/src/main/java/com/fairing/fairplay/ai/rag/event/RagReindexAction.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/event/RagReindexAction.java
@@ -1,0 +1,6 @@
+package com.fairing.fairplay.ai.rag.event;
+
+public enum RagReindexAction {
+    UPSERT,
+    DELETE
+}

--- a/src/main/java/com/fairing/fairplay/ai/rag/event/RagReindexRequest.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/event/RagReindexRequest.java
@@ -1,10 +1,21 @@
 package com.fairing.fairplay.ai.rag.event;
 
+import java.util.Objects;
+
 public record RagReindexRequest(
     RagDocumentType documentType,
     Long documentId,
     RagReindexAction action
 ) {
+    public RagReindexRequest {
+        Objects.requireNonNull(documentType, "documentType must not be null");
+        Objects.requireNonNull(documentId, "documentId must not be null");
+        Objects.requireNonNull(action, "action must not be null");
+        if (documentId <= 0) {
+            throw new IllegalArgumentException("documentId must be positive");
+        }
+    }
+
     public static RagReindexRequest upsert(RagDocumentType documentType, Long documentId) {
         return new RagReindexRequest(documentType, documentId, RagReindexAction.UPSERT);
     }

--- a/src/main/java/com/fairing/fairplay/ai/rag/event/RagReindexRequest.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/event/RagReindexRequest.java
@@ -1,0 +1,15 @@
+package com.fairing.fairplay.ai.rag.event;
+
+public record RagReindexRequest(
+    RagDocumentType documentType,
+    Long documentId,
+    RagReindexAction action
+) {
+    public static RagReindexRequest upsert(RagDocumentType documentType, Long documentId) {
+        return new RagReindexRequest(documentType, documentId, RagReindexAction.UPSERT);
+    }
+
+    public static RagReindexRequest delete(RagDocumentType documentType, Long documentId) {
+        return new RagReindexRequest(documentType, documentId, RagReindexAction.DELETE);
+    }
+}

--- a/src/main/java/com/fairing/fairplay/ai/rag/service/ComprehensiveRagDataLoader.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/service/ComprehensiveRagDataLoader.java
@@ -28,12 +28,16 @@ import com.fairing.fairplay.attendee.repository.AttendeeRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import jakarta.annotation.PostConstruct;
 import org.springframework.data.domain.PageRequest;
@@ -64,6 +68,7 @@ public class ComprehensiveRagDataLoader {
     private final ReservationRepository reservationRepository;
     private final AttendeeRepository attendeeRepository;
     private final DocumentIngestService documentIngestService;
+    private final PlatformTransactionManager transactionManager;
     
     /**
      * 초기화 메서드 - SubCategory 캐시 생성 (N+1 문제 해결)
@@ -71,6 +76,13 @@ public class ComprehensiveRagDataLoader {
     @PostConstruct
     public void init() {
         initializeSubCategoryCache();
+    }
+
+    private <T> T inReadOnlyTransaction(Supplier<T> action) {
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.setReadOnly(true);
+        transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        return transactionTemplate.execute(status -> action.get());
     }
     
     /**
@@ -170,7 +182,6 @@ public class ComprehensiveRagDataLoader {
     /**
      * 모든 공개 데이터를 RAG에 로드
      */
-    @Transactional(readOnly = true)
     public ComprehensiveLoadResult loadAllPublicData() {
         log.info("종합 공개 데이터 RAG 로드 시작...");
         
@@ -201,17 +212,23 @@ public class ComprehensiveRagDataLoader {
         return result;
     }
 
-    @Transactional(readOnly = true)
     public LoadResult loadSingleEvent(Long eventId) {
         try {
-            Event event = eventRepository.findById(eventId).orElse(null);
-            if (event == null || Boolean.TRUE.equals(event.getIsDeleted())) {
+            Document document = inReadOnlyTransaction(() -> {
+                Event event = eventRepository.findById(eventId).orElse(null);
+                if (event == null || Boolean.TRUE.equals(event.getIsDeleted())) {
+                    return null;
+                }
+
+                EventDetail eventDetail = eventDetailRepository.findById(eventId).orElse(null);
+                return buildEventDocument(event, eventDetail);
+            });
+
+            if (document == null) {
                 documentIngestService.deleteDocument("event_" + eventId);
                 return new LoadResult("Event", 1, 1, 0);
             }
 
-            EventDetail eventDetail = eventDetailRepository.findById(eventId).orElse(null);
-            Document document = buildEventDocument(event, eventDetail);
             DocumentIngestService.IngestResult result = documentIngestService.ingestDocument(document);
             return toLoadResult("Event", result);
         } catch (Exception e) {
@@ -220,16 +237,22 @@ public class ComprehensiveRagDataLoader {
         }
     }
 
-    @Transactional(readOnly = true)
     public LoadResult loadSingleBooth(Long boothId) {
         try {
-            Booth booth = boothRepository.findById(boothId).orElse(null);
-            if (booth == null || Boolean.TRUE.equals(booth.getIsDeleted())) {
+            Document document = inReadOnlyTransaction(() -> {
+                Booth booth = boothRepository.findById(boothId).orElse(null);
+                if (booth == null || Boolean.TRUE.equals(booth.getIsDeleted())) {
+                    return null;
+                }
+
+                return buildBoothDocument(booth);
+            });
+
+            if (document == null) {
                 documentIngestService.deleteDocument("booth_" + boothId);
                 return new LoadResult("Booth", 1, 1, 0);
             }
 
-            Document document = buildBoothDocument(booth);
             DocumentIngestService.IngestResult result = documentIngestService.ingestDocument(document);
             return toLoadResult("Booth", result);
         } catch (Exception e) {
@@ -238,16 +261,22 @@ public class ComprehensiveRagDataLoader {
         }
     }
 
-    @Transactional(readOnly = true)
     public LoadResult loadSingleBoothExperience(Long experienceId) {
         try {
-            BoothExperience experience = boothExperienceRepository.findById(experienceId).orElse(null);
-            if (experience == null) {
+            Document document = inReadOnlyTransaction(() -> {
+                BoothExperience experience = boothExperienceRepository.findById(experienceId).orElse(null);
+                if (experience == null) {
+                    return null;
+                }
+
+                return buildBoothExperienceDocument(experience);
+            });
+
+            if (document == null) {
                 documentIngestService.deleteDocument("booth_experience_" + experienceId);
                 return new LoadResult("BoothExperience", 1, 1, 0);
             }
 
-            Document document = buildBoothExperienceDocument(experience);
             DocumentIngestService.IngestResult result = documentIngestService.ingestDocument(document);
             return toLoadResult("BoothExperience", result);
         } catch (Exception e) {
@@ -268,39 +297,12 @@ public class ComprehensiveRagDataLoader {
      */
     private LoadResult loadUserData() {
         log.info("사용자별 개인정보 데이터 로드 중...");
-        List<Users> users = userRepository.findAll();
-        int successCount = 0;
-        int failCount = 0;
-        
-        for (Users user : users) {
-            try {
-                // AI 봇 계정(999) 제외
-                if (user.getUserId() == 999) {
-                    continue;
-                }
-                
-                Document document = buildUserDataDocument(user);
-                
-                DocumentIngestService.IngestResult result = documentIngestService.ingestDocument(document);
-                if (result.isSuccess()) {
-                    successCount++;
-                    log.debug("사용자 데이터 임베딩 성공: {} ({})", user.getUserId(), user.getName());
-                } else {
-                    failCount++;
-                    log.warn("사용자 데이터 임베딩 실패: {} ({}) - 오류: {}", 
-                        user.getUserId(), user.getName(), result.getErrorMessage());
-                }
-            } catch (Exception e) {
-                failCount++;
-                log.error("사용자 데이터 로드 오류: {} ({}) - 예외: {}", 
-                    user.getUserId(), user.getName(), e.getMessage(), e);
-            }
-        }
-        
-        log.info("사용자별 개인정보 데이터 로드 완료: 총 {}개 중 {}개 성공, {}개 실패", 
-            users.size(), successCount, failCount);
-        
-        return new LoadResult("UserData", users.size(), successCount, failCount);
+        List<Document> documents = inReadOnlyTransaction(() -> userRepository.findAll().stream()
+            .filter(user -> user.getUserId() != 999)
+            .map(this::buildUserDataDocument)
+            .collect(Collectors.toList()));
+
+        return ingestDocuments("UserData", documents);
     }
     
     /**
@@ -308,53 +310,26 @@ public class ComprehensiveRagDataLoader {
      */
     private LoadResult loadEvents() {
         log.info("이벤트 데이터 로드 중...");
-        List<Event> events = eventRepository.findAll();
-        log.info("데이터베이스에서 {}개의 이벤트를 찾았습니다", events.size());
-        
-        // 가져온 이벤트 ID들 로깅
-        StringBuilder eventIds = new StringBuilder("가져온 이벤트 ID들: ");
-        for (Event event : events) {
-            eventIds.append(event.getEventId()).append("(").append(event.getTitleKr()).append("), ");
-        }
-        log.info(eventIds.toString());
-        
-        int successCount = 0;
-        int failCount = 0;
-        
-        for (Event event : events) {
-            try {
-                log.info("이벤트 처리 중: ID={}, TitleKr={}, TitleEng={}, Hidden={}", 
-                    event.getEventId(), event.getTitleKr(), event.getTitleEng(), event.getHidden());
-                
-                EventDetail eventDetail = eventDetailRepository.findById(event.getEventId()).orElse(null);
-                if (eventDetail == null) {
-                    log.warn("이벤트 상세 정보 없음: eventId={}", event.getEventId());
-                }
-                
-                Document document = buildEventDocument(event, eventDetail);
-                log.debug("문서 생성 완료: docId={}, 제목={}, 내용 길이={}", 
-                    document.getDocId(), document.getTitle(), document.getContent().length());
-                
-                DocumentIngestService.IngestResult result = documentIngestService.ingestDocument(document);
-                if (result.isSuccess()) {
-                    successCount++;
-                    log.info("이벤트 임베딩 성공: {} ({})", event.getEventId(), event.getTitleKr());
-                } else {
-                    failCount++;
-                    log.error("이벤트 임베딩 실패: {} ({}) - 오류: {}", 
-                        event.getEventId(), event.getTitleKr(), result.getErrorMessage());
-                }
-            } catch (Exception e) {
-                failCount++;
-                log.error("이벤트 로드 오류: {} ({}) - 예외: {}", 
-                    event.getEventId(), event.getTitleKr(), e.getMessage(), e);
-            }
-        }
-        
-        log.info("이벤트 데이터 로드 완료: 총 {}개 중 {}개 성공, {}개 실패", 
-            events.size(), successCount, failCount);
-        
-        return new LoadResult("Event", events.size(), successCount, failCount);
+        List<Document> documents = inReadOnlyTransaction(() -> {
+            List<Event> events = eventRepository.findAll();
+            log.info("데이터베이스에서 {}개의 이벤트를 찾았습니다", events.size());
+
+            return events.stream()
+                .map(event -> {
+                    log.info("이벤트 처리 중: ID={}, TitleKr={}, TitleEng={}, Hidden={}",
+                        event.getEventId(), event.getTitleKr(), event.getTitleEng(), event.getHidden());
+
+                    EventDetail eventDetail = eventDetailRepository.findById(event.getEventId()).orElse(null);
+                    if (eventDetail == null) {
+                        log.warn("이벤트 상세 정보 없음: eventId={}", event.getEventId());
+                    }
+
+                    return buildEventDocument(event, eventDetail);
+                })
+                .collect(Collectors.toList());
+        });
+
+        return ingestDocuments("Event", documents);
     }
     
     /**
@@ -362,28 +337,11 @@ public class ComprehensiveRagDataLoader {
      */
     private LoadResult loadBooths() {
         log.info("부스 데이터 로드 중...");
-        List<Booth> booths = boothRepository.findAll();
-        int successCount = 0;
-        int failCount = 0;
-        
-        for (Booth booth : booths) {
-            try {
-                Document document = buildBoothDocument(booth);
-                
-                DocumentIngestService.IngestResult result = documentIngestService.ingestDocument(document);
-                if (result.isSuccess()) {
-                    successCount++;
-                } else {
-                    failCount++;
-                    log.warn("부스 로드 실패: {} - {}", booth.getId(), result.getErrorMessage());
-                }
-            } catch (Exception e) {
-                failCount++;
-                log.error("부스 로드 오류: {} - {}", booth.getId(), e.getMessage(), e);
-            }
-        }
-        
-        return new LoadResult("Booth", booths.size(), successCount, failCount);
+        List<Document> documents = inReadOnlyTransaction(() -> boothRepository.findAll().stream()
+            .map(this::buildBoothDocument)
+            .collect(Collectors.toList()));
+
+        return ingestDocuments("Booth", documents);
     }
     
     /**
@@ -391,28 +349,11 @@ public class ComprehensiveRagDataLoader {
      */
     private LoadResult loadBoothExperiences() {
         log.info("부스 체험 데이터 로드 중...");
-        List<BoothExperience> experiences = boothExperienceRepository.findAll();
-        int successCount = 0;
-        int failCount = 0;
-        
-        for (BoothExperience experience : experiences) {
-            try {
-                Document document = buildBoothExperienceDocument(experience);
-                
-                DocumentIngestService.IngestResult result = documentIngestService.ingestDocument(document);
-                if (result.isSuccess()) {
-                    successCount++;
-                } else {
-                    failCount++;
-                    log.warn("부스 체험 로드 실패: {} - {}", experience.getExperienceId(), result.getErrorMessage());
-                }
-            } catch (Exception e) {
-                failCount++;
-                log.error("부스 체험 로드 오류: {} - {}", experience.getExperienceId(), e.getMessage(), e);
-            }
-        }
-        
-        return new LoadResult("BoothExperience", experiences.size(), successCount, failCount);
+        List<Document> documents = inReadOnlyTransaction(() -> boothExperienceRepository.findAll().stream()
+            .map(this::buildBoothExperienceDocument)
+            .collect(Collectors.toList()));
+
+        return ingestDocuments("BoothExperience", documents);
     }
     
     /**
@@ -420,28 +361,11 @@ public class ComprehensiveRagDataLoader {
      */
     private LoadResult loadReviews() {
         log.info("리뷰 데이터 로드 중...");
-        List<Review> reviews = reviewRepository.findAll();
-        int successCount = 0;
-        int failCount = 0;
-        
-        for (Review review : reviews) {
-            try {
-                Document document = buildReviewDocument(review);
-                
-                DocumentIngestService.IngestResult result = documentIngestService.ingestDocument(document);
-                if (result.isSuccess()) {
-                    successCount++;
-                } else {
-                    failCount++;
-                    log.warn("리뷰 로드 실패: {} - {}", review.getId(), result.getErrorMessage());
-                }
-            } catch (Exception e) {
-                failCount++;
-                log.error("리뷰 로드 오류: {} - {}", review.getId(), e.getMessage(), e);
-            }
-        }
-        
-        return new LoadResult("Review", reviews.size(), successCount, failCount);
+        List<Document> documents = inReadOnlyTransaction(() -> reviewRepository.findAll().stream()
+            .map(this::buildReviewDocument)
+            .collect(Collectors.toList()));
+
+        return ingestDocuments("Review", documents);
     }
     
     /**
@@ -449,31 +373,43 @@ public class ComprehensiveRagDataLoader {
      */
     private LoadResult loadCategories() {
         log.info("카테고리 데이터 로드 중...");
-        List<MainCategory> categories = mainCategoryRepository.findAll();
+        List<Document> documents = inReadOnlyTransaction(() -> mainCategoryRepository.findAll().stream()
+            .map(category -> {
+                List<SubCategory> subCategories = subCategoryCache.getOrDefault(
+                    category.getGroupId(), new ArrayList<>());
+                return buildCategoryDocument(category, subCategories);
+            })
+            .collect(Collectors.toList()));
+
+        return ingestDocuments("Category", documents);
+    }
+
+    private LoadResult ingestDocuments(String domain, List<Document> documents) {
         int successCount = 0;
         int failCount = 0;
 
-        for (MainCategory category : categories) {
+        for (Document document : documents) {
             try {
-                // 캐시에서 SubCategory 가져오기 (N+1 문제 해결)
-                List<SubCategory> subCategories = subCategoryCache.getOrDefault(
-                    category.getGroupId(), new ArrayList<>());
-                Document document = buildCategoryDocument(category, subCategories);
-
                 DocumentIngestService.IngestResult result = documentIngestService.ingestDocument(document);
                 if (result.isSuccess()) {
                     successCount++;
+                    log.debug("{} RAG 로드 성공: {} (청크 {}개)",
+                        domain, document.getDocId(), result.getProcessedChunks());
                 } else {
                     failCount++;
-                    log.warn("카테고리 로드 실패: {} - {}", category.getGroupId(), result.getErrorMessage());
+                    log.warn("{} RAG 로드 실패: {} - {}",
+                        domain, document.getDocId(), result.getErrorMessage());
                 }
             } catch (Exception e) {
                 failCount++;
-                log.error("카테고리 로드 오류: {} - {}", category.getGroupId(), e.getMessage(), e);
+                log.error("{} RAG 로드 오류: {} - {}", domain, document.getDocId(), e.getMessage(), e);
             }
         }
 
-        return new LoadResult("Category", categories.size(), successCount, failCount);
+        log.info("{} 데이터 로드 완료: 총 {}개 중 {}개 성공, {}개 실패",
+            domain, documents.size(), successCount, failCount);
+
+        return new LoadResult(domain, documents.size(), successCount, failCount);
     }
     
     /**

--- a/src/main/java/com/fairing/fairplay/ai/rag/service/ComprehensiveRagDataLoader.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/service/ComprehensiveRagDataLoader.java
@@ -200,6 +200,68 @@ public class ComprehensiveRagDataLoader {
         
         return result;
     }
+
+    @Transactional(readOnly = true)
+    public LoadResult loadSingleEvent(Long eventId) {
+        try {
+            Event event = eventRepository.findById(eventId).orElse(null);
+            if (event == null || Boolean.TRUE.equals(event.getIsDeleted())) {
+                documentIngestService.deleteDocument("event_" + eventId);
+                return new LoadResult("Event", 1, 1, 0);
+            }
+
+            EventDetail eventDetail = eventDetailRepository.findById(eventId).orElse(null);
+            Document document = buildEventDocument(event, eventDetail);
+            DocumentIngestService.IngestResult result = documentIngestService.ingestDocument(document);
+            return toLoadResult("Event", result);
+        } catch (Exception e) {
+            log.warn("단일 이벤트 RAG 로드 실패: eventId={}, error={}", eventId, e.getMessage(), e);
+            return new LoadResult("Event", 1, 0, 1);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public LoadResult loadSingleBooth(Long boothId) {
+        try {
+            Booth booth = boothRepository.findById(boothId).orElse(null);
+            if (booth == null || Boolean.TRUE.equals(booth.getIsDeleted())) {
+                documentIngestService.deleteDocument("booth_" + boothId);
+                return new LoadResult("Booth", 1, 1, 0);
+            }
+
+            Document document = buildBoothDocument(booth);
+            DocumentIngestService.IngestResult result = documentIngestService.ingestDocument(document);
+            return toLoadResult("Booth", result);
+        } catch (Exception e) {
+            log.warn("단일 부스 RAG 로드 실패: boothId={}, error={}", boothId, e.getMessage(), e);
+            return new LoadResult("Booth", 1, 0, 1);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public LoadResult loadSingleBoothExperience(Long experienceId) {
+        try {
+            BoothExperience experience = boothExperienceRepository.findById(experienceId).orElse(null);
+            if (experience == null) {
+                documentIngestService.deleteDocument("booth_experience_" + experienceId);
+                return new LoadResult("BoothExperience", 1, 1, 0);
+            }
+
+            Document document = buildBoothExperienceDocument(experience);
+            DocumentIngestService.IngestResult result = documentIngestService.ingestDocument(document);
+            return toLoadResult("BoothExperience", result);
+        } catch (Exception e) {
+            log.warn("단일 부스 체험 RAG 로드 실패: experienceId={}, error={}", experienceId, e.getMessage(), e);
+            return new LoadResult("BoothExperience", 1, 0, 1);
+        }
+    }
+
+    private LoadResult toLoadResult(String domain, DocumentIngestService.IngestResult result) {
+        if (result != null && result.isSuccess()) {
+            return new LoadResult(domain, 1, 1, 0);
+        }
+        return new LoadResult(domain, 1, 0, 1);
+    }
     
     /**
      * 사용자별 개인정보 데이터 로드 (예약정보, 티켓정보, 개인정보)

--- a/src/main/java/com/fairing/fairplay/ai/rag/service/DocumentIngestService.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/service/DocumentIngestService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.List;
@@ -32,7 +33,7 @@ public class DocumentIngestService {
     /**
      * 문서를 청킹하고 임베딩하여 저장
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public IngestResult ingestDocument(Document document) {
         log.info("문서 인제스트 시작: {} ({})", document.getTitle(), document.getDocId());
         
@@ -153,6 +154,7 @@ public class DocumentIngestService {
     /**
      * 문서 삭제
      */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void deleteDocument(String docId) {
         log.info("문서 삭제: {}", docId);
         repository.deleteDocument(docId);
@@ -166,6 +168,7 @@ public class DocumentIngestService {
     /**
      * 전체 문서 삭제 (테스트용)
      */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void clearAllDocuments() {
         log.warn("전체 문서 삭제 시작");
         

--- a/src/main/java/com/fairing/fairplay/ai/rag/service/DocumentIngestService.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/service/DocumentIngestService.java
@@ -2,12 +2,9 @@ package com.fairing.fairplay.ai.rag.service;
 
 import com.fairing.fairplay.ai.rag.domain.Chunk;
 import com.fairing.fairplay.ai.rag.domain.Document;
-import com.fairing.fairplay.ai.rag.repository.RagChunkRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.List;
@@ -26,21 +23,17 @@ public class DocumentIngestService {
 
     private final ChunkingService chunkingService;
     private final EmbeddingService embeddingService;
-    private final RagChunkRepository repository;
+    private final RagChunkWriteService ragChunkWriteService;
     private final VectorSearchService vectorSearchService;
     private final ThreadPoolTaskExecutor taskExecutor;
 
     /**
      * 문서를 청킹하고 임베딩하여 저장
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public IngestResult ingestDocument(Document document) {
         log.info("문서 인제스트 시작: {} ({})", document.getTitle(), document.getDocId());
         
         try {
-            // 기존 문서가 있다면 삭제
-            repository.deleteDocument(document.getDocId());
-            
             // 청킹
             List<Chunk> chunks = chunkingService.chunkDocument(
                 document.getDocId(), 
@@ -78,11 +71,13 @@ public class DocumentIngestService {
                             result.getChunk().getChunkId(), result.getErrorMessage());
                     }
                 }
-                
-                // 성공한 청크들을 pgvector 저장소에 배치 저장
-                if (!processedChunkList.isEmpty()) {
-                    repository.saveChunks(processedChunkList);
+
+                if (!chunks.isEmpty() && processedChunkList.isEmpty()) {
+                    throw new RuntimeException("모든 청크 임베딩 실패");
                 }
+
+                // 임베딩 I/O가 끝난 뒤 짧은 쓰기 트랜잭션에서 기존 문서를 교체한다.
+                ragChunkWriteService.replaceDocument(document.getDocId(), processedChunkList);
                 
                 log.info("병렬 청크 처리 완료: 성공 {}, 실패 {}", processedChunks, failedChunks);
                 
@@ -154,10 +149,9 @@ public class DocumentIngestService {
     /**
      * 문서 삭제
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void deleteDocument(String docId) {
         log.info("문서 삭제: {}", docId);
-        repository.deleteDocument(docId);
+        ragChunkWriteService.deleteDocument(docId);
         
         // 캐시 무효화
         vectorSearchService.invalidateCache();
@@ -168,12 +162,11 @@ public class DocumentIngestService {
     /**
      * 전체 문서 삭제 (테스트용)
      */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void clearAllDocuments() {
         log.warn("전체 문서 삭제 시작");
         
         // pgvector RAG 데이터 삭제
-        repository.clearAllData();
+        ragChunkWriteService.clearAllDocuments();
         
         // 캐시 무효화
         vectorSearchService.invalidateCache();

--- a/src/main/java/com/fairing/fairplay/ai/rag/service/EventRagDataLoader.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/service/EventRagDataLoader.java
@@ -8,10 +8,13 @@ import com.fairing.fairplay.event.repository.EventDetailRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * Event/EventDetail 데이터를 RAG용 문서로 변환하는 로더
@@ -24,41 +27,48 @@ public class EventRagDataLoader {
     private final EventRepository eventRepository;
     private final EventDetailRepository eventDetailRepository;
     private final DocumentIngestService documentIngestService;
+    private final PlatformTransactionManager transactionManager;
+
+    private <T> T inReadOnlyTransaction(Supplier<T> action) {
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+        transactionTemplate.setReadOnly(true);
+        transactionTemplate.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        return transactionTemplate.execute(status -> action.get());
+    }
 
     /**
      * 모든 이벤트 데이터를 RAG에 로드
      */
-    @Transactional(readOnly = true)
     public LoadResult loadAllEvents() {
         log.info("이벤트 데이터 RAG 로드 시작...");
-        
-        List<Event> events = eventRepository.findAll();
-        int totalEvents = events.size();
+
+        List<Document> documents = inReadOnlyTransaction(() -> eventRepository.findAll().stream()
+            .map(event -> {
+                EventDetail eventDetail = eventDetailRepository.findById(event.getEventId()).orElse(null);
+                return buildDocumentFromEvent(event, eventDetail);
+            })
+            .collect(Collectors.toList()));
+
+        int totalEvents = documents.size();
         int successCount = 0;
         int failCount = 0;
         
-        for (Event event : events) {
+        for (Document document : documents) {
             try {
-                // EventDetail 조회
-                EventDetail eventDetail = eventDetailRepository.findById(event.getEventId()).orElse(null);
-                
-                // Document 생성
-                Document document = buildDocumentFromEvent(event, eventDetail);
-                
                 // RAG에 인제스트
                 DocumentIngestService.IngestResult result = documentIngestService.ingestDocument(document);
                 
                 if (result.isSuccess()) {
                     successCount++;
-                    log.debug("이벤트 RAG 로드 성공: {} (청크 {}개)", event.getEventId(), result.getProcessedChunks());
+                    log.debug("이벤트 RAG 로드 성공: {} (청크 {}개)", document.getDocId(), result.getProcessedChunks());
                 } else {
                     failCount++;
-                    log.warn("이벤트 RAG 로드 실패: {} - {}", event.getEventId(), result.getErrorMessage());
+                    log.warn("이벤트 RAG 로드 실패: {} - {}", document.getDocId(), result.getErrorMessage());
                 }
                 
             } catch (Exception e) {
                 failCount++;
-                log.error("이벤트 RAG 로드 오류: {} - {}", event.getEventId(), e.getMessage(), e);
+                log.error("이벤트 RAG 로드 오류: {} - {}", document.getDocId(), e.getMessage(), e);
             }
         }
         
@@ -70,17 +80,22 @@ public class EventRagDataLoader {
     /**
      * 특정 이벤트만 RAG에 로드
      */
-    @Transactional(readOnly = true)
     public boolean loadSingleEvent(Long eventId) {
         try {
-            Event event = eventRepository.findById(eventId).orElse(null);
-            if (event == null) {
+            Document document = inReadOnlyTransaction(() -> {
+                Event event = eventRepository.findById(eventId).orElse(null);
+                if (event == null) {
+                    return null;
+                }
+
+                EventDetail eventDetail = eventDetailRepository.findById(eventId).orElse(null);
+                return buildDocumentFromEvent(event, eventDetail);
+            });
+
+            if (document == null) {
                 log.warn("이벤트를 찾을 수 없음: {}", eventId);
                 return false;
             }
-            
-            EventDetail eventDetail = eventDetailRepository.findById(eventId).orElse(null);
-            Document document = buildDocumentFromEvent(event, eventDetail);
             
             DocumentIngestService.IngestResult result = documentIngestService.ingestDocument(document);
             

--- a/src/main/java/com/fairing/fairplay/ai/rag/service/RagChunkWriteService.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/service/RagChunkWriteService.java
@@ -1,0 +1,35 @@
+package com.fairing.fairplay.ai.rag.service;
+
+import com.fairing.fairplay.ai.rag.domain.Chunk;
+import com.fairing.fairplay.ai.rag.repository.RagChunkRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class RagChunkWriteService {
+
+    private final RagChunkRepository repository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void replaceDocument(String docId, List<Chunk> chunks) {
+        repository.deleteDocument(docId);
+        if (chunks != null && !chunks.isEmpty()) {
+            repository.saveChunks(chunks);
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void deleteDocument(String docId) {
+        repository.deleteDocument(docId);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void clearAllDocuments() {
+        repository.clearAllData();
+    }
+}

--- a/src/main/java/com/fairing/fairplay/ai/rag/service/RagIndexingEventPublisher.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/service/RagIndexingEventPublisher.java
@@ -1,0 +1,50 @@
+package com.fairing.fairplay.ai.rag.service;
+
+import com.fairing.fairplay.ai.rag.event.RagDocumentType;
+import com.fairing.fairplay.ai.rag.event.RagReindexRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RagIndexingEventPublisher {
+
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void eventChanged(Long eventId) {
+        publishUpsert(RagDocumentType.EVENT, eventId);
+    }
+
+    public void eventDeleted(Long eventId) {
+        publishDelete(RagDocumentType.EVENT, eventId);
+    }
+
+    public void boothChanged(Long boothId) {
+        publishUpsert(RagDocumentType.BOOTH, boothId);
+    }
+
+    public void boothDeleted(Long boothId) {
+        publishDelete(RagDocumentType.BOOTH, boothId);
+    }
+
+    public void boothExperienceChanged(Long experienceId) {
+        publishUpsert(RagDocumentType.BOOTH_EXPERIENCE, experienceId);
+    }
+
+    public void boothExperienceDeleted(Long experienceId) {
+        publishDelete(RagDocumentType.BOOTH_EXPERIENCE, experienceId);
+    }
+
+    private void publishUpsert(RagDocumentType documentType, Long documentId) {
+        if (documentId != null) {
+            eventPublisher.publishEvent(RagReindexRequest.upsert(documentType, documentId));
+        }
+    }
+
+    private void publishDelete(RagDocumentType documentType, Long documentId) {
+        if (documentId != null) {
+            eventPublisher.publishEvent(RagReindexRequest.delete(documentType, documentId));
+        }
+    }
+}

--- a/src/main/java/com/fairing/fairplay/ai/rag/service/RagReindexEventListener.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/service/RagReindexEventListener.java
@@ -32,8 +32,9 @@ public class RagReindexEventListener {
                 case BOOTH_EXPERIENCE -> comprehensiveRagDataLoader.loadSingleBoothExperience(request.documentId());
             }
         } catch (Exception e) {
-            log.warn("RAG reindex event failed. type={}, id={}, action={}",
+            log.error("RAG reindex event failed. type={}, id={}, action={}",
                 request.documentType(), request.documentId(), request.action(), e);
+            throw new IllegalStateException("RAG reindex event failed", e);
         }
     }
 

--- a/src/main/java/com/fairing/fairplay/ai/rag/service/RagReindexEventListener.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/service/RagReindexEventListener.java
@@ -1,0 +1,48 @@
+package com.fairing.fairplay.ai.rag.service;
+
+import com.fairing.fairplay.ai.rag.event.RagReindexAction;
+import com.fairing.fairplay.ai.rag.event.RagReindexRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RagReindexEventListener {
+
+    private final ComprehensiveRagDataLoader comprehensiveRagDataLoader;
+    private final DocumentIngestService documentIngestService;
+
+    @Async("taskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(RagReindexRequest request) {
+        try {
+            if (request.action() == RagReindexAction.DELETE) {
+                deleteDocument(request);
+                return;
+            }
+
+            switch (request.documentType()) {
+                case EVENT -> comprehensiveRagDataLoader.loadSingleEvent(request.documentId());
+                case BOOTH -> comprehensiveRagDataLoader.loadSingleBooth(request.documentId());
+                case BOOTH_EXPERIENCE -> comprehensiveRagDataLoader.loadSingleBoothExperience(request.documentId());
+            }
+        } catch (Exception e) {
+            log.warn("RAG reindex event failed. type={}, id={}, action={}",
+                request.documentType(), request.documentId(), request.action(), e);
+        }
+    }
+
+    private void deleteDocument(RagReindexRequest request) {
+        String docId = switch (request.documentType()) {
+            case EVENT -> "event_" + request.documentId();
+            case BOOTH -> "booth_" + request.documentId();
+            case BOOTH_EXPERIENCE -> "booth_experience_" + request.documentId();
+        };
+        documentIngestService.deleteDocument(docId);
+    }
+}

--- a/src/main/java/com/fairing/fairplay/booth/service/BoothApplicationService.java
+++ b/src/main/java/com/fairing/fairplay/booth/service/BoothApplicationService.java
@@ -1,6 +1,7 @@
 package com.fairing.fairplay.booth.service;
 
 import com.fairing.fairplay.admin.service.SuperAdminService;
+import com.fairing.fairplay.ai.rag.service.RagIndexingEventPublisher;
 import com.fairing.fairplay.booth.dto.*;
 import com.fairing.fairplay.booth.entity.*;
 import com.fairing.fairplay.booth.mapper.BoothApplicationMapper;
@@ -65,6 +66,7 @@ public class BoothApplicationService {
     private final BoothEmailService boothEmailService;
     private final NotificationService notificationService;
     private final UserSessionRevocationService userSessionRevocationService;
+    private final RagIndexingEventPublisher ragIndexingEventPublisher;
 
 
     // 부스 신청
@@ -292,6 +294,7 @@ public class BoothApplicationService {
             }
 
             log.info("부스 신청이 승인되었습니다. boothApplicationId: {}, boothId: {}", id, booth.getId());
+            ragIndexingEventPublisher.boothChanged(savedBooth.getId());
 
         } else if ("REJECTED".equals(newStatus.getCode())) {
             application.updateStatus(newStatus, dto.getAdminComment());

--- a/src/main/java/com/fairing/fairplay/booth/service/BoothExperienceService.java
+++ b/src/main/java/com/fairing/fairplay/booth/service/BoothExperienceService.java
@@ -9,6 +9,7 @@ import com.fairing.fairplay.booth.repository.BoothExperienceRepository;
 import com.fairing.fairplay.booth.repository.BoothExperienceReservationRepository;
 import com.fairing.fairplay.booth.repository.BoothExperienceStatusCodeRepository;
 import com.fairing.fairplay.booth.repository.BoothRepository;
+import com.fairing.fairplay.ai.rag.service.RagIndexingEventPublisher;
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.core.security.CustomUserDetails;
 import com.fairing.fairplay.event.entity.Event;
@@ -47,6 +48,7 @@ public class BoothExperienceService {
   private final BoothRepository boothRepository;
   private final UserRepository userRepository;
   private final RealtimeSseService realtimeSseService;
+  private final RagIndexingEventPublisher ragIndexingEventPublisher;
 
   // 1. 부스 체험 등록 (부스 담당자)
   @Transactional
@@ -71,6 +73,8 @@ public class BoothExperienceService {
 
     BoothExperience savedExperience = boothExperienceRepository.save(experience);
     log.info("부스 체험 등록 완료 - 체험 ID: {}", savedExperience.getExperienceId());
+    ragIndexingEventPublisher.boothExperienceChanged(savedExperience.getExperienceId());
+    ragIndexingEventPublisher.boothChanged(booth.getId());
 
     return BoothExperienceResponseDto.fromEntity(savedExperience);
   }
@@ -296,6 +300,8 @@ public class BoothExperienceService {
 
     BoothExperience updatedExperience = boothExperienceRepository.save(experience);
     log.info("부스 체험 수정 완료 - 체험 ID: {}", experienceId);
+    ragIndexingEventPublisher.boothExperienceChanged(updatedExperience.getExperienceId());
+    ragIndexingEventPublisher.boothChanged(updatedExperience.getBooth().getId());
 
     return BoothExperienceResponseDto.fromEntity(updatedExperience);
   }
@@ -326,8 +332,11 @@ public class BoothExperienceService {
       log.info("체험 관련 예약 삭제 완료 - 예약 수: {}", allReservations.size());
     }
 
+    Long boothId = experience.getBooth().getId();
     // 체험 삭제
     boothExperienceRepository.delete(experience);
+    ragIndexingEventPublisher.boothExperienceDeleted(experienceId);
+    ragIndexingEventPublisher.boothChanged(boothId);
     log.info("부스 체험 삭제 완료 - 체험 ID: {}", experienceId);
   }
 

--- a/src/main/java/com/fairing/fairplay/booth/service/BoothService.java
+++ b/src/main/java/com/fairing/fairplay/booth/service/BoothService.java
@@ -10,6 +10,7 @@ import com.fairing.fairplay.booth.repository.BoothApplicationRepository;
 import com.fairing.fairplay.booth.repository.BoothExternalLinkRepository;
 import com.fairing.fairplay.booth.repository.BoothRepository;
 import com.fairing.fairplay.booth.repository.BoothTypeRepository;
+import com.fairing.fairplay.ai.rag.service.RagIndexingEventPublisher;
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.core.service.LocalFileService;
 // import com.fairing.fairplay.core.service.AwsS3Service;
@@ -51,6 +52,7 @@ public class BoothService {
     private final BoothAdminRepository boothAdminRepository;
     private final UserRepository userRepository;
     private final BoothApplicationMapper boothApplicationMapper;
+    private final RagIndexingEventPublisher ragIndexingEventPublisher;
 
     // 부스 목록 조회 (관리자용 - 삭제된 부스 포함 조회)
     @Transactional(readOnly = true)
@@ -221,6 +223,7 @@ public class BoothService {
         }
 
         boothRepository.saveAndFlush(booth);
+        ragIndexingEventPublisher.boothChanged(booth.getId());
 
         List<BoothExternalLinkDto> externalLinkDtos = boothExternalLinkRepository.findByBooth(booth).stream()
                 .map(link -> BoothExternalLinkDto.builder()
@@ -250,6 +253,7 @@ public class BoothService {
                 .orElseThrow(() -> new CustomException(HttpStatus.NOT_FOUND, "해당 부스를 찾을 수 없습니다."));
         booth.setIsDeleted(true);
         boothRepository.save(booth);
+        ragIndexingEventPublisher.boothDeleted(boothId);
     }
 
     // 부스 관리자 정보 변경

--- a/src/main/java/com/fairing/fairplay/event/service/EventApplyService.java
+++ b/src/main/java/com/fairing/fairplay/event/service/EventApplyService.java
@@ -1,6 +1,7 @@
 package com.fairing.fairplay.event.service;
 
 import com.fairing.fairplay.admin.service.SuperAdminService;
+import com.fairing.fairplay.ai.rag.service.RagIndexingEventPublisher;
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.core.email.service.EventEmailService;
 import com.fairing.fairplay.core.email.service.TemporaryPasswordEmailService;
@@ -68,6 +69,7 @@ public class EventApplyService {
     private final RegionCodeRepository regionCodeRepository;
     private final SuperAdminService superAdminService;
     private final EventStatusCodeRepository statusCodeRepository;
+    private final RagIndexingEventPublisher ragIndexingEventPublisher;
 
     private static final String NOT_FOUND_STATUS = "해당 상태 코드 없음";
 
@@ -250,6 +252,7 @@ public class EventApplyService {
         }
 
         log.info("행사 신청이 승인되었습니다. eventApplyId: {}, eventId: {}", eventApplyId, event.getEventId());
+        ragIndexingEventPublisher.eventChanged(event.getEventId());
     }
 
     @Transactional

--- a/src/main/java/com/fairing/fairplay/event/service/EventService.java
+++ b/src/main/java/com/fairing/fairplay/event/service/EventService.java
@@ -5,6 +5,7 @@ import com.fairing.fairplay.booth.repository.BoothRepository;
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.core.security.CustomUserDetails;
 import com.fairing.fairplay.core.service.LocalFileService;
+import com.fairing.fairplay.ai.rag.service.RagIndexingEventPublisher;
 // import com.fairing.fairplay.core.service.AwsS3Service;
 import com.fairing.fairplay.event.dto.*;
 import com.fairing.fairplay.event.entity.*;
@@ -64,6 +65,7 @@ public class EventService {
     // private final AwsS3Service awsS3Service;
     private final LocalFileService localFileService;
     private final FileService fileService;
+    private final RagIndexingEventPublisher ragIndexingEventPublisher;
 
     @PersistenceContext
     private EntityManager entityManager;
@@ -384,6 +386,7 @@ public class EventService {
 
         Event savedEvent = eventRepository.save(event);
         Integer newVersion = createVersion(savedEvent, managerId);
+        ragIndexingEventPublisher.eventChanged(savedEvent.getEventId());
 
         return EventResponseDto.builder()
                 .message("행사 정보가 업데이트되었습니다.")
@@ -448,6 +451,7 @@ public class EventService {
 
         log.info("버전 생성 for eventId: {}", eventId);
         Integer newVersion = createVersion(event, managerId);
+        ragIndexingEventPublisher.eventChanged(eventId);
 
         return buildEventDetailResponseDto(event, eventDetail, externalLinkResponseDtos, newVersion, "이벤트 상세 정보가 업데이트되었습니다.");
     }
@@ -466,6 +470,7 @@ public class EventService {
         event.setHidden(true);  // 숨김 처리
 
         eventRepository.saveAndFlush(event);
+        ragIndexingEventPublisher.eventDeleted(eventId);
         log.info("행사 소프트 딜리트 완료");
     }
 
@@ -520,6 +525,7 @@ public class EventService {
 
         eventVersionRepository.deleteAll(event.getEventVersions());
         eventRepository.deleteById(eventId);
+        ragIndexingEventPublisher.eventDeleted(eventId);
 
         log.info("행사 삭제 완료");
     }
@@ -565,6 +571,7 @@ public class EventService {
 
         eventVersionRepository.deleteAll(event.getEventVersions());
         eventRepository.deleteById(eventId);
+        ragIndexingEventPublisher.eventDeleted(eventId);
 
         log.info("행사 삭제 완료");
     }

--- a/src/test/java/com/fairing/fairplay/ai/controller/AiChatWebSocketControllerContractTest.java
+++ b/src/test/java/com/fairing/fairplay/ai/controller/AiChatWebSocketControllerContractTest.java
@@ -4,6 +4,7 @@ import com.fairing.fairplay.ai.dto.AiChatMessageDto;
 import com.fairing.fairplay.ai.service.ChatAiService;
 import com.fairing.fairplay.chat.dto.ChatMessageResponseDto;
 import com.fairing.fairplay.chat.service.ChatMessageService;
+import com.fairing.fairplay.core.security.CustomUserDetails;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -11,6 +12,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 
 import java.security.Principal;
 import java.time.LocalDateTime;
@@ -48,6 +50,24 @@ class AiChatWebSocketControllerContractTest {
         controller.sendAiMessage(aiChatMessage(roomId, senderId), principal(senderId));
 
         verify(chatMessageService).sendMessage(roomId, senderId, "예매 방법 알려줘");
+    }
+
+    @Test
+    void sendAiMessageUsesCustomUserDetailsUserIdWhenPrincipalNameIsEmail() {
+        Long roomId = 101L;
+        Long authenticatedUserId = 10L;
+        when(chatMessageService.sendMessage(roomId, authenticatedUserId, "예매 방법 알려줘"))
+                .thenReturn(savedUserMessage(roomId, authenticatedUserId, "예매 방법 알려줘"));
+
+        controller.sendAiMessage(aiChatMessage(roomId, 999L), authentication(authenticatedUserId, "b@b.b"));
+
+        verify(chatMessageService).sendMessage(roomId, authenticatedUserId, "예매 방법 알려줘");
+        verify(messagingTemplate, never()).convertAndSend(
+                eq("/topic/ai-chat." + roomId),
+                (Object) argThat(payload -> payload instanceof AiChatMessageDto dto
+                        && "system_error".equals(dto.getType())
+                        && "인증이 필요합니다.".equals(dto.getContent()))
+        );
     }
 
     @Test
@@ -111,6 +131,11 @@ class AiChatWebSocketControllerContractTest {
 
     private Principal principal(Long senderId) {
         return () -> senderId.toString();
+    }
+
+    private Principal authentication(Long userId, String email) {
+        CustomUserDetails userDetails = CustomUserDetails.fromSession(userId, email, "ADMIN", 1);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }
 
     private ChatMessageResponseDto savedUserMessage(Long roomId, Long senderId, String content) {

--- a/src/test/java/com/fairing/fairplay/ai/rag/event/RagReindexRequestTest.java
+++ b/src/test/java/com/fairing/fairplay/ai/rag/event/RagReindexRequestTest.java
@@ -1,0 +1,29 @@
+package com.fairing.fairplay.ai.rag.event;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RagReindexRequestTest {
+
+    @Test
+    void rejectsNullDocumentType() {
+        assertThatThrownBy(() -> RagReindexRequest.upsert(null, 1L))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("documentType must not be null");
+    }
+
+    @Test
+    void rejectsNullDocumentId() {
+        assertThatThrownBy(() -> RagReindexRequest.delete(RagDocumentType.EVENT, null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("documentId must not be null");
+    }
+
+    @Test
+    void rejectsNonPositiveDocumentId() {
+        assertThatThrownBy(() -> RagReindexRequest.upsert(RagDocumentType.EVENT, 0L))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("documentId must be positive");
+    }
+}

--- a/src/test/java/com/fairing/fairplay/ai/rag/service/DocumentIngestServiceTest.java
+++ b/src/test/java/com/fairing/fairplay/ai/rag/service/DocumentIngestServiceTest.java
@@ -1,0 +1,115 @@
+package com.fairing.fairplay.ai.rag.service;
+
+import com.fairing.fairplay.ai.rag.domain.Chunk;
+import com.fairing.fairplay.ai.rag.domain.Document;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DocumentIngestServiceTest {
+
+    @Mock
+    ChunkingService chunkingService;
+
+    @Mock
+    EmbeddingService embeddingService;
+
+    @Mock
+    RagChunkWriteService ragChunkWriteService;
+
+    @Mock
+    VectorSearchService vectorSearchService;
+
+    ThreadPoolTaskExecutor taskExecutor;
+    DocumentIngestService documentIngestService;
+
+    @BeforeEach
+    void setUp() {
+        taskExecutor = new ThreadPoolTaskExecutor();
+        taskExecutor.setCorePoolSize(1);
+        taskExecutor.setMaxPoolSize(1);
+        taskExecutor.initialize();
+
+        documentIngestService = new DocumentIngestService(
+            chunkingService,
+            embeddingService,
+            ragChunkWriteService,
+            vectorSearchService,
+            taskExecutor
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        taskExecutor.shutdown();
+    }
+
+    @Test
+    void replacesDocumentAfterEmbeddingSucceeds() throws Exception {
+        Document document = document();
+        Chunk chunk = chunk();
+
+        when(chunkingService.chunkDocument(document.getDocId(), document.getContent()))
+            .thenReturn(List.of(chunk));
+        when(embeddingService.embedText(chunk.getText()))
+            .thenReturn(new float[] {0.1f, 0.2f});
+
+        DocumentIngestService.IngestResult result = documentIngestService.ingestDocument(document);
+
+        assertThat(result.isSuccess()).isTrue();
+        verify(ragChunkWriteService).replaceDocument(eq(document.getDocId()), argThat(chunks ->
+            chunks.size() == 1 && chunks.get(0).getEmbedding().length == 2
+        ));
+        verify(vectorSearchService).invalidateCache();
+    }
+
+    @Test
+    void keepsExistingDocumentWhenEveryEmbeddingFails() throws Exception {
+        Document document = document();
+        Chunk chunk = chunk();
+
+        when(chunkingService.chunkDocument(document.getDocId(), document.getContent()))
+            .thenReturn(List.of(chunk));
+        when(embeddingService.embedText(chunk.getText()))
+            .thenThrow(new IllegalStateException("embedding unavailable"));
+
+        DocumentIngestService.IngestResult result = documentIngestService.ingestDocument(document);
+
+        assertThat(result.isSuccess()).isFalse();
+        verify(ragChunkWriteService, never()).replaceDocument(anyString(), anyList());
+        verify(vectorSearchService, never()).invalidateCache();
+    }
+
+    private Document document() {
+        return Document.builder()
+            .docId("event_52")
+            .title("2025 트렌드페어")
+            .content("2025 트렌드페어 행사 정보와 장소, 기간, 티켓 정보를 포함한 충분히 긴 테스트 문서입니다.")
+            .category("event")
+            .build();
+    }
+
+    private Chunk chunk() {
+        return Chunk.builder()
+            .chunkId("chunk_1")
+            .docId("event_52")
+            .text("2025 트렌드페어 행사 정보와 장소, 기간, 티켓 정보를 포함한 청크입니다.")
+            .build();
+    }
+}

--- a/src/test/java/com/fairing/fairplay/ai/rag/service/DocumentIngestServiceTransactionContractTest.java
+++ b/src/test/java/com/fairing/fairplay/ai/rag/service/DocumentIngestServiceTransactionContractTest.java
@@ -11,11 +11,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DocumentIngestServiceTransactionContractTest {
 
     @Test
-    void ingestDocumentUsesIndependentWriteTransaction() throws Exception {
+    void ingestDocumentDoesNotHoldTransactionDuringEmbeddingIo() throws Exception {
         Method method = DocumentIngestService.class.getMethod(
             "ingestDocument",
             com.fairing.fairplay.ai.rag.domain.Document.class
         );
+
+        Transactional transactional = method.getAnnotation(Transactional.class);
+
+        assertThat(transactional).isNull();
+    }
+
+    @Test
+    void chunkReplacementUsesIndependentWriteTransaction() throws Exception {
+        Method method = RagChunkWriteService.class.getMethod("replaceDocument", String.class, java.util.List.class);
 
         Transactional transactional = method.getAnnotation(Transactional.class);
 
@@ -25,7 +34,7 @@ class DocumentIngestServiceTransactionContractTest {
 
     @Test
     void deleteDocumentUsesIndependentWriteTransaction() throws Exception {
-        Method method = DocumentIngestService.class.getMethod("deleteDocument", String.class);
+        Method method = RagChunkWriteService.class.getMethod("deleteDocument", String.class);
 
         Transactional transactional = method.getAnnotation(Transactional.class);
 

--- a/src/test/java/com/fairing/fairplay/ai/rag/service/DocumentIngestServiceTransactionContractTest.java
+++ b/src/test/java/com/fairing/fairplay/ai/rag/service/DocumentIngestServiceTransactionContractTest.java
@@ -1,0 +1,35 @@
+package com.fairing.fairplay.ai.rag.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.reflect.Method;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DocumentIngestServiceTransactionContractTest {
+
+    @Test
+    void ingestDocumentUsesIndependentWriteTransaction() throws Exception {
+        Method method = DocumentIngestService.class.getMethod(
+            "ingestDocument",
+            com.fairing.fairplay.ai.rag.domain.Document.class
+        );
+
+        Transactional transactional = method.getAnnotation(Transactional.class);
+
+        assertThat(transactional).isNotNull();
+        assertThat(transactional.propagation()).isEqualTo(Propagation.REQUIRES_NEW);
+    }
+
+    @Test
+    void deleteDocumentUsesIndependentWriteTransaction() throws Exception {
+        Method method = DocumentIngestService.class.getMethod("deleteDocument", String.class);
+
+        Transactional transactional = method.getAnnotation(Transactional.class);
+
+        assertThat(transactional).isNotNull();
+        assertThat(transactional.propagation()).isEqualTo(Propagation.REQUIRES_NEW);
+    }
+}

--- a/src/test/java/com/fairing/fairplay/ai/rag/service/RagReindexEventListenerTest.java
+++ b/src/test/java/com/fairing/fairplay/ai/rag/service/RagReindexEventListenerTest.java
@@ -8,6 +8,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -48,5 +50,30 @@ class RagReindexEventListenerTest {
         listener.handle(RagReindexRequest.delete(RagDocumentType.EVENT, 52L));
 
         verify(documentIngestService).deleteDocument("event_52");
+    }
+
+    @Test
+    void deleteBoothRemovesStoredDocument() {
+        listener.handle(RagReindexRequest.delete(RagDocumentType.BOOTH, 11L));
+
+        verify(documentIngestService).deleteDocument("booth_11");
+    }
+
+    @Test
+    void deleteBoothExperienceRemovesStoredDocument() {
+        listener.handle(RagReindexRequest.delete(RagDocumentType.BOOTH_EXPERIENCE, 7L));
+
+        verify(documentIngestService).deleteDocument("booth_experience_7");
+    }
+
+    @Test
+    void reindexFailureIsSurfaced() {
+        doThrow(new IllegalStateException("loader down"))
+            .when(comprehensiveRagDataLoader).loadSingleEvent(52L);
+
+        assertThatThrownBy(() -> listener.handle(RagReindexRequest.upsert(RagDocumentType.EVENT, 52L)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("RAG reindex event failed")
+            .hasRootCauseMessage("loader down");
     }
 }

--- a/src/test/java/com/fairing/fairplay/ai/rag/service/RagReindexEventListenerTest.java
+++ b/src/test/java/com/fairing/fairplay/ai/rag/service/RagReindexEventListenerTest.java
@@ -1,0 +1,52 @@
+package com.fairing.fairplay.ai.rag.service;
+
+import com.fairing.fairplay.ai.rag.event.RagDocumentType;
+import com.fairing.fairplay.ai.rag.event.RagReindexRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RagReindexEventListenerTest {
+
+    @Mock
+    ComprehensiveRagDataLoader comprehensiveRagDataLoader;
+
+    @Mock
+    DocumentIngestService documentIngestService;
+
+    @InjectMocks
+    RagReindexEventListener listener;
+
+    @Test
+    void eventUpsertReloadsSingleEventDocument() {
+        listener.handle(RagReindexRequest.upsert(RagDocumentType.EVENT, 52L));
+
+        verify(comprehensiveRagDataLoader).loadSingleEvent(52L);
+    }
+
+    @Test
+    void boothUpsertReloadsSingleBoothDocument() {
+        listener.handle(RagReindexRequest.upsert(RagDocumentType.BOOTH, 11L));
+
+        verify(comprehensiveRagDataLoader).loadSingleBooth(11L);
+    }
+
+    @Test
+    void boothExperienceUpsertReloadsSingleExperienceDocument() {
+        listener.handle(RagReindexRequest.upsert(RagDocumentType.BOOTH_EXPERIENCE, 7L));
+
+        verify(comprehensiveRagDataLoader).loadSingleBoothExperience(7L);
+    }
+
+    @Test
+    void deleteRemovesStoredDocument() {
+        listener.handle(RagReindexRequest.delete(RagDocumentType.EVENT, 52L));
+
+        verify(documentIngestService).deleteDocument("event_52");
+    }
+}

--- a/src/test/java/com/fairing/fairplay/booth/service/BoothExperienceServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/booth/service/BoothExperienceServiceAuthorizationTest.java
@@ -11,6 +11,7 @@ import com.fairing.fairplay.booth.repository.BoothExperienceRepository;
 import com.fairing.fairplay.booth.repository.BoothExperienceReservationRepository;
 import com.fairing.fairplay.booth.repository.BoothExperienceStatusCodeRepository;
 import com.fairing.fairplay.booth.repository.BoothRepository;
+import com.fairing.fairplay.ai.rag.service.RagIndexingEventPublisher;
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.core.security.CustomUserDetails;
 import com.fairing.fairplay.event.entity.Event;
@@ -62,6 +63,9 @@ class BoothExperienceServiceAuthorizationTest {
   @Mock
   private RealtimeSseService realtimeSseService;
 
+  @Mock
+  private RagIndexingEventPublisher ragIndexingEventPublisher;
+
   private BoothExperienceService service;
 
   @BeforeEach
@@ -72,7 +76,8 @@ class BoothExperienceServiceAuthorizationTest {
         statusCodeRepository,
         boothRepository,
         userRepository,
-        realtimeSseService
+        realtimeSseService,
+        ragIndexingEventPublisher
     );
   }
 

--- a/src/test/java/com/fairing/fairplay/booth/service/BoothQrServiceAuthorizationTest.java
+++ b/src/test/java/com/fairing/fairplay/booth/service/BoothQrServiceAuthorizationTest.java
@@ -10,6 +10,7 @@ import com.fairing.fairplay.booth.repository.BoothExperienceRepository;
 import com.fairing.fairplay.booth.repository.BoothExperienceReservationRepository;
 import com.fairing.fairplay.booth.repository.BoothExperienceStatusCodeRepository;
 import com.fairing.fairplay.booth.repository.BoothRepository;
+import com.fairing.fairplay.ai.rag.service.RagIndexingEventPublisher;
 import com.fairing.fairplay.common.exception.CustomException;
 import com.fairing.fairplay.event.entity.Event;
 import com.fairing.fairplay.qr.dto.scan.CheckResponseDto;
@@ -65,6 +66,9 @@ class BoothQrServiceAuthorizationTest {
   @Mock
   private RealtimeSseService realtimeSseService;
 
+  @Mock
+  private RagIndexingEventPublisher ragIndexingEventPublisher;
+
   private BoothQrService boothQrService;
 
   @BeforeEach
@@ -75,7 +79,8 @@ class BoothQrServiceAuthorizationTest {
         statusCodeRepository,
         boothRepository,
         userRepository,
-        realtimeSseService
+        realtimeSseService,
+        ragIndexingEventPublisher
     );
     boothQrService = new BoothQrService(
         userRepository,


### PR DESCRIPTION
## Summary
- Fix AI chat WebSocket sender auth by reading userId from CustomUserDetails instead of parsing principal name as a numeric id
- Isolate RAG document ingest/delete into REQUIRES_NEW write transactions so admin full reindex works from read-only loader flows
- Add after-commit RAG reindex events for event, booth, and booth-experience create/update/delete paths
- Add focused contract tests for AI WebSocket auth, RAG transaction propagation, and reindex event routing

## Root cause
- Live logs showed authenticated WebSocket principal name was the email, so Long.parseLong(principal.getName()) returned null and emitted "인증이 필요합니다."
- Production rag_chunks was empty, and manual full reindex failed because a read-only loader transaction attempted DELETE before inserting chunks

## Tests
- ./gradlew test

## Notes
- CodeRabbit rate limits/stale notices are non-blocking per project rule; concrete critical/high/actionable review findings should still be addressed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * AI 검색 시스템이 이벤트, 부스, 체험 정보 변경 시 자동으로 데이터를 동기화합니다
  * AI 채팅 시스템의 사용자 인증 처리가 개선되었습니다

* **Tests**
  * 트랜잭션 관리 및 비동기 이벤트 처리에 대한 테스트 커버리지가 추가되었습니다

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rktclgh/FairPlay_BE/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->