### PR TITLE
Keep public RAG backfills out of private user data

### DIFF
--- a/src/main/java/com/fairing/fairplay/ai/rag/service/ComprehensiveRagDataLoader.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/service/ComprehensiveRagDataLoader.java
@@ -204,8 +204,9 @@ public class ComprehensiveRagDataLoader {
         result.categoryResult = new LoadResult("Category", 0, 0, 0);
         log.info("카테고리 로딩 완전 비활성화: 예매/취소/환불 정책이 실제 이벤트 검색을 완전히 방해함");
         
-        // 6. 사용자별 개인정보 데이터 로드 (예약정보, 티켓정보)
-        result.userDataResult = loadUserData();
+        // 6. 사용자별 개인정보 데이터는 공개 상담 RAG 범위에서 제외
+        result.userDataResult = new LoadResult("UserData", 0, 0, 0);
+        log.info("사용자 개인정보 RAG 로딩 비활성화: 공개 AI 상담 색인에는 행사/부스 공개 정보만 포함");
         
         log.info("종합 공개 데이터 RAG 로드 완료: {}", result.getSummary());
         

--- a/src/test/java/com/fairing/fairplay/ai/rag/service/ComprehensiveRagDataLoaderPublicScopeTest.java
+++ b/src/test/java/com/fairing/fairplay/ai/rag/service/ComprehensiveRagDataLoaderPublicScopeTest.java
@@ -1,0 +1,114 @@
+package com.fairing.fairplay.ai.rag.service;
+
+import com.fairing.fairplay.attendee.repository.AttendeeRepository;
+import com.fairing.fairplay.booth.repository.BoothExperienceRepository;
+import com.fairing.fairplay.booth.repository.BoothRepository;
+import com.fairing.fairplay.event.repository.EventDetailRepository;
+import com.fairing.fairplay.event.repository.EventRepository;
+import com.fairing.fairplay.event.repository.MainCategoryRepository;
+import com.fairing.fairplay.event.repository.SubCategoryRepository;
+import com.fairing.fairplay.reservation.repository.ReservationRepository;
+import com.fairing.fairplay.review.repository.ReviewRepository;
+import com.fairing.fairplay.ticket.repository.EventScheduleRepository;
+import com.fairing.fairplay.ticket.repository.TicketRepository;
+import com.fairing.fairplay.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.AbstractPlatformTransactionManager;
+import org.springframework.transaction.support.DefaultTransactionStatus;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ComprehensiveRagDataLoaderPublicScopeTest {
+
+    @Mock
+    EventRepository eventRepository;
+    @Mock
+    EventDetailRepository eventDetailRepository;
+    @Mock
+    MainCategoryRepository mainCategoryRepository;
+    @Mock
+    SubCategoryRepository subCategoryRepository;
+    @Mock
+    BoothRepository boothRepository;
+    @Mock
+    BoothExperienceRepository boothExperienceRepository;
+    @Mock
+    ReviewRepository reviewRepository;
+    @Mock
+    TicketRepository ticketRepository;
+    @Mock
+    EventScheduleRepository eventScheduleRepository;
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    ReservationRepository reservationRepository;
+    @Mock
+    AttendeeRepository attendeeRepository;
+    @Mock
+    DocumentIngestService documentIngestService;
+
+    ComprehensiveRagDataLoader loader;
+
+    @BeforeEach
+    void setUp() {
+        loader = new ComprehensiveRagDataLoader(
+            eventRepository,
+            eventDetailRepository,
+            mainCategoryRepository,
+            subCategoryRepository,
+            boothRepository,
+            boothExperienceRepository,
+            reviewRepository,
+            ticketRepository,
+            eventScheduleRepository,
+            userRepository,
+            reservationRepository,
+            attendeeRepository,
+            documentIngestService,
+            new NoOpTransactionManager()
+        );
+    }
+
+    @Test
+    void comprehensivePublicLoadDoesNotReadUserPrivateData() {
+        when(eventRepository.findAll()).thenReturn(List.of());
+        when(boothRepository.findAll()).thenReturn(List.of());
+        when(boothExperienceRepository.findAll()).thenReturn(List.of());
+        when(reviewRepository.findAll()).thenReturn(List.of());
+
+        ComprehensiveRagDataLoader.ComprehensiveLoadResult result = loader.loadAllPublicData();
+
+        assertThat(result.userDataResult.getTotalCount()).isZero();
+        assertThat(result.userDataResult.getSuccessCount()).isZero();
+        verifyNoInteractions(userRepository, reservationRepository, attendeeRepository);
+    }
+
+    private static class NoOpTransactionManager extends AbstractPlatformTransactionManager {
+        @Override
+        protected Object doGetTransaction() {
+            return new Object();
+        }
+
+        @Override
+        protected void doBegin(Object transaction, TransactionDefinition definition) {
+        }
+
+        @Override
+        protected void doCommit(DefaultTransactionStatus status) {
+        }
+
+        @Override
+        protected void doRollback(DefaultTransactionStatus status) {
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- disables UserData loading from the comprehensive public RAG backfill
- adds a regression test that the public backfill does not touch user/reservation/attendee repositories

## Why
The manual full-embedding endpoint is used for the AI counselor's event/booth search index. It should not index private profile or reservation data.

## Verification
- ./gradlew test --tests com.fairing.fairplay.ai.rag.service.ComprehensiveRagDataLoaderPublicScopeTest --no-daemon
- ./gradlew test --no-daemon

Co-authored-by: OmX <omx@oh-my-codex.dev>