### PR TITLE
Run admin RAG reloads asynchronously

### DIFF
--- a/src/main/java/com/fairing/fairplay/ai/rag/controller/RagAdminController.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/controller/RagAdminController.java
@@ -3,7 +3,9 @@ package com.fairing.fairplay.ai.rag.controller;
 import com.fairing.fairplay.ai.rag.service.VectorSearchService;
 import com.fairing.fairplay.ai.rag.service.EventRagDataLoader;
 import com.fairing.fairplay.ai.rag.service.ComprehensiveRagDataLoader;
+import com.fairing.fairplay.ai.rag.service.RagLoadJobService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,6 +22,7 @@ public class RagAdminController {
     private final VectorSearchService vectorSearchService;
     private final EventRagDataLoader eventRagDataLoader;
     private final ComprehensiveRagDataLoader comprehensiveRagDataLoader;
+    private final RagLoadJobService ragLoadJobService;
 
     /**
      * 캐시 상태 확인
@@ -107,55 +110,29 @@ public class RagAdminController {
      * 제외: User 개인정보, 통계 데이터, Admin 전용 데이터, 결제 정보
      */
     @PostMapping("/load/comprehensive")
-    public ResponseEntity<Map<String, Object>> loadComprehensiveData() {
-        try {
-            ComprehensiveRagDataLoader.ComprehensiveLoadResult result = 
-                comprehensiveRagDataLoader.loadAllPublicData();
-            
-            return ResponseEntity.ok(Map.of(
-                "success", true,
-                "message", "종합 공개 데이터 로드 완료",
-                "totalSuccessCount", result.getTotalSuccessCount(),
-                "totalFailCount", result.getTotalFailCount(),
-                "summary", result.getSummary(),
-                "details", Map.of(
-                    "event", Map.of(
-                        "total", result.eventResult.getTotalCount(),
-                        "success", result.eventResult.getSuccessCount(),
-                        "fail", result.eventResult.getFailCount()
-                    ),
-                    "booth", Map.of(
-                        "total", result.boothResult.getTotalCount(),
-                        "success", result.boothResult.getSuccessCount(),
-                        "fail", result.boothResult.getFailCount()
-                    ),
-                    "boothExperience", Map.of(
-                        "total", result.boothExperienceResult.getTotalCount(),
-                        "success", result.boothExperienceResult.getSuccessCount(),
-                        "fail", result.boothExperienceResult.getFailCount()
-                    ),
-                    "review", Map.of(
-                        "total", result.reviewResult.getTotalCount(),
-                        "success", result.reviewResult.getSuccessCount(),
-                        "fail", result.reviewResult.getFailCount()
-                    ),
-                    "category", Map.of(
-                        "total", result.categoryResult.getTotalCount(),
-                        "success", result.categoryResult.getSuccessCount(),
-                        "fail", result.categoryResult.getFailCount()
-                    ),
-                    "userData", Map.of(
-                        "total", result.userDataResult.getTotalCount(),
-                        "success", result.userDataResult.getSuccessCount(),
-                        "fail", result.userDataResult.getFailCount()
-                    )
-                )
-            ));
-        } catch (Exception e) {
-            return ResponseEntity.badRequest().body(Map.of(
+    public ResponseEntity<RagLoadJobService.JobSnapshot> loadComprehensiveData() {
+        RagLoadJobService.JobSnapshot job = ragLoadJobService.startComprehensiveLoad();
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(job);
+    }
+
+    @GetMapping("/load/comprehensive/jobs/latest")
+    public ResponseEntity<?> getLatestComprehensiveLoadJob() {
+        return ragLoadJobService.getLatestJob()
+            .<ResponseEntity<?>>map(ResponseEntity::ok)
+            .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of(
                 "success", false,
-                "message", "종합 데이터 로드 실패: " + e.getMessage()
-            ));
-        }
+                "message", "실행된 종합 RAG 로드 작업이 없습니다."
+            )));
+    }
+
+    @GetMapping("/load/comprehensive/jobs/{jobId}")
+    public ResponseEntity<?> getComprehensiveLoadJob(@PathVariable String jobId) {
+        return ragLoadJobService.getJob(jobId)
+            .<ResponseEntity<?>>map(ResponseEntity::ok)
+            .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of(
+                "success", false,
+                "message", "RAG 로드 작업을 찾을 수 없습니다.",
+                "jobId", jobId
+            )));
     }
 }

--- a/src/main/java/com/fairing/fairplay/ai/rag/service/RagLoadJobService.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/service/RagLoadJobService.java
@@ -1,0 +1,160 @@
+package com.fairing.fairplay.ai.rag.service;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Service
+@Slf4j
+public class RagLoadJobService {
+
+    private final ComprehensiveRagDataLoader comprehensiveRagDataLoader;
+    private final Executor ragAdminTaskExecutor;
+    private final ConcurrentHashMap<String, JobSnapshot> jobs = new ConcurrentHashMap<>();
+    private final AtomicReference<String> latestJobId = new AtomicReference<>();
+    private final Object startLock = new Object();
+
+    public RagLoadJobService(
+            ComprehensiveRagDataLoader comprehensiveRagDataLoader,
+            @Qualifier("ragAdminTaskExecutor") Executor ragAdminTaskExecutor) {
+        this.comprehensiveRagDataLoader = comprehensiveRagDataLoader;
+        this.ragAdminTaskExecutor = ragAdminTaskExecutor;
+    }
+
+    public JobSnapshot startComprehensiveLoad() {
+        synchronized (startLock) {
+            Optional<JobSnapshot> runningJob = getLatestJob()
+                .filter(job -> JobStatus.RUNNING.equals(job.getStatus()));
+            if (runningJob.isPresent()) {
+                JobSnapshot job = runningJob.get().withAlreadyRunning(true);
+                jobs.put(job.getJobId(), job);
+                return job;
+            }
+
+            JobSnapshot job = JobSnapshot.running(UUID.randomUUID().toString());
+            jobs.put(job.getJobId(), job);
+            latestJobId.set(job.getJobId());
+            ragAdminTaskExecutor.execute(() -> runComprehensiveLoad(job.getJobId()));
+            return job;
+        }
+    }
+
+    public Optional<JobSnapshot> getLatestJob() {
+        String jobId = latestJobId.get();
+        if (jobId == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(jobs.get(jobId));
+    }
+
+    public Optional<JobSnapshot> getJob(String jobId) {
+        return Optional.ofNullable(jobs.get(jobId));
+    }
+
+    private void runComprehensiveLoad(String jobId) {
+        try {
+            log.info("RAG comprehensive load job started: {}", jobId);
+            ComprehensiveRagDataLoader.ComprehensiveLoadResult result =
+                comprehensiveRagDataLoader.loadAllPublicData();
+            jobs.computeIfPresent(jobId, (id, job) -> job.succeeded(result));
+            log.info("RAG comprehensive load job succeeded: {}", jobId);
+        } catch (Exception e) {
+            jobs.computeIfPresent(jobId, (id, job) -> job.failed(e));
+            log.error("RAG comprehensive load job failed: {}", jobId, e);
+        }
+    }
+
+    public enum JobStatus {
+        RUNNING,
+        SUCCEEDED,
+        FAILED
+    }
+
+    @Getter
+    public static class JobSnapshot {
+        private final String jobId;
+        private final JobStatus status;
+        private final Instant startedAt;
+        private final Instant finishedAt;
+        private final boolean alreadyRunning;
+        private final String summary;
+        private final Integer totalSuccessCount;
+        private final Integer totalFailCount;
+        private final String errorMessage;
+
+        private JobSnapshot(
+                String jobId,
+                JobStatus status,
+                Instant startedAt,
+                Instant finishedAt,
+                boolean alreadyRunning,
+                String summary,
+                Integer totalSuccessCount,
+                Integer totalFailCount,
+                String errorMessage) {
+            this.jobId = jobId;
+            this.status = status;
+            this.startedAt = startedAt;
+            this.finishedAt = finishedAt;
+            this.alreadyRunning = alreadyRunning;
+            this.summary = summary;
+            this.totalSuccessCount = totalSuccessCount;
+            this.totalFailCount = totalFailCount;
+            this.errorMessage = errorMessage;
+        }
+
+        static JobSnapshot running(String jobId) {
+            return new JobSnapshot(jobId, JobStatus.RUNNING, Instant.now(), null, false, null, null, null, null);
+        }
+
+        JobSnapshot withAlreadyRunning(boolean alreadyRunning) {
+            return new JobSnapshot(
+                jobId,
+                status,
+                startedAt,
+                finishedAt,
+                alreadyRunning,
+                summary,
+                totalSuccessCount,
+                totalFailCount,
+                errorMessage
+            );
+        }
+
+        JobSnapshot succeeded(ComprehensiveRagDataLoader.ComprehensiveLoadResult result) {
+            return new JobSnapshot(
+                jobId,
+                JobStatus.SUCCEEDED,
+                startedAt,
+                Instant.now(),
+                false,
+                result.getSummary(),
+                result.getTotalSuccessCount(),
+                result.getTotalFailCount(),
+                null
+            );
+        }
+
+        JobSnapshot failed(Exception e) {
+            return new JobSnapshot(
+                jobId,
+                JobStatus.FAILED,
+                startedAt,
+                Instant.now(),
+                false,
+                summary,
+                totalSuccessCount,
+                totalFailCount,
+                e.getMessage()
+            );
+        }
+    }
+}

--- a/src/main/java/com/fairing/fairplay/config/AsyncConfig.java
+++ b/src/main/java/com/fairing/fairplay/config/AsyncConfig.java
@@ -77,4 +77,19 @@ public class AsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    @Bean(name = "ragAdminTaskExecutor")
+    public ThreadPoolTaskExecutor ragAdminTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(1);
+        executor.setQueueCapacity(1);
+        executor.setThreadNamePrefix("rag-admin-");
+        executor.setBeanName("ragAdminTaskExecutor");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
+        executor.initialize();
+        return executor;
+    }
 }

--- a/src/test/java/com/fairing/fairplay/ai/rag/service/RagLoadJobServiceTest.java
+++ b/src/test/java/com/fairing/fairplay/ai/rag/service/RagLoadJobServiceTest.java
@@ -1,0 +1,64 @@
+package com.fairing.fairplay.ai.rag.service;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RagLoadJobServiceTest {
+
+    @Test
+    void startsComprehensiveLoadInExecutorAndStoresResult() {
+        ComprehensiveRagDataLoader dataLoader = mock(ComprehensiveRagDataLoader.class);
+        ComprehensiveRagDataLoader.ComprehensiveLoadResult loadResult = successfulResult();
+        when(dataLoader.loadAllPublicData()).thenReturn(loadResult);
+        RagLoadJobService service = new RagLoadJobService(dataLoader, Runnable::run);
+
+        RagLoadJobService.JobSnapshot started = service.startComprehensiveLoad();
+        RagLoadJobService.JobSnapshot latest = service.getLatestJob().orElseThrow();
+
+        assertThat(started.getStatus()).isEqualTo(RagLoadJobService.JobStatus.RUNNING);
+        assertThat(latest.getStatus()).isEqualTo(RagLoadJobService.JobStatus.SUCCEEDED);
+        assertThat(latest.getSummary()).contains("Event");
+        assertThat(latest.getTotalFailCount()).isZero();
+        verify(dataLoader).loadAllPublicData();
+    }
+
+    @Test
+    void returnsCurrentRunningJobInsteadOfStartingDuplicateLoad() {
+        ComprehensiveRagDataLoader dataLoader = mock(ComprehensiveRagDataLoader.class);
+        AtomicReference<Runnable> pendingTask = new AtomicReference<>();
+        AtomicInteger executeCount = new AtomicInteger();
+        Executor capturingExecutor = task -> {
+            executeCount.incrementAndGet();
+            pendingTask.set(task);
+        };
+        RagLoadJobService service = new RagLoadJobService(dataLoader, capturingExecutor);
+
+        RagLoadJobService.JobSnapshot first = service.startComprehensiveLoad();
+        RagLoadJobService.JobSnapshot second = service.startComprehensiveLoad();
+
+        assertThat(first.getJobId()).isEqualTo(second.getJobId());
+        assertThat(second.isAlreadyRunning()).isTrue();
+        assertThat(executeCount).hasValue(1);
+        assertThat(pendingTask.get()).isNotNull();
+    }
+
+    private ComprehensiveRagDataLoader.ComprehensiveLoadResult successfulResult() {
+        ComprehensiveRagDataLoader.ComprehensiveLoadResult result =
+            new ComprehensiveRagDataLoader.ComprehensiveLoadResult();
+        result.eventResult = new ComprehensiveRagDataLoader.LoadResult("Event", 1, 1, 0);
+        result.boothResult = new ComprehensiveRagDataLoader.LoadResult("Booth", 1, 1, 0);
+        result.boothExperienceResult = new ComprehensiveRagDataLoader.LoadResult("BoothExperience", 1, 1, 0);
+        result.reviewResult = new ComprehensiveRagDataLoader.LoadResult("Review", 1, 1, 0);
+        result.categoryResult = new ComprehensiveRagDataLoader.LoadResult("Category", 0, 0, 0);
+        result.userDataResult = new ComprehensiveRagDataLoader.LoadResult("UserData", 1, 1, 0);
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary
- change the admin comprehensive RAG reload endpoint to return 202 with a job snapshot instead of blocking behind Cloudflare
- run the full reload on a bounded single-worker executor and expose latest/job status polling endpoints
- prevent duplicate concurrent manual reloads from stacking while one job is running

## Why
Cloudflare returned 524 because the origin request stayed open while Gemini embedding calls were intentionally throttled to avoid 429s. The backend kept working and completed, but the client timed out at the proxy. This makes the admin action asynchronous without removing the provider-safe throttle.

## Verification
- git diff --check
- ./gradlew test --tests com.fairing.fairplay.ai.rag.service.RagLoadJobServiceTest --no-daemon
- ./gradlew test --no-daemon