### PR TITLE
Block operational commands in AI chat

### DIFF
--- a/src/main/java/com/fairing/fairplay/ai/rag/service/RagChatService.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/service/RagChatService.java
@@ -224,7 +224,37 @@ public class RagChatService {
                compact.contains("api키") ||
                compact.contains("토큰") ||
                compact.contains("비밀번호") ||
-               compact.contains("패스워드");
+               compact.contains("패스워드") ||
+               isOperationalCommandQuery(normalized, compact);
+    }
+
+    private boolean isOperationalCommandQuery(String normalized, String compact) {
+        if (normalized == null || normalized.isBlank()) {
+            return false;
+        }
+
+        if (compact.contains("../") ||
+            compact.contains("..\\") ||
+            compact.contains("/etc/") ||
+            compact.contains("/proc/") ||
+            compact.contains("/var/log") ||
+            compact.contains("~/.ssh") ||
+            compact.contains("idrsa") ||
+            compact.contains(".env")) {
+            return true;
+        }
+
+        if (normalized.contains("&&") ||
+            normalized.contains("||") ||
+            normalized.contains("$(") ||
+            normalized.contains("`") ||
+            normalized.contains(" >") ||
+            normalized.contains(" <") ||
+            normalized.contains(" | ")) {
+            return true;
+        }
+
+        return normalized.matches("^(cd|ls|ll|pwd|cat|env|printenv|whoami|id|uname|hostname|ps|top|htop|free|df|du|docker|kubectl|curl|wget|ssh|scp|sudo|su|rm|cp|mv|chmod|chown|find|grep|tail|head|less|vi|vim|nano)(\\s+.*)?$");
     }
 
     private boolean isEventInformationQuery(String question) {

--- a/src/test/java/com/fairing/fairplay/ai/rag/service/RagChatServiceScopeTest.java
+++ b/src/test/java/com/fairing/fairplay/ai/rag/service/RagChatServiceScopeTest.java
@@ -159,6 +159,25 @@ class RagChatServiceScopeTest {
     }
 
     @Test
+    void operationalCommandRequestIsBlockedBeforeSearchOrLlm() throws Exception {
+        RagChatService.RagResponse response = ragChatService.chat(
+            "cd ../",
+            List.of(ChatMessageDto.user("cd ../")),
+            10L
+        );
+
+        assertThat(response.isHasContext()).isFalse();
+        assertThat(response.getAnswer())
+            .contains("도와드릴 수 없어요")
+            .contains("서버 자원");
+        verify(vectorSearchService, never()).searchUserData(any(), any());
+        verify(vectorSearchService, never()).searchUserPrivate(any(), any());
+        verify(vectorSearchService, never()).searchPublicOnly(any());
+        verify(vectorSearchService, never()).searchPublicEventsFirst(any());
+        verify(llmRouter, never()).pick(any());
+    }
+
+    @Test
     void questionWithoutFairPlayContextDoesNotCallLlm() throws Exception {
         when(vectorSearchService.searchPublicOnly("미국 수도가 어디야?"))
             .thenReturn(SearchResult.builder()


### PR DESCRIPTION
Blocks shell-style and server-probing prompts before vector search, so false-positive RAG chunks cannot route operational commands into the local LLM.

Included:
- Treats filesystem traversal, common shell commands, shell metacharacters, env/host/process probing, and Docker/Kubernetes commands as security-boundary requests.
- Keeps FairPlay-domain no-context fallback behavior intact.
- Adds regression coverage for cd ../ being blocked before search or LLM.

Tested: ./gradlew test --tests com.fairing.fairplay.ai.rag.service.RagChatServiceScopeTest --no-daemon.
Tested: git diff --check.