### PR TITLE
Deploy latest RAG search scope fixes

### DIFF
--- a/src/main/java/com/fairing/fairplay/ai/rag/repository/PgVectorRagRepository.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/repository/PgVectorRagRepository.java
@@ -100,7 +100,7 @@ public class PgVectorRagRepository implements RagChunkRepository {
 
     @Override
     public List<SearchResult.ScoredChunk> searchUserSimilar(Long userId, float[] queryEmbedding, int topK, double threshold) {
-        return searchSimilarByScope(queryEmbedding, topK, threshold, "AND owner_user_id = ?", userId);
+        return searchSimilarByScope(queryEmbedding, topK, threshold, "AND visibility = 'USER_PRIVATE' AND owner_user_id = ?", userId);
     }
 
     @Override
@@ -136,7 +136,7 @@ public class PgVectorRagRepository implements RagChunkRepository {
 
     @Override
     public List<SearchResult.ScoredChunk> searchUserKeyword(Long userId, String query, int topK) {
-        return searchKeywordByScope(query, topK, "AND owner_user_id = ?", userId);
+        return searchKeywordByScope(query, topK, "AND visibility = 'USER_PRIVATE' AND owner_user_id = ?", userId);
     }
 
     @Override
@@ -275,7 +275,7 @@ public class PgVectorRagRepository implements RagChunkRepository {
     }
 
     private String userTypeScope(List<String> docTypes) {
-        return "AND owner_user_id = ? AND doc_type IN (" + placeholders(docTypes) + ")";
+        return "AND visibility = 'USER_PRIVATE' AND owner_user_id = ? AND doc_type IN (" + placeholders(docTypes) + ")";
     }
 
     private String placeholders(List<String> values) {

--- a/src/main/java/com/fairing/fairplay/ai/rag/service/VectorSearchService.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/service/VectorSearchService.java
@@ -69,11 +69,16 @@ public class VectorSearchService {
         List<SearchResult.ScoredChunk> combined =
             combineSearchResults(vectorChunks, keywordChunks, DEFAULT_TOP_K, query);
 
-        return SearchResult.builder()
+        SearchResult result = SearchResult.builder()
             .chunks(combined)
             .contextText(buildContextTextFromScored(combined))
             .totalChunks(combined.size())
             .build();
+
+        if (result.getChunks().isEmpty()) {
+            result.setContextText("해당 사용자의 정보를 찾을 수 없습니다.");
+        }
+        return result;
     }
 
     public SearchResult searchPublicEventsFirst(String query) throws Exception {

--- a/src/main/java/com/fairing/fairplay/ai/rag/service/VectorSearchService.java
+++ b/src/main/java/com/fairing/fairplay/ai/rag/service/VectorSearchService.java
@@ -69,16 +69,7 @@ public class VectorSearchService {
         List<SearchResult.ScoredChunk> combined =
             combineSearchResults(vectorChunks, keywordChunks, DEFAULT_TOP_K, query);
 
-        SearchResult result = SearchResult.builder()
-            .chunks(combined)
-            .contextText(buildContextTextFromScored(combined))
-            .totalChunks(combined.size())
-            .build();
-
-        if (result.getChunks().isEmpty()) {
-            result.setContextText("해당 사용자의 정보를 찾을 수 없습니다.");
-        }
-        return result;
+        return toResult(combined);
     }
 
     public SearchResult searchPublicEventsFirst(String query) throws Exception {

--- a/src/test/java/com/fairing/fairplay/ai/rag/repository/PgVectorRagRepositoryScopeTest.java
+++ b/src/test/java/com/fairing/fairplay/ai/rag/repository/PgVectorRagRepositoryScopeTest.java
@@ -1,0 +1,109 @@
+package com.fairing.fairplay.ai.rag.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.PreparedStatementSetter;
+import org.springframework.jdbc.core.RowMapper;
+
+class PgVectorRagRepositoryScopeTest {
+
+    private JdbcTemplate jdbcTemplate;
+    private PgVectorRagRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate = org.mockito.Mockito.mock(JdbcTemplate.class);
+        repository = new PgVectorRagRepository(jdbcTemplate);
+    }
+
+    @Test
+    void publicKeywordSearchUsesVisibilityScopeInsteadOfDocIdPrefixHeuristic() {
+        stubQuery();
+
+        repository.searchPublicKeyword("2025 명원 세계차 품평대회", 5);
+
+        String sql = capturedSql();
+        assertThat(sql).contains("AND visibility = 'PUBLIC'");
+        assertThat(sql).doesNotContain("doc_id NOT LIKE");
+    }
+
+    @Test
+    void publicVectorSearchUsesVisibilityScopeInsteadOfDocIdPrefixHeuristic() {
+        stubQuery();
+
+        repository.searchPublicSimilar(vector(), 5, 0.1);
+
+        String sql = capturedSql();
+        assertThat(sql).contains("AND visibility = 'PUBLIC'");
+        assertThat(sql).doesNotContain("doc_id NOT LIKE");
+    }
+
+    @Test
+    void publicTypedSearchUsesPublicVisibilityScope() {
+        stubQuery();
+
+        repository.searchPublicKeywordByTypes(List.of("PUBLIC_EVENT"), "AWS Summit", 5);
+
+        String sql = capturedSql();
+        assertThat(sql).contains("AND visibility = 'PUBLIC' AND doc_type IN (?)");
+    }
+
+    @Test
+    void userKeywordSearchScopesToOwnerPrivateChunks() {
+        stubQuery();
+
+        repository.searchUserKeyword(10L, "내 예약", 5);
+
+        String sql = capturedSql();
+        assertThat(sql).contains("AND visibility = 'USER_PRIVATE' AND owner_user_id = ?");
+        assertThat(sql).doesNotContain("doc_id = ?");
+    }
+
+    @Test
+    void userVectorSearchScopesToOwnerPrivateChunks() {
+        stubQuery();
+
+        repository.searchUserSimilar(10L, vector(), 5, 0.05);
+
+        String sql = capturedSql();
+        assertThat(sql).contains("AND visibility = 'USER_PRIVATE' AND owner_user_id = ?");
+        assertThat(sql).doesNotContain("doc_id = ?");
+    }
+
+    @Test
+    void userTypedSearchScopesToOwnerPrivateChunks() {
+        stubQuery();
+
+        repository.searchUserKeywordByTypes(10L, List.of("USER_RESERVATION"), "내 예약", 5);
+
+        String sql = capturedSql();
+        assertThat(sql).contains("AND visibility = 'USER_PRIVATE' AND owner_user_id = ? AND doc_type IN (?)");
+        assertThat(sql).doesNotContain("doc_id = ?");
+    }
+
+    private void stubQuery() {
+        doReturn(List.of())
+            .when(jdbcTemplate)
+            .query(anyString(), any(PreparedStatementSetter.class), any(RowMapper.class));
+    }
+
+    private String capturedSql() {
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        org.mockito.Mockito.verify(jdbcTemplate)
+            .query(sqlCaptor.capture(), any(PreparedStatementSetter.class), any(RowMapper.class));
+        return sqlCaptor.getValue();
+    }
+
+    private float[] vector() {
+        return new float[] {0.1f, 0.2f, 0.3f};
+    }
+}

--- a/src/test/java/com/fairing/fairplay/ai/rag/service/VectorSearchServiceScopeTest.java
+++ b/src/test/java/com/fairing/fairplay/ai/rag/service/VectorSearchServiceScopeTest.java
@@ -1,0 +1,60 @@
+package com.fairing.fairplay.ai.rag.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.fairing.fairplay.ai.rag.domain.Chunk;
+import com.fairing.fairplay.ai.rag.domain.SearchResult;
+import com.fairing.fairplay.ai.rag.repository.RagChunkRepository;
+
+class VectorSearchServiceScopeTest {
+
+    private RagChunkRepository repository;
+    private EmbeddingService embeddingService;
+    private VectorSearchService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        repository = Mockito.mock(RagChunkRepository.class);
+        embeddingService = Mockito.mock(EmbeddingService.class);
+        service = new VectorSearchService(repository, embeddingService);
+
+        when(embeddingService.embedQuery(any())).thenReturn(new float[] {0.1f, 0.2f, 0.3f});
+    }
+
+    @Test
+    void userDataSearchDoesNotRequireLegacyUserDocIdBeforeSearchingOwnerScopedChunks() throws Exception {
+        Chunk reservationChunk = Chunk.builder()
+            .chunkId("chunk_reservation_24")
+            .docId("reservation_24")
+            .text("=== 개인 예약 내역 ===\n행사명: 2025 명원세계차(茶) 품평대회")
+            .build();
+        SearchResult.ScoredChunk scoredChunk = SearchResult.ScoredChunk.builder()
+            .chunk(reservationChunk)
+            .similarity(0.9)
+            .build();
+        when(repository.searchUserSimilarByTypes(eq(10L), anyList(), any(), anyInt(), anyDouble()))
+            .thenReturn(List.of(scoredChunk));
+        when(repository.searchUserKeywordByTypes(eq(10L), anyList(), any(), anyInt()))
+            .thenReturn(List.of());
+
+        SearchResult result = service.searchUserData(10L, "내 예약 알려줘");
+
+        assertThat(result.getChunks()).containsExactly(scoredChunk);
+        assertThat(result.getContextText()).contains("2025 명원세계차");
+        verify(repository, never()).findByDocId("user_10");
+    }
+}

--- a/src/test/java/com/fairing/fairplay/ai/rag/service/VectorSearchServiceScopeTest.java
+++ b/src/test/java/com/fairing/fairplay/ai/rag/service/VectorSearchServiceScopeTest.java
@@ -50,11 +50,27 @@ class VectorSearchServiceScopeTest {
             .thenReturn(List.of(scoredChunk));
         when(repository.searchUserKeywordByTypes(eq(10L), anyList(), any(), anyInt()))
             .thenReturn(List.of());
+        when(repository.getTotalChunkCount()).thenReturn(132L);
 
         SearchResult result = service.searchUserData(10L, "내 예약 알려줘");
 
         assertThat(result.getChunks()).containsExactly(scoredChunk);
         assertThat(result.getContextText()).contains("2025 명원세계차");
+        assertThat(result.getTotalChunks()).isEqualTo(132);
         verify(repository, never()).findByDocId("user_10");
+    }
+
+    @Test
+    void userDataSearchKeepsContextEmptyWhenNoPrivateChunksMatch() throws Exception {
+        when(repository.searchUserSimilarByTypes(eq(10L), anyList(), any(), anyInt(), anyDouble()))
+            .thenReturn(List.of());
+        when(repository.searchUserKeywordByTypes(eq(10L), anyList(), any(), anyInt()))
+            .thenReturn(List.of());
+
+        SearchResult result = service.searchUserData(10L, "없는 예약 알려줘");
+
+        assertThat(result.getChunks()).isEmpty();
+        assertThat(result.getContextText()).isEmpty();
+        assertThat(result.getTotalChunks()).isZero();
     }
 }


### PR DESCRIPTION
## Summary
- Promote develop to main for the latest RAG search-scope and chat safety fixes
- Keep public AI chat search scoped to PUBLIC chunks and user-private search scoped to USER_PRIVATE owner chunks
- Include deploy workflow hardening already merged into develop

## Verification
- PR #82 backend-ci/test passed
- Local backend tests passed on issue/be-rag-search-scope:
  - ./gradlew test --tests com.fairing.fairplay.ai.rag.repository.PgVectorRagRepositoryScopeTest --tests com.fairing.fairplay.ai.rag.service.VectorSearchServiceScopeTest --no-daemon
  - ./gradlew test --no-daemon

## Post-deploy
- Run comprehensive RAG reload so AWS Summit event/booths are embedded
- Verify chat can retrieve AWS Summit and 2025 명원세계차 from public event context